### PR TITLE
feat: establish safe conversion contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 A safety-first codemod for migrating projects away from the archived Angular Flex-Layout library.
 
-Version 2 is under active development and is not published to npm yet. The current branch establishes the build, test, package, and repository foundations; it does not claim production-ready conversion coverage.
+Version 2 is under active development and is not published to npm yet. It does not claim production-ready conversion coverage. See the [compatibility reference](docs/compatibility.md) for the current directive-by-directive status and safety limitations.
 
 ## Direction
 
 The v2 CLI will analyze Angular templates before changing them and classify each directive as converted, requiring manual review, or unsupported. Native CSS will be the primary target, with Tailwind CSS provided by a separate adapter. Ambiguous responsive and dynamic behavior will not be approximated silently.
+
+The current prerelease preserves dynamic bindings, responsive inputs, custom breakpoints, and unsupported directives for review instead of removing them. The CLI reporting interface described below is still being implemented.
 
 Planned commands:
 

--- a/docs/architecture/conversion-safety.md
+++ b/docs/architecture/conversion-safety.md
@@ -1,0 +1,110 @@
+# Conversion safety model
+
+The codemod must preserve layout behavior or clearly explain why it cannot. It must never remove an Angular Flex-Layout directive after making an approximate or incomplete conversion.
+
+This document defines the contract shared by the analyzer, target adapters, CLI, and compatibility tests.
+
+## Source contract
+
+The compatibility inventory is based on the archived [Angular Flex-Layout source](https://github.com/angular/flex-layout) and its [API documentation](https://github.com/angular/flex-layout/wiki/API-Documentation). It covers:
+
+- Flex directives: `fxLayout`, `fxLayoutAlign`, `fxLayoutGap`, `fxFlex`, `fxGrow`, `fxShrink`, `fxFlexAlign`, `fxFlexFill`/`fxFill`, `fxFlexOffset`, and `fxFlexOrder`.
+- Visibility directives: `fxShow` and `fxHide`.
+- Grid directives: `gdAlignColumns`, `gdAlignRows`, `gdArea`, `gdAreas`, `gdAuto`, `gdColumn`, `gdColumns`, `gdGap`, `gdGridAlign`, `gdRow`, and `gdRows`.
+- Extended responsive inputs: `class`, `ngClass`, `style`, `ngStyle`, and `imgSrc`.
+- Default aliases: `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`.
+- Optional orientation aliases, the `print` alias, and custom breakpoint registrations.
+
+## Conversion outcomes
+
+Every recognized input receives one outcome before a file is changed.
+
+| Outcome       | Meaning                                                                                                    | Mutation allowed |
+| ------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
+| `converted`   | The target representation is semantically equivalent.                                                      | Yes              |
+| `review`      | Conversion depends on runtime data, configuration, or surrounding layout that cannot be proven statically. | No               |
+| `unsupported` | The selected target has no equivalent implemented by this version.                                         | No               |
+| `invalid`     | The directive or value does not match the upstream input contract.                                         | No               |
+
+An attribute is removed only when its outcome is `converted`. A file may contain converted and unresolved inputs; unresolved inputs remain byte-for-byte equivalent apart from formatter behavior.
+
+Each unresolved result includes a stable diagnostic code, file location, directive, reason, and suggested next action. Stable codes allow CI systems to distinguish known migration debt from new findings.
+
+## Static and bound values
+
+Literal values can be converted when the adapter supports their complete semantics. Angular property bindings are not literals merely because their source text resembles one. For example, `[fxFlex]="basis"` is a runtime expression and requires review, while `[fxFlex]="'25%'"` may be reduced to a literal after Angular-expression parsing proves it is constant.
+
+Interpolation, pipes, method calls, object or array expressions, and template variables require review unless a later analyzer explicitly proves them constant. The codemod does not evaluate application code.
+
+## Responsive behavior
+
+Angular Flex-Layout aliases are media-query contracts, not names that can be substituted with similarly named framework breakpoints. The default aliases include bounded ranges and overlapping `lt-*` and `gt-*` ranges. Tailwind's default responsive variants are mobile-first minimum-width queries, so `fxLayout.sm` is not generally equivalent to `sm:flex-row`.
+
+Adapters must use the exact upstream media query, a verified project configuration with identical semantics, or return `review`. Orientation, print, and custom aliases require the same proof. The analyzer records the alias separately from the directive so breakpoint policy remains target-independent.
+
+## Target adapters
+
+The analyzer produces a normalized directive, parsed value, binding kind, breakpoint, source location, and relevant element context. It does not generate CSS classes.
+
+Each target adapter declares the cases it supports and returns either a complete edit set or an unresolved outcome. The initial adapters are:
+
+- `css`: emits deterministic, reusable CSS rules and template classes. Generated names are stable so repeated runs are idempotent.
+- `tailwind`: emits utilities only when current Tailwind syntax represents the full source behavior. Arbitrary properties and variants are allowed when they are deterministic and valid for content scanning.
+
+The `plain-css` CLI spelling is retained as a deprecated alias for `css` during the v2 prerelease period. Selecting an adapter that cannot convert any discovered directive is an error, not a successful no-op.
+
+## Processing pipeline
+
+1. Parse the Angular template without interpreting expressions as HTML attributes.
+2. Discover all Flex-Layout inputs, including bracketed bindings and responsive suffixes.
+3. Normalize aliases and parse directive values according to the upstream contract.
+4. Ask the selected adapter to classify each input and propose edits.
+5. Validate that edits do not conflict and that every removed input has a `converted` result.
+6. Apply edits, format changed files, and write a migration report.
+7. Re-analyze the output in tests to prove that a second run produces no additional edits.
+
+Analysis and mutation are separate operations. `--dry-run` executes all analysis and reporting without writing files.
+
+## CLI contract
+
+The default summary reports files scanned, files changed, converted inputs, review items, unsupported inputs, and invalid inputs. Normal output is concise; `--report <path>` writes a machine-readable JSON report.
+
+Exit codes are stable:
+
+| Code | Meaning                                                                                   |
+| ---- | ----------------------------------------------------------------------------------------- |
+| `0`  | The command completed and no unresolved inputs remain.                                    |
+| `1`  | The command failed because of configuration, parsing, I/O, or an internal error.          |
+| `2`  | The migration completed but review, unsupported, or invalid inputs remain in strict mode. |
+
+Strict mode is enabled by default. `--allow-unresolved` permits exit code `0` while still reporting and preserving unresolved inputs.
+
+## Compatibility verification
+
+The test corpus is organized by directive rather than implementation class. Every directive family includes, where applicable:
+
+- default and explicit literal values;
+- all supported value keywords and CSS units;
+- bracketed constants and dynamic bindings;
+- each default breakpoint category;
+- optional and unknown breakpoint aliases;
+- interaction with existing `class`, bound class, and style attributes;
+- parent-direction or sibling-dependent behavior;
+- malformed values and empty attributes;
+- repeated execution and mixed converted/unresolved inputs.
+
+Fixtures assert both the generated output and the structured result. Snapshot-only tests are insufficient: important classes, retained attributes, diagnostics, and exit behavior receive explicit assertions.
+
+## Delivery sequence
+
+The conversion engine is delivered in reviewable increments:
+
+1. Compatibility inventory, analyzer result types, discovery, and preservation guarantees.
+2. Exact breakpoint model and reporting.
+3. Flex directive support for the CSS adapter.
+4. Flex directive support for the Tailwind adapter.
+5. Visibility and extended responsive inputs.
+6. Grid directives.
+7. CLI strict mode, dry-run, JSON reports, and upgrade documentation.
+
+Each increment adds failing compatibility tests before implementation and leaves the repository in a releasable state.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,71 @@
+# Compatibility
+
+Version 2 is prerelease software. Its current conversion coverage is deliberately narrow while the project replaces legacy best-effort behavior with a safety-first conversion pipeline.
+
+The source contract and classification rules are documented in [Conversion safety model](architecture/conversion-safety.md).
+
+## Status definitions
+
+- **Limited**: unbound, non-responsive literal values have an existing Tailwind converter. Its complete value matrix is still being audited.
+- **Planned**: the analyzer recognizes the input, but no target adapter converts it yet.
+- **Preserved**: the input is intentionally left unchanged and reported for review.
+
+No native CSS conversions are available yet. The `plain-css` target currently performs no conversions and will become the `css` adapter during the v2 prerelease cycle.
+
+## Flex directives
+
+| Directive       | Tailwind | Notes                                                                        |
+| --------------- | -------- | ---------------------------------------------------------------------------- |
+| `fxLayout`      | Limited  | Static values without a breakpoint only.                                     |
+| `fxLayoutAlign` | Limited  | Static values without a breakpoint only; parent direction affects semantics. |
+| `fxLayoutGap`   | Limited  | Static values without a breakpoint only.                                     |
+| `fxFlex`        | Limited  | Static values without a breakpoint only; the value matrix is incomplete.     |
+| `fxGrow`        | Planned  | Recognized and preserved.                                                    |
+| `fxShrink`      | Planned  | Recognized and preserved.                                                    |
+| `fxFlexAlign`   | Planned  | Recognized and preserved.                                                    |
+| `fxFlexFill`    | Limited  | Static use without a breakpoint only.                                        |
+| `fxFill`        | Planned  | Alias recognized and preserved.                                              |
+| `fxFlexOffset`  | Limited  | Static values without a breakpoint only; parent direction affects semantics. |
+| `fxFlexOrder`   | Limited  | Static values without a breakpoint only.                                     |
+| `fxShow`        | Planned  | Recognized and preserved.                                                    |
+| `fxHide`        | Planned  | Recognized and preserved.                                                    |
+
+## Grid directives
+
+All grid directives are recognized and preserved. Target conversion has not been implemented.
+
+| Directive        | Tailwind |
+| ---------------- | -------- |
+| `gdAlignColumns` | Planned  |
+| `gdAlignRows`    | Planned  |
+| `gdArea`         | Planned  |
+| `gdAreas`        | Planned  |
+| `gdAuto`         | Planned  |
+| `gdColumn`       | Planned  |
+| `gdColumns`      | Planned  |
+| `gdGap`          | Planned  |
+| `gdGridAlign`    | Planned  |
+| `gdRow`          | Planned  |
+| `gdRows`         | Planned  |
+
+## Extended responsive inputs
+
+Responsive `class`, `ngClass`, `style`, `ngStyle`, and `imgSrc` inputs are recognized and preserved. Ordinary unsuffixed HTML and Angular `class` and `style` attributes are not treated as Flex-Layout inputs.
+
+## Bindings and breakpoints
+
+The current safety gate preserves these cases for review:
+
+- every Angular property binding, including bindings whose expression appears constant;
+- every built-in responsive alias;
+- orientation and print aliases;
+- unknown aliases, because they may be registered as custom project breakpoints;
+- every directive not implemented by the selected target adapter.
+
+This is intentional. Angular Flex-Layout's `sm`, `md`, and other bounded aliases are not generally equivalent to Tailwind's mobile-first variants. Exact media-query support will be added before responsive attributes are converted.
+
+## Reporting API
+
+`FileMigrator#getResults()` returns one structured result per recognized input processed in a file. Results use the statuses `converted`, `review`, `unsupported`, and `invalid`. Review and unsupported results include a stable diagnostic code, reason, and suggested action.
+
+The public CLI summary, strict exit codes, and JSON report described in the architecture document are planned and are not implemented in this increment.

--- a/src/analyzer/conversion-result.ts
+++ b/src/analyzer/conversion-result.ts
@@ -2,7 +2,7 @@ import type { FlexLayoutInput } from './flex-layout-attribute.analyzer';
 
 export type ConversionStatus = 'converted' | 'review' | 'unsupported' | 'invalid';
 
-export type DiagnosticCode = 'breakpoint-unverified' | 'dynamic-binding' | 'target-unsupported' | 'unknown-breakpoint';
+export type DiagnosticCode = 'breakpoint-unverified' | 'custom-breakpoint' | 'dynamic-binding' | 'target-unsupported';
 
 export interface ConversionResult {
   status: ConversionStatus;

--- a/src/analyzer/conversion-result.ts
+++ b/src/analyzer/conversion-result.ts
@@ -1,0 +1,13 @@
+import type { FlexLayoutInput } from './flex-layout-attribute.analyzer';
+
+export type ConversionStatus = 'converted' | 'review' | 'unsupported' | 'invalid';
+
+export type DiagnosticCode = 'breakpoint-unverified' | 'dynamic-binding' | 'target-unsupported' | 'unknown-breakpoint';
+
+export interface ConversionResult {
+  status: ConversionStatus;
+  input: FlexLayoutInput;
+  code?: DiagnosticCode;
+  reason?: string;
+  suggestion?: string;
+}

--- a/src/analyzer/flex-layout-attribute.analyzer.spec.ts
+++ b/src/analyzer/flex-layout-attribute.analyzer.spec.ts
@@ -1,0 +1,41 @@
+import { analyzeFlexLayoutAttribute } from './flex-layout-attribute.analyzer';
+
+describe('analyzeFlexLayoutAttribute', () => {
+  test.each([
+    ['fxLayout', 'row', 'fxLayout', undefined, 'literal'],
+    ['fxLayout.sm', 'column', 'fxLayout', 'sm', 'literal'],
+    ['[fxFlex]', 'basis', 'fxFlex', undefined, 'property'],
+    ['[fxShow.gt-md]', 'visible', 'fxShow', 'gt-md', 'property'],
+    ['[fxLayout.handset.landscape]', 'row', 'fxLayout', 'handset.landscape', 'property'],
+    ['class.sm', 'compact', 'class', 'sm', 'literal'],
+  ] as const)('analyzes %s without evaluating its value', (sourceName, value, directive, breakpoint, binding) => {
+    expect(analyzeFlexLayoutAttribute(sourceName, value)).toEqual({
+      sourceName,
+      value,
+      directive,
+      breakpoint,
+      binding,
+    });
+  });
+
+  test('retains an unknown breakpoint for later classification', () => {
+    expect(analyzeFlexLayoutAttribute('fxLayout.cinema', 'row')).toEqual({
+      sourceName: 'fxLayout.cinema',
+      value: 'row',
+      directive: 'fxLayout',
+      breakpoint: 'cinema',
+      binding: 'literal',
+    });
+  });
+
+  test.each([
+    ['aria-label', 'Menu'],
+    ['class', 'card'],
+    ['style', 'display: block'],
+    ['[class]', 'cardClass'],
+    ['[style]', 'cardStyle'],
+    ['fxLayout]', 'row'],
+  ])('ignores unrelated or malformed attribute %s', (sourceName, value) => {
+    expect(analyzeFlexLayoutAttribute(sourceName, value)).toBeUndefined();
+  });
+});

--- a/src/analyzer/flex-layout-attribute.analyzer.ts
+++ b/src/analyzer/flex-layout-attribute.analyzer.ts
@@ -1,0 +1,40 @@
+import { FLEX_LAYOUT_DIRECTIVES, FlexLayoutDirective, isFlexLayoutDirective } from './flex-layout.catalog';
+
+export type BindingKind = 'literal' | 'property';
+
+export interface FlexLayoutInput {
+  sourceName: string;
+  directive: FlexLayoutDirective;
+  value: string;
+  binding: BindingKind;
+  breakpoint: string | undefined;
+}
+
+const responsiveOnlyDirectives = new Set<FlexLayoutDirective>(['class', 'ngClass', 'style', 'ngStyle']);
+const directivesByLength = [...FLEX_LAYOUT_DIRECTIVES].sort((left, right) => right.length - left.length);
+
+export function analyzeFlexLayoutAttribute(sourceName: string, value: string): FlexLayoutInput | undefined {
+  const startsWithBracket = sourceName.startsWith('[');
+  const endsWithBracket = sourceName.endsWith(']');
+
+  if (startsWithBracket !== endsWithBracket) return undefined;
+
+  const binding: BindingKind = startsWithBracket ? 'property' : 'literal';
+  const normalizedName = startsWithBracket ? sourceName.slice(1, -1) : sourceName;
+  const directive = directivesByLength.find(
+    candidate => normalizedName === candidate || normalizedName.startsWith(`${candidate}.`),
+  );
+
+  if (!directive || !isFlexLayoutDirective(directive)) return undefined;
+
+  const breakpoint = normalizedName === directive ? undefined : normalizedName.slice(directive.length + 1);
+  if (responsiveOnlyDirectives.has(directive) && !breakpoint) return undefined;
+
+  return {
+    sourceName,
+    value,
+    directive,
+    breakpoint,
+    binding,
+  };
+}

--- a/src/analyzer/flex-layout.catalog.spec.ts
+++ b/src/analyzer/flex-layout.catalog.spec.ts
@@ -1,0 +1,67 @@
+import {
+  DEFAULT_BREAKPOINTS,
+  FLEX_LAYOUT_DIRECTIVES,
+  isFlexLayoutDirective,
+  isKnownBreakpoint,
+} from './flex-layout.catalog';
+
+describe('Flex-Layout catalog', () => {
+  test('recognizes every upstream directive family', () => {
+    const directives = [
+      'fxLayout',
+      'fxLayoutAlign',
+      'fxLayoutGap',
+      'fxFlex',
+      'fxGrow',
+      'fxShrink',
+      'fxFlexAlign',
+      'fxFlexFill',
+      'fxFill',
+      'fxFlexOffset',
+      'fxFlexOrder',
+      'fxShow',
+      'fxHide',
+      'gdAlignColumns',
+      'gdAlignRows',
+      'gdArea',
+      'gdAreas',
+      'gdAuto',
+      'gdColumn',
+      'gdColumns',
+      'gdGap',
+      'gdGridAlign',
+      'gdRow',
+      'gdRows',
+      'class',
+      'ngClass',
+      'style',
+      'ngStyle',
+      'imgSrc',
+    ];
+
+    expect(FLEX_LAYOUT_DIRECTIVES).toEqual(directives);
+    expect(directives.every(isFlexLayoutDirective)).toBe(true);
+    expect(isFlexLayoutDirective('aria-label')).toBe(false);
+  });
+
+  test('recognizes default, orientation, and print breakpoints', () => {
+    expect(DEFAULT_BREAKPOINTS).toEqual([
+      'xs',
+      'sm',
+      'md',
+      'lg',
+      'xl',
+      'lt-sm',
+      'lt-md',
+      'lt-lg',
+      'lt-xl',
+      'gt-xs',
+      'gt-sm',
+      'gt-md',
+      'gt-lg',
+    ]);
+    expect(isKnownBreakpoint('handset.landscape')).toBe(true);
+    expect(isKnownBreakpoint('print')).toBe(true);
+    expect(isKnownBreakpoint('cinema')).toBe(false);
+  });
+});

--- a/src/analyzer/flex-layout.catalog.ts
+++ b/src/analyzer/flex-layout.catalog.ts
@@ -1,0 +1,79 @@
+export const FLEX_LAYOUT_DIRECTIVES = [
+  'fxLayout',
+  'fxLayoutAlign',
+  'fxLayoutGap',
+  'fxFlex',
+  'fxGrow',
+  'fxShrink',
+  'fxFlexAlign',
+  'fxFlexFill',
+  'fxFill',
+  'fxFlexOffset',
+  'fxFlexOrder',
+  'fxShow',
+  'fxHide',
+  'gdAlignColumns',
+  'gdAlignRows',
+  'gdArea',
+  'gdAreas',
+  'gdAuto',
+  'gdColumn',
+  'gdColumns',
+  'gdGap',
+  'gdGridAlign',
+  'gdRow',
+  'gdRows',
+  'class',
+  'ngClass',
+  'style',
+  'ngStyle',
+  'imgSrc',
+] as const;
+
+export type FlexLayoutDirective = (typeof FLEX_LAYOUT_DIRECTIVES)[number];
+
+export const DEFAULT_BREAKPOINTS = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'lt-sm',
+  'lt-md',
+  'lt-lg',
+  'lt-xl',
+  'gt-xs',
+  'gt-sm',
+  'gt-md',
+  'gt-lg',
+] as const;
+
+export const ORIENTATION_BREAKPOINTS = [
+  'handset',
+  'handset.portrait',
+  'handset.landscape',
+  'tablet',
+  'tablet.portrait',
+  'tablet.landscape',
+  'web',
+  'web.portrait',
+  'web.landscape',
+] as const;
+
+export const SPECIAL_BREAKPOINTS = ['print'] as const;
+
+export type KnownBreakpoint =
+  | (typeof DEFAULT_BREAKPOINTS)[number]
+  | (typeof ORIENTATION_BREAKPOINTS)[number]
+  | (typeof SPECIAL_BREAKPOINTS)[number];
+
+const directiveNames = new Set<string>(FLEX_LAYOUT_DIRECTIVES);
+const breakpointNames = new Set<string>([...DEFAULT_BREAKPOINTS, ...ORIENTATION_BREAKPOINTS, ...SPECIAL_BREAKPOINTS]);
+
+export function isFlexLayoutDirective(value: string): value is FlexLayoutDirective {
+  return directiveNames.has(value);
+}
+
+export function isKnownBreakpoint(value: string): value is KnownBreakpoint {
+  return breakpointNames.has(value);
+}

--- a/src/migrator/file.migrator.spec.ts
+++ b/src/migrator/file.migrator.spec.ts
@@ -2,13 +2,18 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { IConverter } from '../converter/converter';
+import { TailwindCssConverter } from '../converter/tailwind/tailwind.converter';
 import { FileMigrator } from './file.migrator';
 
 describe('FileMigrator', () => {
   let temporaryDirectory: string;
+  let input: string;
+  let output: string;
 
   beforeEach(async () => {
     temporaryDirectory = await mkdtemp(join(tmpdir(), 'flex-layout-codemod-'));
+    input = join(temporaryDirectory, 'input.html');
+    output = join(temporaryDirectory, 'output', 'result.html');
   });
 
   afterEach(async () => {
@@ -16,8 +21,6 @@ describe('FileMigrator', () => {
   });
 
   test('migrates a template through the converter and writes the result', async () => {
-    const input = join(temporaryDirectory, 'input.html');
-    const output = join(temporaryDirectory, 'output', 'result.html');
     await writeFile(input, '<div fxFlex="100%"></div>', 'utf8');
 
     const converter = {
@@ -29,13 +32,79 @@ describe('FileMigrator', () => {
       getPrettierConfig: vi.fn(() => ({ parser: 'angular' as const })),
     } as unknown as IConverter;
 
-    await new FileMigrator(converter, input, output).migrate();
+    const migrator = new FileMigrator(converter, input, output);
+    await migrator.migrate();
 
-    expect(converter.getAllAttributes).toHaveBeenCalledOnce();
     expect(converter.canConvert).toHaveBeenCalledWith('fxFlex', false);
     expect(converter.convert).toHaveBeenCalledOnce();
     const migrated = await readFile(output, 'utf8');
     expect(migrated).toContain('class="flex-full"');
     expect(migrated).not.toContain('fxFlex');
+    expect(migrator.getResults()).toEqual([
+      expect.objectContaining({
+        status: 'converted',
+        input: expect.objectContaining({ directive: 'fxFlex', value: '100%' }),
+      }),
+    ]);
+  });
+
+  test('preserves dynamic bindings instead of approximating them', async () => {
+    await writeFile(input, '<div [fxFlex]="basis"></div>', 'utf8');
+    const migrator = new FileMigrator(new TailwindCssConverter(), input, output);
+
+    await migrator.migrate();
+
+    expect(await readFile(output, 'utf8')).toContain('[fxFlex]="basis"');
+    expect(migrator.getResults()).toContainEqual(
+      expect.objectContaining({
+        status: 'review',
+        code: 'dynamic-binding',
+      }),
+    );
+  });
+
+  test('preserves recognized inputs unsupported by the adapter', async () => {
+    await writeFile(input, '<div fxShow="false"></div>', 'utf8');
+    const migrator = new FileMigrator(new TailwindCssConverter(), input, output);
+
+    await migrator.migrate();
+
+    expect(await readFile(output, 'utf8')).toContain('fxShow="false"');
+    expect(migrator.getResults()).toContainEqual(
+      expect.objectContaining({
+        status: 'unsupported',
+        code: 'target-unsupported',
+      }),
+    );
+  });
+
+  test('preserves responsive inputs until exact media queries are implemented', async () => {
+    await writeFile(input, '<div fxLayout.sm="row"></div>', 'utf8');
+    const migrator = new FileMigrator(new TailwindCssConverter(), input, output);
+
+    await migrator.migrate();
+
+    expect(await readFile(output, 'utf8')).toContain('fxLayout.sm="row"');
+    expect(migrator.getResults()).toContainEqual(
+      expect.objectContaining({
+        status: 'review',
+        code: 'breakpoint-unverified',
+      }),
+    );
+  });
+
+  test('preserves custom breakpoints for review', async () => {
+    await writeFile(input, '<div fxLayout.cinema="row"></div>', 'utf8');
+    const migrator = new FileMigrator(new TailwindCssConverter(), input, output);
+
+    await migrator.migrate();
+
+    expect(await readFile(output, 'utf8')).toContain('fxLayout.cinema="row"');
+    expect(migrator.getResults()).toContainEqual(
+      expect.objectContaining({
+        status: 'review',
+        code: 'custom-breakpoint',
+      }),
+    );
   });
 });

--- a/src/migrator/file.migrator.ts
+++ b/src/migrator/file.migrator.ts
@@ -4,14 +4,18 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { Cheerio, CheerioAPI } from 'cheerio';
 import type { Element } from 'domhandler';
+import { ConversionResult } from '../analyzer/conversion-result';
+import { analyzeFlexLayoutAttribute, FlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import { isKnownBreakpoint } from '../analyzer/flex-layout.catalog';
 import { logger } from '../logger';
-import { BreakPoint } from '../converter/breakpoint.type';
 import { AttributeContext, IConverter } from '../converter/converter';
 import { formatFile } from '../lib/prettier.formatter';
-import { findElementsWithCustomAttributes, loadHtml } from '../util/cheerio.util';
+import { findElementsWithFlexLayoutAttributes, loadHtml } from '../util/cheerio.util';
 import PQueue from 'p-queue';
 
 export class FileMigrator extends BaseMigrator {
+  private results: ConversionResult[] = [];
+
   constructor(
     protected override converter: IConverter,
     private input: string,
@@ -21,16 +25,14 @@ export class FileMigrator extends BaseMigrator {
   }
 
   public async migrate(): Promise<void> {
+    this.results = [];
     const inputFilename = path.basename(this.input);
     this.notifyFileStarted(inputFilename);
 
     const html = await fs.promises.readFile(this.input, 'utf8');
     const $ = loadHtml(html);
 
-    const attributeNamesToLookFor = this.converter.getAllAttributes();
-    logger.debug('Attributes: [%s]', attributeNamesToLookFor.join(', '));
-
-    const elements = findElementsWithCustomAttributes($, attributeNamesToLookFor);
+    const elements = findElementsWithFlexLayoutAttributes($);
     logger.debug('Found %i elements', elements.length);
 
     if (!elements.length) {
@@ -48,6 +50,10 @@ export class FileMigrator extends BaseMigrator {
     await this.performConversion(elements, $, inputFilename, totalElements, attributeContexts);
 
     await this.writeOutputFile($);
+  }
+
+  public getResults(): readonly ConversionResult[] {
+    return [...this.results];
   }
 
   /**
@@ -97,24 +103,15 @@ export class FileMigrator extends BaseMigrator {
 
     if (!attrs) return attributeContexts;
 
-    for (const [attribute] of Object.entries(attrs)) {
-      const { attr, canConvert, normalizedAttribute } = this.extractAttributeData(attribute);
+    for (const [attribute, value] of Object.entries(attrs)) {
+      const input = analyzeFlexLayoutAttribute(attribute, value);
+      if (!input || this.getUnresolvedResult(input) || !this.converter.canConvert(input.directive, false)) continue;
 
-      if (!canConvert) {
-        continue;
-      }
-
-      let context = this.converter.prepare(normalizedAttribute, $, el);
+      let context = this.converter.prepare(input.directive, $, el);
 
       context ??= {
         usesPropertyBinding: false,
       } as AttributeContext<unknown>;
-
-      // Check if the attribute is using property binding syntax
-      // If so, we provide a context to the converter
-      if (attr.startsWith('[') && attr.endsWith(']')) {
-        context.usesPropertyBinding = true;
-      }
 
       const uniqueKey = `${index}_${attribute}`;
       attributeContexts.set(uniqueKey, context);
@@ -162,10 +159,25 @@ export class FileMigrator extends BaseMigrator {
     if (!attrs) return;
 
     for (const [attribute, value] of Object.entries(attrs)) {
-      const { canConvert, normalizedAttribute, breakPoint } = this.extractAttributeData(attribute);
-      logger.debug('Attribute: %s, value: %s. Can be converted: %s', attribute, value, canConvert);
+      const input = analyzeFlexLayoutAttribute(attribute, value);
+      if (!input) continue;
 
+      const unresolvedResult = this.getUnresolvedResult(input);
+      if (unresolvedResult) {
+        this.results.push(unresolvedResult);
+        continue;
+      }
+
+      const canConvert = this.converter.canConvert(input.directive, false);
+      logger.debug('Attribute: %s, value: %s. Can be converted: %s', attribute, value, canConvert);
       if (!canConvert) {
+        this.results.push({
+          status: 'unsupported',
+          input,
+          code: 'target-unsupported',
+          reason: `The selected target does not support ${input.directive}.`,
+          suggestion: 'Keep the directive and migrate it manually.',
+        });
         continue;
       }
 
@@ -185,50 +197,45 @@ export class FileMigrator extends BaseMigrator {
         values = value && value.includes(' ') ? value.split(' ') : [value];
       }
 
-      this.converter.convert(normalizedAttribute, values, el, breakPoint, contextData);
+      this.converter.convert(input.directive, values, el, undefined, contextData);
 
       element.removeAttr(attribute);
+      this.results.push({ status: 'converted', input });
     }
   }
 
-  /**
-   * Extracts the attribute name and breakpoint from the attribute string.
-   * @param attribute The attribute string
-   * @param isBreakpointAttribute Whether the attribute is a breakpoint attribute
-   * @returns an object with the following properties: attr, breakPoint
-   */
-  private extractAttributeAndBreakpoint(
-    attribute: string,
-    isBreakpointAttribute: boolean,
-  ): {
-    attr: string;
-    breakPoint: BreakPoint | undefined;
-  } {
-    // Check if the attribute is a breakpoint attribute
-    if (isBreakpointAttribute) {
-      const [attr, breakPoint] = attribute.split('.');
-      return { attr: attr ?? attribute, breakPoint: breakPoint as BreakPoint };
+  private getUnresolvedResult(input: FlexLayoutInput): ConversionResult | undefined {
+    if (input.breakpoint && !isKnownBreakpoint(input.breakpoint)) {
+      return {
+        status: 'review',
+        input,
+        code: 'custom-breakpoint',
+        reason: `The breakpoint alias ${input.breakpoint} may be registered by the project.`,
+        suggestion: 'Provide its media query or migrate this responsive input manually.',
+      };
     }
-    return { attr: attribute, breakPoint: undefined };
-  }
 
-  /**
-   * Extracts essential data from the attribute string. This includes the attribute name, breakpoint, whether the attribute is a breakpoint attribute, and whether the attribute can be converted. The attribute name is normalized to remove any breakpoint suffixes.
-   * @param attribute The attribute string
-   * @returns an object with the following properties: attr, normalizedAttribute, breakPoint, canConvert, isBreakpointAttribute
-   */
-  private extractAttributeData(attribute: string): {
-    attr: string;
-    normalizedAttribute: string;
-    breakPoint: BreakPoint | undefined;
-    canConvert: boolean;
-    isBreakpointAttribute: boolean;
-  } {
-    const isBreakpointAttribute = !!attribute && attribute.includes('.');
-    const canConvert = this.converter.canConvert(attribute, isBreakpointAttribute);
-    const { attr, breakPoint } = this.extractAttributeAndBreakpoint(attribute, isBreakpointAttribute);
-    const normalizedAttribute = this.normalizeAttribute(attr);
-    return { attr, normalizedAttribute, breakPoint, canConvert, isBreakpointAttribute };
+    if (input.binding === 'property') {
+      return {
+        status: 'review',
+        input,
+        code: 'dynamic-binding',
+        reason: 'Angular property bindings may depend on runtime state.',
+        suggestion: 'Replace the binding manually or make it a literal before migration.',
+      };
+    }
+
+    if (input.breakpoint) {
+      return {
+        status: 'review',
+        input,
+        code: 'breakpoint-unverified',
+        reason: `Exact media-query output for ${input.breakpoint} is not implemented.`,
+        suggestion: 'Keep the responsive directive until exact breakpoint support is available.',
+      };
+    }
+
+    return undefined;
   }
 
   private async writeOutputFile($: CheerioAPI): Promise<void> {
@@ -243,15 +250,6 @@ export class FileMigrator extends BaseMigrator {
 
     const inputFilename = path.basename(this.input);
     this.notifyFileCompleted(inputFilename);
-  }
-
-  /**
-   * Removes the square brackets from the attribute name. For example, [fxFlex] => fxFlex
-   * @param attribute The attribute name
-   * @returns the normalized attribute name
-   */
-  private normalizeAttribute(attribute: string): string {
-    return attribute.replace('[', '').replace(']', '');
   }
 
   private notifyFileStarted(inputFilename: string): void {

--- a/src/util/cheerio.util.spec.ts
+++ b/src/util/cheerio.util.spec.ts
@@ -1,4 +1,4 @@
-import { addInlineStyles } from './cheerio.util';
+import { addInlineStyles, findElementsWithFlexLayoutAttributes, loadHtml } from './cheerio.util';
 import * as cheerio from 'cheerio';
 
 describe('addInlineStyles', () => {
@@ -31,5 +31,25 @@ describe('addInlineStyles', () => {
 
     const expectedStyle = `${existingStyle} background-color: blue; font-weight: bold;`;
     expect(testElement.attr('style')).toBe(expectedStyle);
+  });
+});
+
+describe('findElementsWithFlexLayoutAttributes', () => {
+  test('discovers supported, unsupported, and bound Flex-Layout inputs', () => {
+    const $ = loadHtml(`
+      <main>
+        <div fxLayout="row"></div>
+        <div [fxShow.gt-md]="visible" gdColumns="1fr 1fr"></div>
+        <div class="card" aria-label="Card"></div>
+      </main>
+    `);
+
+    const elements = findElementsWithFlexLayoutAttributes($);
+
+    expect(elements).toHaveLength(2);
+    expect(elements.map(element => Object.keys(element.attr() ?? {}))).toEqual([
+      ['fxLayout'],
+      ['[fxShow.gt-md]', 'gdColumns'],
+    ]);
   });
 });

--- a/src/util/cheerio.util.ts
+++ b/src/util/cheerio.util.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio';
 import type { AnyNode, Element as CheerioElement } from 'domhandler';
 import { Stack } from '../lib/stack';
 import { NodeWithChildren } from 'domhandler';
+import { analyzeFlexLayoutAttribute } from '../analyzer/flex-layout-attribute.analyzer';
 
 /**
  * Loads the given html into cheerio and returns the result
@@ -59,6 +60,33 @@ export function findElementsWithCustomAttributes(
   }
 
   return elementsWithAttributes;
+}
+
+export function findElementsWithFlexLayoutAttributes(cheerioRoot: CheerioAPI): Cheerio<CheerioElement>[] {
+  const matchingElements: Cheerio<CheerioElement>[] = [];
+  const stack = new Stack<NodeWithChildren>();
+  const root = cheerioRoot.root()[0];
+  if (!root) return matchingElements;
+  stack.push(root);
+
+  while (!stack.isEmpty()) {
+    const node = stack.pop();
+    if (!node?.children) continue;
+
+    for (const child of node.children) {
+      if (child.type === 'tag') {
+        const element = cheerioRoot(child as CheerioElement);
+        const hasFlexLayoutInput = Object.entries(child.attribs ?? {}).some(([name, value]) =>
+          analyzeFlexLayoutAttribute(name, value),
+        );
+        if (hasFlexLayoutInput) matchingElements.push(element);
+      }
+
+      stack.push(child as NodeWithChildren);
+    }
+  }
+
+  return matchingElements;
 }
 
 /**


### PR DESCRIPTION
## Summary

Establishes the first safety-first conversion increment:

- catalogs the complete upstream Flex-Layout directive and breakpoint namespace
- adds target-independent parsing for literal, bound, responsive, orientation, print, and custom-breakpoint inputs
- discovers Flex-Layout inputs independently of current adapter support
- removes attributes only after a supported static conversion succeeds
- preserves dynamic, responsive, custom-breakpoint, and unsupported inputs with structured results
- documents the conversion safety model and honest directive-by-directive compatibility baseline

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

TDD red-green cycles cover catalog completeness, binding and breakpoint parsing, target-independent discovery, successful conversion results, and preservation of dynamic, responsive, custom-breakpoint, and unsupported inputs.

## Migration example

Dynamic input before:

```html
<div [fxFlex]="basis"></div>
```

Output in this increment:

```html
<div [fxFlex]="basis"></div>
```

The directive remains unchanged and is reported with `review / dynamic-binding` instead of being approximated or removed.

## Dependencies and compatibility

No dependency or runtime changes.

All responsive aliases are intentionally preserved until exact Angular Flex-Layout media-query semantics are implemented. The existing native CSS target still has no conversions and is documented accordingly.
