### PR TITLE
feat: migrate exact visibility semantics

### DIFF
--- a/.changeset/exact-visibility-migrate.md
+++ b/.changeset/exact-visibility-migrate.md
@@ -2,4 +2,4 @@
 '@nipe-solutions/flex-layout-codemod': minor
 ---
 
-Convert literal `fxShow` and `fxHide` families at base and standard viewport breakpoints when their complete display behavior is provable, and preserve dynamic, conflicting, or restoration-unsafe visibility inputs with structured diagnostics.
+Convert Angular-decoded literal `fxShow` and `fxHide` families at base and standard viewport breakpoints when their complete display behavior is provable, and preserve dynamic, conflicting, restoration-unsafe, partially overlapping layout, or responsive class/style-authority cases with structured diagnostics.

--- a/.changeset/exact-visibility-migrate.md
+++ b/.changeset/exact-visibility-migrate.md
@@ -1,0 +1,5 @@
+---
+'@nipe-solutions/flex-layout-codemod': minor
+---
+
+Convert literal `fxShow` and `fxHide` families at base and standard viewport breakpoints when their complete display behavior is provable, and preserve dynamic, conflicting, or restoration-unsafe visibility inputs with structured diagnostics.

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,5 @@ package-lock.json
 docs/superpowers/
 test/fixtures/compatibility/responsive.input.html
 test/fixtures/compatibility/responsive.expected.html
+test/fixtures/compatibility/visibility.input.html
+test/fixtures/compatibility/visibility.expected.html

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The v2 engine parses templates with the Angular compiler and applies validated s
 
 The current prerelease converts documented static inputs and literal responsive inputs using the standard Angular Flex-Layout viewport aliases (`xs` through `xl`, `lt-*`, and `gt-*`) to exact Tailwind CSS v4 arbitrary media variants. For example, `fxLayout.sm="row"` becomes `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-row` alongside the other layout utilities. Dynamic bindings, orientation, print, and custom breakpoints, unsupported directives, and responsive families with conflicting overlapping values remain unchanged with structured review results. Ambiguous behavior is never approximated silently.
 
-Literal `fxShow` and `fxHide` inputs are converted when the element's complete display behavior is provable. The conversion follows Angular Flex-Layout coercion: `fxShow="false"` hides, `fxHide="false"` shows, and other literal strings, including `"0"`, are truthy before `fxHide` inversion. Hiding uses `hidden`; a responsive shown state after base hiding restores only a display value proven by a converted `fxLayout` or one unambiguous base Tailwind display utility.
+Literal `fxShow` and `fxHide` inputs are converted when the element's complete display behavior is provable. The conversion follows Angular Flex-Layout coercion: `fxShow="false"` hides, `fxHide="false"` shows, and other literal strings, including `"0"`, are truthy before `fxHide` inversion. Literal values use Angular-decoded text, so an entity-spelled value such as `fals&#101;` has the same semantics as `false`. Hiding uses `hidden`; a responsive shown state after base hiding restores only a display value proven by a converted `fxLayout` or one unambiguous base Tailwind display utility.
 
 ```html
 <!-- input -->
@@ -22,7 +22,7 @@ Literal `fxShow` and `fxHide` inputs are converted when the element's complete d
 ></div>
 ```
 
-The complete visibility family is preserved when it contains a binding or interpolation, an orientation, print, or custom alias, conflicting overlapping states, an unverified restoration display, or an unsafe class/style interaction. A literal or bound style that can control `display` always blocks conversion. A bound class blocks a family that needs generated classes, but does not block an all-shown no-op whose attributes can simply be removed. See the [compatibility reference](docs/compatibility.md) and [visibility architecture](docs/architecture/visibility-semantics.md) for the exact boundary.
+The complete visibility family is preserved when it contains a binding or interpolation, an orientation, print, or custom alias, conflicting overlapping states, an unverified restoration display, a partially overlapping responsive layout display without safe ownership, or an unsafe class/style interaction. A literal or bound style that can control `display` always blocks conversion. Unsupported responsive `class`, `ngClass`, `style`, and `ngStyle` authorities also preserve generated visibility output. A bound class blocks a family that needs generated classes, but does not block an all-shown no-op whose attributes can simply be removed. See the [compatibility reference](docs/compatibility.md) and [visibility architecture](docs/architecture/visibility-semantics.md) for the exact boundary.
 
 ## CLI workflow
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,21 @@ Version 2 is under active development and is not published to npm yet. It does n
 
 The v2 engine parses templates with the Angular compiler and applies validated source-range edits. It preserves comments, control-flow syntax, interpolation, line endings, and all unrelated source text instead of serializing the template as generic HTML.
 
-The current prerelease converts documented static inputs and literal responsive inputs using the standard Angular Flex-Layout viewport aliases (`xs` through `xl`, `lt-*`, and `gt-*`) to exact Tailwind CSS v4 arbitrary media variants. For example, `fxLayout.sm="row"` becomes `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-row` alongside the other layout utilities. Dynamic bindings, orientation, print, and custom breakpoints, bound class values, unsupported directives, and responsive families with conflicting overlapping values remain unchanged with structured review results. Ambiguous behavior is never approximated silently.
+The current prerelease converts documented static inputs and literal responsive inputs using the standard Angular Flex-Layout viewport aliases (`xs` through `xl`, `lt-*`, and `gt-*`) to exact Tailwind CSS v4 arbitrary media variants. For example, `fxLayout.sm="row"` becomes `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-row` alongside the other layout utilities. Dynamic bindings, orientation, print, and custom breakpoints, unsupported directives, and responsive families with conflicting overlapping values remain unchanged with structured review results. Ambiguous behavior is never approximated silently.
+
+Literal `fxShow` and `fxHide` inputs are converted when the element's complete display behavior is provable. The conversion follows Angular Flex-Layout coercion: `fxShow="false"` hides, `fxHide="false"` shows, and other literal strings, including `"0"`, are truthy before `fxHide` inversion. Hiding uses `hidden`; a responsive shown state after base hiding restores only a display value proven by a converted `fxLayout` or one unambiguous base Tailwind display utility.
+
+```html
+<!-- input -->
+<div fxLayout="column" fxShow="false" fxShow.sm></div>
+
+<!-- output -->
+<div
+  class="flex flex-col box-border hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex"
+></div>
+```
+
+The complete visibility family is preserved when it contains a binding or interpolation, an orientation, print, or custom alias, conflicting overlapping states, an unverified restoration display, or an unsafe class/style interaction. A literal or bound style that can control `display` always blocks conversion. A bound class blocks a family that needs generated classes, but does not block an all-shown no-op whose attributes can simply be removed. See the [compatibility reference](docs/compatibility.md) and [visibility architecture](docs/architecture/visibility-semantics.md) for the exact boundary.
 
 ## CLI workflow
 

--- a/docs/architecture/angular-template-ast.md
+++ b/docs/architecture/angular-template-ast.md
@@ -45,7 +45,7 @@ type TemplateParseResult =
   { status: 'parsed'; template: ParsedTemplate } | { status: 'parse-error'; diagnostics: readonly ParseDiagnostic[] };
 ```
 
-`ParsedTemplate` contains normalized elements and inputs rather than Angular AST nodes. Every input records its directive name, raw source name, raw value, binding kind, optional breakpoint, element identity, and absolute source ranges. Ranges use half-open offsets: `start` is inclusive and `end` is exclusive.
+`ParsedTemplate` contains normalized elements and inputs rather than Angular AST nodes. Every attribute keeps its Angular-decoded semantic value separately from its raw source spelling and edit ranges. Bound attributes also retain Angular's property, attribute, class, style, animation, or two-way target kind so normalized target names cannot be mistaken for directive inputs. Ranges use half-open offsets: `start` is inclusive and `end` is exclusive.
 
 The wrapper traverses elements, templates, and control-flow branches in document order. Angular compiler nodes never cross this boundary.
 
@@ -67,13 +67,18 @@ interface TemplateElement {
 
 interface TemplateAttribute {
   readonly name: string;
+  readonly rawName: string;
+  readonly rawValue: string;
   readonly value: string;
   readonly binding: 'literal' | 'property';
+  readonly bindingTarget?: 'property' | 'attribute' | 'class' | 'style' | 'animation' | 'two-way';
   readonly source: SourceRange;
   readonly nameSource: SourceRange;
   readonly valueSource?: SourceRange;
 }
 ```
+
+For literal attributes, `value` is the Angular-decoded semantic text and `rawValue` is the exact text covered by `valueSource`. Property-binding expressions remain unevaluated raw text.
 
 Element identifiers are deterministic source offsets, not generated UUIDs. Parent relationships allow context-sensitive conversions without exposing mutable DOM nodes.
 

--- a/docs/architecture/responsive-breakpoints.md
+++ b/docs/architecture/responsive-breakpoints.md
@@ -141,5 +141,5 @@ Deferred work includes:
 - orientation and print conversion;
 - generated named variants and stylesheet mutation;
 - dynamic responsive expressions;
-- visibility and extended responsive directives; and
+- responsive class, style, and image directives; and
 - CSS Grid directives.

--- a/docs/architecture/visibility-semantics.md
+++ b/docs/architecture/visibility-semantics.md
@@ -1,0 +1,176 @@
+# Exact visibility conversion semantics
+
+## Status
+
+Approved design for the Tailwind CSS v4 `fxShow` and `fxHide` conversion increment.
+
+## Purpose
+
+Angular Flex-Layout visibility directives update the host element's inline `display` style. They normalize `fxShow` and `fxHide` into a shared show state, select responsive values using the library's breakpoint machinery, hide with `display: none`, and restore the element's original computed display value when shown.
+
+A direct `fxShow` to `block` or `fxHide` to `hidden` mapping is not generally exact. The original display may be `inline`, `table`, a layout-derived flex value, or a value supplied by application CSS. This increment converts only visibility families whose complete display behavior is statically provable.
+
+The source contract is pinned to the archived upstream [`ShowHideDirective`](https://github.com/angular/flex-layout/blob/84ac0ed3fe49263e405f2a449323fb73a798ff84/projects/libs/flex-layout/extended/show-hide/show-hide.ts) and its show/hide tests at commit `84ac0ed`.
+
+## Scope
+
+This increment supports literal `fxShow` and `fxHide` inputs at base and at the 13 standard viewport aliases already defined by the exact breakpoint catalog.
+
+It does not add support for:
+
+- Angular property bindings or interpolation;
+- orientation, print, or custom breakpoint aliases;
+- responsive `class`, `ngClass`, `style`, `ngStyle`, or `imgSrc` inputs;
+- stylesheet discovery or mutation; or
+- a native CSS target.
+
+Unsupported inputs remain unchanged with structured diagnostics. No CLI option or runtime dependency is added.
+
+## Upstream value semantics
+
+Visibility values normalize to the upstream show state:
+
+| Input            | Normalized show state |
+| ---------------- | --------------------- |
+| `fxShow`         | shown                 |
+| `fxShow=""`      | shown                 |
+| `fxShow="false"` | hidden                |
+| other literals   | shown                 |
+| `fxHide`         | hidden                |
+| `fxHide=""`      | hidden                |
+| `fxHide="false"` | shown                 |
+| other literals   | hidden                |
+
+The literal string `0` is truthy under the upstream coercion path. Bound numeric zero is false upstream, but every property binding remains dynamic because the codemod does not evaluate Angular expressions.
+
+`VisibilityValueParser` owns this coercion and `fxHide` inversion. It returns an explicit result type rather than booleans with directive-specific interpretation elsewhere.
+
+## Visibility state model
+
+`VisibilityStatePlanner` groups all `fxShow` and `fxHide` inputs on one element into one atomic visibility family. Each literal member becomes a `VisibilityState` containing:
+
+- shown or hidden intent;
+- base or verified media activation range;
+- original input identity; and
+- upstream breakpoint priority for diagnostics and conservative overlap analysis.
+
+The family uses these rules:
+
+1. A family containing a dynamic, optional, print, or custom member is preserved atomically.
+2. More than one base member is safe only when every base member normalizes to the same state.
+3. Members in disjoint ranges may convert together.
+4. Intersecting responsive members are safe only when they normalize to the same state.
+5. Conflicting same-range or overlapping states remain unchanged with `responsive-precedence-unverified`.
+6. A family whose effective state is always shown is a safe no-op: its attributes are removed and no class is generated.
+7. A shown state that must override an effective hidden state requires a proven restoration display.
+
+The planner never relies on HTML attribute order or Tailwind stylesheet order to choose between contradictory visibility inputs.
+
+## Display restoration
+
+`VisibleDisplayResolver` proves the display used by each effective shown state. Resolution is conservative and ordered:
+
+1. A safely converted `fxLayout` supplies `flex` or `inline-flex` for the matching activation range.
+2. One unambiguous, unmodified base Tailwind display utility may supply the original display for every range where it remains active.
+3. If no directive state needs to restore visibility after an effective hidden state, no restoration class is required.
+4. Otherwise the display is unverified and the complete visibility family is preserved with `display-restoration-unverified`.
+
+Recognized restoration utilities are Tailwind v4's standard display values except `hidden`, including block, inline, flex, grid, table, flow-root, contents, and list-item families. Important, variant-prefixed, contradictory, or multiple base display utilities do not provide an unambiguous restoration value.
+
+A literal or bound style that controls `display` always blocks conversion. Flex-Layout overwrote and later restored an inline display declaration; a normal Tailwind utility cannot reproduce that behavior without editing the style attribute. Bound class inputs continue to block generated classes under the existing safety contract.
+
+An existing `hidden` utility is compatible only when every effective visibility state is hidden. Any shown state would require overriding that class and therefore remains unresolved.
+
+## Layout and visibility composition
+
+`fxLayout` and visibility both control `display`, so their strategies cannot be finalized independently. The adapter adds an element-level `DisplayCompositionPlanner` after semantic family planning and before existing-class conflict validation.
+
+The composition planner consumes:
+
+- converted layout plans and their base/responsive display utilities;
+- the complete visibility state plan;
+- the resolved original display; and
+- activation ranges from the breakpoint catalog.
+
+It produces one canonical element display plan:
+
+- hidden ranges emit `hidden`;
+- shown ranges that follow an effective hidden state emit the proven restoration utility;
+- layout display utilities that are fully covered by a hidden range are suppressed for that range;
+- non-display layout utilities such as direction, wrapping, alignment, and box sizing remain intact; and
+- layout and visibility results are either both safe or preserved according to their dependency relationship.
+
+This is a composition stage, not another directive strategy. It prevents same-range `flex` and `hidden` utilities from competing through Tailwind's cascade and keeps the responsibility for final display ownership in one place.
+
+If unresolved visibility needs a converted layout to restore display, dependency closure preserves the layout family. If an unresolved layout makes restoration uncertain, dependency closure preserves the visibility family. Parent layout-gap behavior remains safe because native CSS gap ignores elements whose final display is none; unresolved legacy gap families retain their existing layout-context preservation rules.
+
+## Tailwind emission and conflicts
+
+`VisibilityEmitter` converts a finalized display plan into Tailwind CSS v4 tokens. It uses `hidden` for base hiding and the existing exact arbitrary media variant emitter for responsive states. Restoration utilities are emitted only from a proven display value.
+
+Representative hidden and restoration tokens are compiled with Tailwind CSS v4 for base, bounded, min-only, and max-only activation ranges. Compiler output must prove the intended media query and final display declaration.
+
+The existing Tailwind conflict policy remains the final external-class gate. It is extended only where needed to distinguish:
+
+- a base display utility deliberately consumed as the restoration source;
+- a compatible existing `hidden` state; and
+- a competing display utility that makes the final state ambiguous.
+
+Post-conflict dependency closure runs before source edits, so preserving one display owner cannot leave a coupled layout or visibility family partially removed.
+
+## Diagnostics
+
+This increment adds:
+
+- `display-restoration-unverified`: a shown state must restore a display value that cannot be proven from the template and planned layout semantics.
+
+Existing diagnostics remain applicable:
+
+- `dynamic-binding` for property bindings and interpolation;
+- `breakpoint-unverified` for orientation and print aliases;
+- `custom-breakpoint` for unknown aliases;
+- `responsive-precedence-unverified` for conflicting intersecting states;
+- `class-conflict` for incompatible existing display utilities;
+- `bound-class` for generated output blocked by a class binding; and
+- `context-unverified` for an unresolved layout/visibility dependency.
+
+Intrinsic binding and breakpoint diagnostics take precedence over contextual diagnostics. Every unresolved member retains its most actionable reason even when dependency closure preserves related inputs.
+
+## Data flow
+
+1. The Angular parser and analyzer discover all visibility and layout inputs without evaluating bindings.
+2. `VisibilityValueParser` normalizes literal show/hide values.
+3. `VisibilityStatePlanner` validates the complete visibility family and activation-range overlaps.
+4. Existing layout strategies produce semantic layout plans.
+5. `VisibleDisplayResolver` proves restoration values from safe layout context or one static display utility.
+6. `DisplayCompositionPlanner` produces the final element display plan and dependency relationships.
+7. `VisibilityEmitter` decorates finalized display utilities with exact Tailwind v4 media variants.
+8. Existing-class conflict validation and post-conflict dependency closure run across the complete element plan.
+9. Source edits are emitted only when every removed input has a safe converted result.
+
+## Testing strategy
+
+Development follows test-driven delivery. Every behavior is represented by a failing test before implementation.
+
+### Unit contracts
+
+- Table-driven parser tests cover empty, `false`, arbitrary truthy literals, literal `0`, directive inversion, and dynamic input rejection.
+- State-planner tests cover base-only, responsive-only, base plus responsive, disjoint ranges, identical overlaps, conflicting overlaps, duplicate bases, and mixed show/hide declarations.
+- Display-resolution tests cover layout-derived flex and inline-flex, every recognized static display family, hidden, important and variant-prefixed classes, contradictory classes, inline display styles, and bound class/style values.
+- Composition tests cover same-range layout and hiding, hidden-to-visible restoration, suppression of competing layout display utilities, non-display layout preservation, and dependency closure.
+- Tailwind compiler tests cover hidden and restoration output in every media-range shape.
+
+### Integration contracts
+
+- Planner tests prove visibility/layout atomicity before and after class conflicts.
+- Compatibility fixtures cover every standard alias, exact output, all preserved alias/binding families, diagnostic precedence, existing class/style interactions, source-order independence, and idempotence.
+- CLI and JSON report tests prove the new diagnostic and strict unresolved behavior.
+- Mutation checks demonstrate that overlap, ordering, and composition tests fail when their safety gates are removed.
+
+The complete repository verification, coverage thresholds, build, package smoke test, audit, package-content inspection, tracked-file hygiene scan, and independent whole-branch review remain release gates.
+
+## Delivery boundary
+
+This is one feature PR with a minor Changeset. It adds exact visibility conversion without changing the CLI or published runtime dependencies.
+
+Deferred work includes responsive class/style/image inputs, project-aware display discovery, stylesheet mutation, print and orientation visibility, dynamic expressions, CSS Grid directives, and a native CSS adapter.

--- a/docs/architecture/visibility-semantics.md
+++ b/docs/architecture/visibility-semantics.md
@@ -110,6 +110,39 @@ If unresolved visibility needs a converted layout to restore display, dependency
 
 Representative hidden and restoration tokens are compiled with Tailwind CSS v4 for base, bounded, min-only, and max-only activation ranges. Compiler output must prove the intended media query and final display declaration.
 
+The final compiler-proven token examples are:
+
+| Activation | Emitted token                                                             | Compiled result                                                  |
+| ---------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| base       | `hidden`                                                                  | `display: none`                                                  |
+| `sm`       | `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden` | bounded `600px`–`959.98px` media rule containing `display: none` |
+| `gt-xs`    | `[@media_screen_and_(min-width:_600px)]:flex`                             | min-only `600px` media rule containing `display: flex`           |
+| `lt-sm`    | `[@media_screen_and_(max-width:_599.98px)]:inline-flex`                   | max-only `599.98px` media rule containing `display: inline-flex` |
+
+Composition assigns those tokens only after resolving display ownership. For example:
+
+```html
+<!-- input -->
+<div fxLayout="column" fxShow="false" fxShow.sm></div>
+
+<!-- output -->
+<div
+  class="flex flex-col box-border hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex"
+></div>
+```
+
+When responsive layout and hiding share the `sm` range, the competing responsive `flex` token is omitted while direction and box sizing remain:
+
+```html
+<!-- input -->
+<div fxLayout.sm="column" fxHide.sm></div>
+
+<!-- output -->
+<div
+  class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-col [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:box-border [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"
+></div>
+```
+
 The existing Tailwind conflict policy remains the final external-class gate. It is extended only where needed to distinguish:
 
 - a base display utility deliberately consumed as the restoration source;

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -53,11 +53,13 @@ If an existing recognized Tailwind utility conflicts with a generated class in a
 
 The literal string `"0"` is truthy. Property-bound zero remains dynamic because the codemod does not evaluate Angular expressions.
 
+Literal semantics use the Angular compiler's decoded attribute value. HTML character references therefore behave exactly like their decoded spelling, while source edits retain the original raw spelling of existing class evidence.
+
 Base and responsive hiding emits `hidden` under the exact activation range. An all-shown family is a safe no-op: the visibility attributes are removed without generating a class. Disjoint responsive states and identical overlapping states may convert together. Conflicting base states or conflicting overlapping responsive states preserve the whole family with `responsive-precedence-unverified`, independent of attribute order.
 
-A shown override after base hiding converts only when its restoration display is proven by a safely converted `fxLayout` or one unambiguous, unmodified base Tailwind display utility. Otherwise the family is preserved with `display-restoration-unverified`. Literal or bound display styles always block conversion. Bound class inputs block generated visibility classes with `bound-class`, while an all-shown no-op may still be removed beside a bound class. An existing `hidden` utility is compatible only when every effective state is hidden; conflicting, multiple, important, or variant-prefixed display utilities do not provide safe restoration evidence.
+A shown override after base hiding converts only when its restoration display is proven by a safely converted `fxLayout` or one unambiguous, unmodified base Tailwind display utility. Otherwise the family is preserved with `display-restoration-unverified`. Literal or bound display styles always block conversion; literal declaration lists are parsed conservatively, including comments, CSS escapes, and decoded character references. Bound class inputs block generated visibility classes with `bound-class`, while an all-shown no-op may still be removed beside a bound class. An existing `hidden` utility is compatible only when every effective state is hidden; conflicting, multiple, important, or variant-prefixed display utilities do not provide safe restoration evidence.
 
-When layout and visibility both control `display`, the planner composes them before editing. Visibility owns hidden ranges, covered `flex` or `inline-flex` layout utilities are suppressed, and non-display layout utilities remain. If one family is needed to prove the other, unresolved state closes across both families. See [Exact visibility conversion semantics](architecture/visibility-semantics.md) for the complete composition and diagnostic contract.
+When layout and visibility both control `display`, the planner composes them before editing. Visibility owns hidden ranges, covered `flex` or `inline-flex` layout utilities are suppressed, and non-display layout utilities remain. A responsive layout display that only partially overlaps hiding is preserved with the visibility family when generated CSS cannot prove safe ownership. Exact, disjoint, fully covered, and base-layout cases retain their proven conversions. If one family is needed to prove the other, unresolved state closes across both families. See [Exact visibility conversion semantics](architecture/visibility-semantics.md) for the complete composition and diagnostic contract.
 
 ## Grid directives
 
@@ -79,7 +81,7 @@ All grid directives are recognized and preserved. Target conversion has not been
 
 ## Extended responsive inputs
 
-Responsive `class`, `ngClass`, `style`, `ngStyle`, and `imgSrc` inputs are recognized and preserved. Ordinary unsuffixed HTML and Angular `class` and `style` attributes are not treated as Flex-Layout inputs.
+Responsive `class`, `ngClass`, `style`, `ngStyle`, and `imgSrc` inputs are recognized and preserved. Literal, bracket, and `bind-` class/style forms also preserve a visibility family that would generate display classes, because the unsupported responsive authority may override them. Ordinary unsuffixed HTML and Angular `class` and `style` attributes are not treated as Flex-Layout inputs.
 
 ## Bindings and breakpoints
 
@@ -94,6 +96,8 @@ The current safety gate preserves these cases for review:
 - unknown aliases, because they may be registered as custom project breakpoints;
 - visibility whose shown state needs a display value that cannot be proven from template and layout semantics;
 - visibility on an element whose literal or bound style may control `display`;
+- generated visibility output beside an unsupported responsive class or style authority;
+- partially overlapping responsive layout and hidden ranges without proven display ownership;
 - generated visibility output that cannot be merged safely with bound classes or existing display utilities;
 - every directive not implemented by the selected target adapter.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -27,14 +27,37 @@ No native CSS conversions are available yet. The CLI currently accepts only the 
 | `fxFill`        | Limited  | Non-responsive alias of `fxFlexFill`.                                                                                       |
 | `fxFlexOffset`  | Limited  | Static values with a statically known parent axis; unitless values remain percentages.                                      |
 | `fxFlexOrder`   | Limited  | Static integer values emitted independently of the Tailwind theme.                                                          |
-| `fxShow`        | Planned  | Recognized and preserved.                                                                                                   |
-| `fxHide`        | Planned  | Recognized and preserved.                                                                                                   |
+| `fxShow`        | Limited  | Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.     |
+| `fxHide`        | Limited  | Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.  |
 
 All generated lengths that originate in the template use Tailwind arbitrary values. This prevents a project spacing scale from changing `fxLayoutGap="4"` from Angular Flex-Layout's `4px`, or `fxFlexOffset="4"` from its `4%` meaning.
 
 The complete static semantic and diagnostic contract is documented in [Tailwind CSS v4 static conversion semantics](architecture/tailwind-v4-static-semantics.md).
 
-If an existing recognized Tailwind utility controls the same CSS property as a generated class, the directive remains unchanged with a `class-conflict` review result. This avoids relying on HTML class order, which does not determine Tailwind's cascade order.
+If an existing recognized Tailwind utility conflicts with a generated class in an intersecting activation range, the directive remains unchanged with a `class-conflict` review result. This avoids relying on HTML class order, which does not determine Tailwind's cascade order. Visibility restoration sources and the compatible `hidden` cases described below are deliberate exceptions.
+
+## Visibility semantics
+
+`fxShow` and `fxHide` are planned together as one atomic visibility family per element. Literal values use Angular Flex-Layout's coercion and inversion rules:
+
+| Input            | Resulting state |
+| ---------------- | --------------- |
+| `fxShow`         | shown           |
+| `fxShow=""`      | shown           |
+| `fxShow="false"` | hidden          |
+| other literals   | shown           |
+| `fxHide`         | hidden          |
+| `fxHide=""`      | hidden          |
+| `fxHide="false"` | shown           |
+| other literals   | hidden          |
+
+The literal string `"0"` is truthy. Property-bound zero remains dynamic because the codemod does not evaluate Angular expressions.
+
+Base and responsive hiding emits `hidden` under the exact activation range. An all-shown family is a safe no-op: the visibility attributes are removed without generating a class. Disjoint responsive states and identical overlapping states may convert together. Conflicting base states or conflicting overlapping responsive states preserve the whole family with `responsive-precedence-unverified`, independent of attribute order.
+
+A shown override after base hiding converts only when its restoration display is proven by a safely converted `fxLayout` or one unambiguous, unmodified base Tailwind display utility. Otherwise the family is preserved with `display-restoration-unverified`. Literal or bound display styles always block conversion. Bound class inputs block generated visibility classes with `bound-class`, while an all-shown no-op may still be removed beside a bound class. An existing `hidden` utility is compatible only when every effective state is hidden; conflicting, multiple, important, or variant-prefixed display utilities do not provide safe restoration evidence.
+
+When layout and visibility both control `display`, the planner composes them before editing. Visibility owns hidden ranges, covered `flex` or `inline-flex` layout utilities are suppressed, and non-display layout utilities remain. If one family is needed to prove the other, unresolved state closes across both families. See [Exact visibility conversion semantics](architecture/visibility-semantics.md) for the complete composition and diagnostic contract.
 
 ## Grid directives
 
@@ -69,6 +92,9 @@ The current safety gate preserves these cases for review:
 - every Angular property binding, including bindings whose expression appears constant;
 - orientation and print aliases;
 - unknown aliases, because they may be registered as custom project breakpoints;
+- visibility whose shown state needs a display value that cannot be proven from template and layout semantics;
+- visibility on an element whose literal or bound style may control `display`;
+- generated visibility output that cannot be merged safely with bound classes or existing display utilities;
 - every directive not implemented by the selected target adapter.
 
 This is intentional. Angular Flex-Layout's bounded and overlapping aliases are not equivalent to Tailwind's named mobile-first variants, so the codemod emits exact arbitrary media ranges rather than substituting `sm:`, `md:`, or another named Tailwind variant.

--- a/src/adapter/conversion-adapter.ts
+++ b/src/adapter/conversion-adapter.ts
@@ -1,6 +1,6 @@
 import type { DiagnosticCode } from '../analyzer/conversion-result';
 import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
-import type { TemplateElement } from '../template/template.model';
+import type { TemplateAttribute, TemplateElement } from '../template/template.model';
 
 export interface ConversionContext {
   readonly element: TemplateElement;
@@ -9,6 +9,8 @@ export interface ConversionContext {
   readonly parentInputs?: readonly LocatedFlexLayoutInput[];
   readonly activeLayout?: string;
   readonly activeParentLayout?: string;
+  readonly existingClassNames?: readonly string[];
+  readonly attributeEvidence?: readonly TemplateAttribute[];
 }
 
 export type PlannedConversion =

--- a/src/adapter/tailwind/responsive-family.planner.spec.ts
+++ b/src/adapter/tailwind/responsive-family.planner.spec.ts
@@ -128,4 +128,26 @@ describe('ResponsiveFamilyPlanner', () => {
       expect.objectContaining({ status: 'review', code: 'dynamic-binding' }),
     ]);
   });
+
+  test('closes fxShow and fxHide as one visibility family without replanning their semantics', () => {
+    const show = input('fxShow', '', { directive: 'fxShow' });
+    const hide = input('fxHide.sm', '', { directive: 'fxHide' });
+    const planner = new ResponsiveFamilyPlanner();
+    const plans = planner.closeDependencies([show, hide], { element, inputs: [show, hide] }, item =>
+      item.id === show.id
+        ? {
+            status: 'review',
+            input: item,
+            code: 'class-conflict',
+            reason: 'conflict',
+            suggestion: 'reconcile',
+          }
+        : { status: 'converted', input: item, classNames: ['hidden'] },
+    );
+
+    expect(plans).toEqual([
+      expect.objectContaining({ status: 'review', code: 'class-conflict' }),
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+    ]);
+  });
 });

--- a/src/adapter/tailwind/responsive-family.planner.spec.ts
+++ b/src/adapter/tailwind/responsive-family.planner.spec.ts
@@ -150,4 +150,55 @@ describe('ResponsiveFamilyPlanner', () => {
       expect.objectContaining({ status: 'review', code: 'context-unverified' }),
     ]);
   });
+
+  test('retains intrinsic visibility diagnostics when dynamic closure preserves the family', () => {
+    const optional = input('fxShow.handset', '', { directive: 'fxShow' });
+    const custom = input('fxHide.cinema', '', { directive: 'fxHide' });
+    const dynamic = input('[fxShow.sm]', 'visible', { directive: 'fxShow' });
+    const existing = new Map<string, PlannedConversion>([
+      [
+        optional.id,
+        {
+          status: 'review',
+          input: optional,
+          code: 'breakpoint-unverified',
+          reason: 'optional breakpoint',
+          suggestion: 'keep the directive',
+        },
+      ],
+      [
+        custom.id,
+        {
+          status: 'review',
+          input: custom,
+          code: 'custom-breakpoint',
+          reason: 'custom breakpoint',
+          suggestion: 'provide its media query',
+        },
+      ],
+      [
+        dynamic.id,
+        {
+          status: 'review',
+          input: dynamic,
+          code: 'dynamic-binding',
+          reason: 'dynamic binding',
+          suggestion: 'make the input literal',
+        },
+      ],
+    ]);
+    const inputs = [optional, custom, dynamic];
+
+    const plans = new ResponsiveFamilyPlanner().closeDependencies(
+      inputs,
+      { element, inputs },
+      item => existing.get(item.id) ?? planOne(item),
+    );
+
+    expect(plans).toEqual([
+      expect.objectContaining({ status: 'review', code: 'breakpoint-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'custom-breakpoint' }),
+      expect.objectContaining({ status: 'review', code: 'dynamic-binding' }),
+    ]);
+  });
 });

--- a/src/adapter/tailwind/responsive-family.planner.ts
+++ b/src/adapter/tailwind/responsive-family.planner.ts
@@ -6,7 +6,15 @@ import { ResponsiveVariantEmitter } from './responsive-variant.emitter';
 import type { TailwindStrategyResult } from './tailwind-semantic.model';
 
 export type DirectiveFamily =
-  'layout' | 'layout-gap' | 'layout-align' | 'flex-item' | 'flex-align' | 'flex-fill' | 'flex-offset' | 'flex-order';
+  | 'layout'
+  | 'layout-gap'
+  | 'layout-align'
+  | 'flex-item'
+  | 'flex-align'
+  | 'flex-fill'
+  | 'flex-offset'
+  | 'flex-order'
+  | 'visibility';
 
 export type PlanOne = (input: LocatedFlexLayoutInput, context: ConversionContext) => PlannedConversion;
 
@@ -22,6 +30,8 @@ const familyByDirective = new Map<LocatedFlexLayoutInput['directive'], Directive
   ['fxFill', 'flex-fill'],
   ['fxFlexOffset', 'flex-offset'],
   ['fxFlexOrder', 'flex-order'],
+  ['fxShow', 'visibility'],
+  ['fxHide', 'visibility'],
 ]);
 
 const localLayoutDependents = new Set<DirectiveFamily>(['layout-gap', 'layout-align']);

--- a/src/adapter/tailwind/responsive-family.planner.ts
+++ b/src/adapter/tailwind/responsive-family.planner.ts
@@ -434,12 +434,20 @@ export class ResponsiveFamilyPlanner {
     validateResponsivePrecedence: boolean,
   ): readonly PlannedConversion[] {
     if (inputs.some(input => input.binding !== 'literal')) {
-      return inputs.map((input, index) =>
-        input.binding !== 'literal'
-          ? (semanticPlans[index] ??
-            contextUnverified(input, 'The dynamic member of this directive family cannot be planned.'))
-          : contextUnverified(input, 'Another member of this responsive directive family is dynamic.'),
-      );
+      return inputs.map((input, index) => {
+        const semanticPlan =
+          semanticPlans[index] ??
+          contextUnverified(input, 'The dynamic member of this directive family cannot be planned.');
+        if (input.binding !== 'literal') return semanticPlan;
+        const breakpointPlan = this.validateBreakpoint(semanticPlan);
+        if (
+          breakpointPlan.status !== 'converted' &&
+          (breakpointPlan.code === 'breakpoint-unverified' || breakpointPlan.code === 'custom-breakpoint')
+        ) {
+          return breakpointPlan;
+        }
+        return contextUnverified(input, 'Another member of this responsive directive family is dynamic.');
+      });
     }
     const supportedPlans = semanticPlans.map(plan => this.validateBreakpoint(plan));
     if (supportedPlans.some(plan => plan.status !== 'converted')) {

--- a/src/adapter/tailwind/tailwind-class-conflict.spec.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.spec.ts
@@ -1,8 +1,85 @@
-import { findTailwindClassConflicts } from './tailwind-class-conflict';
+import { describeTailwindDisplay, findTailwindClassConflicts } from './tailwind-class-conflict';
 
 const xs = (utility: string) => `[@media_screen_and_(min-width:_0px)_and_(max-width:_599.98px)]:${utility}`;
 const sm = (utility: string) => `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:${utility}`;
 const gtXs = (utility: string) => `[@media_screen_and_(min-width:_600px)]:${utility}`;
+
+describe('describeTailwindDisplay', () => {
+  test.each([
+    'inline',
+    'block',
+    'inline-block',
+    'flow-root',
+    'flex',
+    'inline-flex',
+    'grid',
+    'inline-grid',
+    'contents',
+    'table',
+    'inline-table',
+    'table-caption',
+    'table-cell',
+    'table-column',
+    'table-column-group',
+    'table-footer-group',
+    'table-header-group',
+    'table-row-group',
+    'table-row',
+    'list-item',
+    'hidden',
+  ])('describes the standard Tailwind display utility %s', utility => {
+    expect(describeTailwindDisplay(utility)).toEqual({
+      token: utility,
+      utility,
+      activation: { kind: 'base' },
+      important: false,
+    });
+  });
+
+  test.each([
+    ['!block', 'block'],
+    ['inline-flex!', 'inline-flex'],
+  ])('normalizes the important display utility %s', (token, utility) => {
+    expect(describeTailwindDisplay(token)).toEqual({
+      token,
+      utility,
+      activation: { kind: 'base' },
+      important: true,
+    });
+  });
+
+  test.each([
+    [sm('grid'), { min: 600, max: 959.98 }],
+    [gtXs('flex'), { min: 600 }],
+    ['[@media_screen_and_(max-width:_599.98px)]:inline', { max: 599.98 }],
+  ])('describes the generated media activation for %s', (token, range) => {
+    expect(describeTailwindDisplay(token)).toEqual({
+      token,
+      utility: token.slice(token.lastIndexOf(':') + 1),
+      activation: { kind: 'media', range },
+      important: false,
+    });
+  });
+
+  test('retains an ordinary variant as a modified base display token', () => {
+    expect(describeTailwindDisplay('hover:contents')).toEqual({
+      token: 'hover:contents',
+      utility: 'contents',
+      activation: { kind: 'base' },
+      important: false,
+    });
+  });
+
+  test('does not split an arbitrary display property at its inner colon', () => {
+    expect(describeTailwindDisplay('[display:block]')).toEqual({
+      token: '[display:block]',
+      utility: '[display:block]',
+      activation: { kind: 'base' },
+      important: false,
+    });
+    expect(describeTailwindDisplay('[flex:1_1_auto]')).toBeUndefined();
+  });
+});
 
 describe('findTailwindClassConflicts', () => {
   test.each([

--- a/src/adapter/tailwind/tailwind-class-conflict.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.ts
@@ -1,6 +1,13 @@
 import { mediaRangesIntersect, type MediaRange } from '../../breakpoint/breakpoint-catalog';
 
-type TailwindActivation = { readonly kind: 'base' } | { readonly kind: 'media'; readonly range: MediaRange };
+export type TailwindActivation = { readonly kind: 'base' } | { readonly kind: 'media'; readonly range: MediaRange };
+
+export interface TailwindDisplayUtility {
+  readonly token: string;
+  readonly utility: string;
+  readonly activation: TailwindActivation;
+  readonly important: boolean;
+}
 
 interface TailwindUtilityDescriptor {
   readonly token: string;
@@ -105,9 +112,27 @@ function propertyGroup(utility: string): string | undefined {
   return undefined;
 }
 
-function describe(token: string): TailwindUtilityDescriptor {
-  const { variants, utility } = splitVariants(token);
-  return { token, propertyGroup: propertyGroup(utility), activation: activation(variants) };
+interface DescribedTailwindUtility extends TailwindUtilityDescriptor {
+  readonly utility: string;
+  readonly important: boolean;
+}
+
+function describe(token: string): DescribedTailwindUtility {
+  const { variants, utility: modifiedUtility } = splitVariants(token);
+  const important = modifiedUtility.startsWith('!') || modifiedUtility.endsWith('!');
+  const utility = modifiedUtility.replace(/^!/u, '').replace(/!$/u, '');
+  return { token, utility, propertyGroup: propertyGroup(utility), activation: activation(variants), important };
+}
+
+export function describeTailwindDisplay(token: string): TailwindDisplayUtility | undefined {
+  const descriptor = describe(token);
+  if (descriptor.propertyGroup !== 'display') return undefined;
+  return {
+    token: descriptor.token,
+    utility: descriptor.utility,
+    activation: descriptor.activation,
+    important: descriptor.important,
+  };
 }
 
 function activationsIntersect(left: TailwindActivation, right: TailwindActivation): boolean {

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -37,10 +37,50 @@ describe('TailwindAdapter', () => {
   test.each([
     [{ binding: 'property' }, 'review', 'dynamic-binding'],
     [{ breakpoint: 'cinema', sourceName: 'fxLayout.cinema' }, 'review', 'custom-breakpoint'],
-    [{ directive: 'fxShow', sourceName: 'fxShow' }, 'unsupported', 'target-unsupported'],
+    [{ directive: 'fxShow', sourceName: 'fxShow' }, 'review', 'context-unverified'],
     [{ value: 'diagonal' }, 'invalid', 'invalid-value'],
   ] as const)('classifies unresolved input %o', (overrides, status, code) => {
     expect(new TailwindAdapter().plan(input(overrides), { element })).toMatchObject({ status, code });
+  });
+
+  test('plans a complete static and responsive visibility family through the dedicated state pipeline', () => {
+    const adapter = new TailwindAdapter();
+    const inputs = [
+      input({ id: 'fixture:show', directive: 'fxShow', sourceName: 'fxShow', value: 'false' }),
+      input({
+        id: 'fixture:show-sm',
+        directive: 'fxShow',
+        sourceName: 'fxShow.sm',
+        breakpoint: 'sm',
+        value: '',
+      }),
+    ];
+
+    expect(adapter.planElement(inputs, { element, inputs, existingClassNames: ['block'] })).toEqual([
+      expect.objectContaining({ status: 'converted', classNames: ['hidden', expect.stringContaining(']:block')] }),
+      expect.objectContaining({ status: 'converted', classNames: [] }),
+    ]);
+  });
+
+  test('uses converted layout display as responsive visibility restoration', () => {
+    const adapter = new TailwindAdapter();
+    const inputs = [
+      input({ id: 'fixture:layout', directive: 'fxLayout', sourceName: 'fxLayout', value: 'column' }),
+      input({ id: 'fixture:show', directive: 'fxShow', sourceName: 'fxShow', value: 'false' }),
+      input({
+        id: 'fixture:show-sm',
+        directive: 'fxShow',
+        sourceName: 'fxShow.sm',
+        breakpoint: 'sm',
+        value: '',
+      }),
+    ];
+
+    expect(adapter.planElement(inputs, { element, inputs, existingClassNames: [] })).toEqual([
+      expect.objectContaining({ status: 'converted', classNames: ['flex', 'flex-col', 'box-border'] }),
+      expect.objectContaining({ status: 'converted', classNames: ['hidden', expect.stringContaining(']:flex')] }),
+      expect.objectContaining({ status: 'converted', classNames: [] }),
+    ]);
   });
 
   test('decorates verified responsive classes after planning their literal value semantics', () => {

--- a/src/adapter/tailwind/tailwind.adapter.ts
+++ b/src/adapter/tailwind/tailwind.adapter.ts
@@ -20,6 +20,13 @@ import { VisibleDisplayResolver } from './visibility/visible-display.resolver';
 
 const flexItemDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxFlex', 'fxGrow', 'fxShrink']);
 const visibilityDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxShow', 'fxHide']);
+const responsiveDisplayAuthorityDirectives = new Set<LocatedFlexLayoutInput['directive']>([
+  'class',
+  'ngClass',
+  'style',
+  'ngStyle',
+]);
+const responsiveStyleAuthorityDirectives = new Set<LocatedFlexLayoutInput['directive']>(['style', 'ngStyle']);
 
 const supportedDirectives = new Set<LocatedFlexLayoutInput['directive']>([
   'fxFlex',
@@ -74,7 +81,7 @@ function staticLayoutContext(attributes: readonly TemplateAttribute[]): string |
 function isBoundClassAttribute(attribute: TemplateAttribute): boolean {
   if (attribute.binding !== 'property') return false;
   return [...templateAttributeKeys(attribute)].some(
-    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.') || key.startsWith('ngclass.'),
   );
 }
 
@@ -210,6 +217,9 @@ export class TailwindAdapter implements ConversionAdapter {
     if (!visibilityInputs.length) return strategyPlans;
 
     const layoutPlans = strategyPlans.filter(plan => plan.input.directive === 'fxLayout');
+    const responsiveStyleInputs = strategyInputs.filter(input =>
+      responsiveStyleAuthorityDirectives.has(input.directive),
+    );
     const visibilityPlan = this.visibilityStatePlanner.plan(visibilityInputs);
     const displayResolution =
       visibilityPlan.status === 'converted'
@@ -220,6 +230,7 @@ export class TailwindAdapter implements ConversionAdapter {
             attributes: (context.attributeEvidence ?? context.element.attributes).filter(
               attribute => !isBoundClassAttribute(attribute),
             ),
+            responsiveStyleInputs,
           })
         : { status: 'resolved' as const, utility: undefined };
     const composed = this.displayCompositionPlanner.compose({
@@ -373,12 +384,15 @@ export class TailwindAdapter implements ConversionAdapter {
   private closeDisplayDependencies(plans: readonly PlannedConversion[]): readonly PlannedConversion[] {
     const layoutPlans = plans.filter(plan => plan.input.directive === 'fxLayout');
     const visibilityPlans = plans.filter(plan => visibilityDirectives.has(plan.input.directive));
+    const authorityPlans = plans.filter(plan => responsiveDisplayAuthorityDirectives.has(plan.input.directive));
     const visibilityIsNoOp =
       visibilityPlans.length > 0 &&
       visibilityPlans.every(plan => plan.status === 'converted' && plan.classNames.length === 0);
-    if (!layoutPlans.length || !visibilityPlans.length || visibilityIsNoOp) return plans;
+    if ((!layoutPlans.length && !authorityPlans.length) || !visibilityPlans.length || visibilityIsNoOp) return plans;
 
-    const displayContextIsUnresolved = [...layoutPlans, ...visibilityPlans].some(plan => plan.status !== 'converted');
+    const displayContextIsUnresolved = [...layoutPlans, ...visibilityPlans, ...authorityPlans].some(
+      plan => plan.status !== 'converted',
+    );
     if (!displayContextIsUnresolved) return plans;
     return plans.map(plan =>
       plan.status === 'converted' &&

--- a/src/adapter/tailwind/tailwind.adapter.ts
+++ b/src/adapter/tailwind/tailwind.adapter.ts
@@ -8,13 +8,17 @@ import { planLayoutAlign } from './directives/layout-align.strategy';
 import { planIndependentDirective } from './independent-directive.registry';
 import type { TemplateAttribute } from '../../template/template.model';
 import { planLayout } from './directives/layout.strategy';
-import { findTailwindClassConflicts } from './tailwind-class-conflict';
+import { describeTailwindDisplay, findTailwindClassConflicts } from './tailwind-class-conflict';
 import { BreakpointCatalog } from '../../breakpoint/breakpoint-catalog';
 import { ResponsiveVariantEmitter } from './responsive-variant.emitter';
 import { planResponsiveClasses } from './responsive-plan';
 import { ResponsiveFamilyPlanner } from './responsive-family.planner';
+import { DisplayCompositionPlanner } from './visibility/display-composition.planner';
+import { VisibilityStatePlanner } from './visibility/visibility-state.planner';
+import { VisibleDisplayResolver } from './visibility/visible-display.resolver';
 
 const flexItemDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxFlex', 'fxGrow', 'fxShrink']);
+const visibilityDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxShow', 'fxHide']);
 
 const supportedDirectives = new Set<LocatedFlexLayoutInput['directive']>([
   'fxFlex',
@@ -66,6 +70,60 @@ function staticLayoutContext(attributes: readonly TemplateAttribute[]): string |
   return layout?.name === 'fxLayout' && layout.binding === 'literal' ? layout.value : undefined;
 }
 
+function isBoundClassAttribute(attribute: TemplateAttribute): boolean {
+  if (attribute.binding !== 'property') return false;
+  const rawName = attribute.rawName.toLowerCase();
+  const key =
+    rawName.startsWith('[') && rawName.endsWith(']')
+      ? rawName.slice(1, -1)
+      : rawName.startsWith('bind-')
+        ? rawName.slice('bind-'.length)
+        : rawName;
+  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
+}
+
+function contextUnverified(input: LocatedFlexLayoutInput, reason: string): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'context-unverified',
+    reason,
+    suggestion: 'Migrate the complete layout and visibility context together manually.',
+  };
+}
+
+function compatibleVisibilityClasses(
+  plan: Extract<PlannedConversion, { readonly status: 'converted' }>,
+  existingClassNames: readonly string[],
+): readonly string[] {
+  if (!visibilityDirectives.has(plan.input.directive)) return existingClassNames;
+
+  const generatedDisplays = plan.classNames.map(describeTailwindDisplay).filter(descriptor => descriptor !== undefined);
+  const hasBaseHidden = generatedDisplays.some(
+    descriptor => descriptor.activation.kind === 'base' && descriptor.utility === 'hidden',
+  );
+
+  return existingClassNames.filter(className => {
+    const existing = describeTailwindDisplay(className);
+    if (
+      !existing ||
+      existing.activation.kind !== 'base' ||
+      existing.important ||
+      existing.token !== existing.utility ||
+      existing.utility === 'hidden'
+    ) {
+      return true;
+    }
+
+    const suppliesResponsiveVisibility = hasBaseHidden
+      ? generatedDisplays.some(
+          generated => generated.activation.kind === 'media' && generated.utility === existing.utility,
+        )
+      : generatedDisplays.length > 0 && generatedDisplays.every(generated => generated.activation.kind === 'media');
+    return !suppliesResponsiveVisibility;
+  });
+}
+
 export class TailwindAdapter implements ConversionAdapter {
   readonly name = 'tailwind' as const;
   private readonly breakpointCatalog = new BreakpointCatalog();
@@ -74,6 +132,9 @@ export class TailwindAdapter implements ConversionAdapter {
     this.breakpointCatalog,
     this.responsiveEmitter,
   );
+  private readonly visibilityStatePlanner = new VisibilityStatePlanner(this.breakpointCatalog);
+  private readonly visibleDisplayResolver = new VisibleDisplayResolver();
+  private readonly displayCompositionPlanner = new DisplayCompositionPlanner(this.breakpointCatalog);
 
   resolveClassConflicts(
     plans: readonly PlannedConversion[],
@@ -82,13 +143,22 @@ export class TailwindAdapter implements ConversionAdapter {
     const convertedPlans = plans.filter(
       (plan): plan is Extract<PlannedConversion, { readonly status: 'converted' }> => plan.status === 'converted',
     );
-    const conflictingTokens = findTailwindClassConflicts(
+    const sharedConflictingTokens = findTailwindClassConflicts(
       existingClassNames,
       convertedPlans.flatMap(plan => plan.classNames),
     );
     const conflictingFamilies = new Set(
       convertedPlans
-        .filter(plan => plan.classNames.some(className => conflictingTokens.has(className)))
+        .filter(plan => {
+          if (!visibilityDirectives.has(plan.input.directive)) {
+            return plan.classNames.some(className => sharedConflictingTokens.has(className));
+          }
+          const conflictingTokens = findTailwindClassConflicts(
+            compatibleVisibilityClasses(plan, existingClassNames),
+            plan.classNames,
+          );
+          return plan.classNames.some(className => conflictingTokens.has(className));
+        })
         .map(plan => this.directiveFamily(plan.input.directive)),
     );
     return plans.map(plan =>
@@ -110,25 +180,74 @@ export class TailwindAdapter implements ConversionAdapter {
     plansByInputId: ReadonlyMap<string, PlannedConversion>,
   ): readonly PlannedConversion[] {
     const inputs = plans.map(plan => plan.input);
-    const currentPlans = new Map(plans.map(plan => [plan.input.id, plan]));
-    return this.responsiveFamilyPlanner.closeDependencies(inputs, { ...context, inputs }, (input, itemContext) => {
-      return plansByInputId.get(input.id) ?? currentPlans.get(input.id) ?? this.planSemantic(input, itemContext);
-    });
+    const closeResponsiveDependencies = (current: readonly PlannedConversion[]): readonly PlannedConversion[] => {
+      const currentPlans = new Map(current.map(plan => [plan.input.id, plan]));
+      return this.responsiveFamilyPlanner.closeDependencies(
+        inputs,
+        { ...context, inputs },
+        (input, itemContext) =>
+          currentPlans.get(input.id) ?? plansByInputId.get(input.id) ?? this.planSemantic(input, itemContext),
+      );
+    };
+
+    let closed = closeResponsiveDependencies(plans);
+    closed = this.closeDisplayDependencies(closed);
+    closed = closeResponsiveDependencies(closed);
+    return this.closeDisplayDependencies(closed);
   }
 
   private directiveFamily(directive: LocatedFlexLayoutInput['directive']): string {
     if (flexItemDirectives.has(directive)) return 'flex-item';
     if (directive === 'fxFlexFill' || directive === 'fxFill') return 'flex-fill';
+    if (visibilityDirectives.has(directive)) return 'visibility';
     return directive;
   }
 
   planElement(inputs: readonly LocatedFlexLayoutInput[], context: ConversionContext): readonly PlannedConversion[] {
-    return this.responsiveFamilyPlanner.plan(inputs, { ...context, inputs }, (input, itemContext) =>
-      this.planSemantic(input, itemContext),
+    const visibilityInputs = inputs.filter(input => visibilityDirectives.has(input.directive));
+    const strategyInputs = inputs.filter(input => !visibilityDirectives.has(input.directive));
+    const strategyPlans = this.responsiveFamilyPlanner.plan(
+      strategyInputs,
+      { ...context, inputs },
+      (input, itemContext) => this.planSemantic(input, itemContext),
     );
+    if (!visibilityInputs.length) return strategyPlans;
+
+    const layoutPlans = strategyPlans.filter(plan => plan.input.directive === 'fxLayout');
+    const visibilityPlan = this.visibilityStatePlanner.plan(visibilityInputs);
+    const displayResolution =
+      visibilityPlan.status === 'converted'
+        ? this.visibleDisplayResolver.resolve({
+            states: visibilityPlan.states,
+            layoutPlans,
+            existingClassNames: context.existingClassNames ?? [],
+            attributes: (context.attributeEvidence ?? context.element.attributes).filter(
+              attribute => !isBoundClassAttribute(attribute),
+            ),
+          })
+        : { status: 'resolved' as const, utility: undefined };
+    const composed = this.displayCompositionPlanner.compose({
+      visibilityPlan,
+      displayResolution,
+      layoutPlans,
+    });
+    const plansById = new Map(
+      [...strategyPlans.filter(plan => plan.input.directive !== 'fxLayout'), ...composed.plans].map(plan => [
+        plan.input.id,
+        plan,
+      ]),
+    );
+    return inputs.map(input => plansById.get(input.id) ?? this.planSemantic(input, context));
   }
 
   plan(input: LocatedFlexLayoutInput, context: ConversionContext): PlannedConversion {
+    if (visibilityDirectives.has(input.directive)) {
+      const family = this.visibilityStatePlanner.plan([input]);
+      if (family.status === 'unresolved')
+        return family.plans[0] ?? contextUnverified(input, 'Visibility is unresolved.');
+      return contextUnverified(input, 'Visibility requires complete element-family context before conversion.');
+    }
+
     const semantic = this.planSemantic(input, context);
     if (semantic.status !== 'converted') return semantic;
     return toResponsivePlannedConversion(
@@ -253,5 +372,26 @@ export class TailwindAdapter implements ConversionAdapter {
       reason: `${input.value} is not a supported ${input.directive} value.`,
       suggestion: 'Correct the value or migrate this directive manually.',
     };
+  }
+
+  private closeDisplayDependencies(plans: readonly PlannedConversion[]): readonly PlannedConversion[] {
+    const layoutPlans = plans.filter(plan => plan.input.directive === 'fxLayout');
+    const visibilityPlans = plans.filter(plan => visibilityDirectives.has(plan.input.directive));
+    const visibilityIsNoOp =
+      visibilityPlans.length > 0 &&
+      visibilityPlans.every(plan => plan.status === 'converted' && plan.classNames.length === 0);
+    if (!layoutPlans.length || !visibilityPlans.length || visibilityIsNoOp) return plans;
+
+    const displayContextIsUnresolved = [...layoutPlans, ...visibilityPlans].some(plan => plan.status !== 'converted');
+    if (!displayContextIsUnresolved) return plans;
+    return plans.map(plan =>
+      plan.status === 'converted' &&
+      (plan.input.directive === 'fxLayout' || visibilityDirectives.has(plan.input.directive))
+        ? contextUnverified(
+            plan.input,
+            'The element display context contains an unresolved layout or visibility family.',
+          )
+        : plan,
+    );
   }
 }

--- a/src/adapter/tailwind/tailwind.adapter.ts
+++ b/src/adapter/tailwind/tailwind.adapter.ts
@@ -7,6 +7,7 @@ import type { TailwindStrategyResult } from './tailwind-semantic.model';
 import { planLayoutAlign } from './directives/layout-align.strategy';
 import { planIndependentDirective } from './independent-directive.registry';
 import type { TemplateAttribute } from '../../template/template.model';
+import { templateAttributeKeys } from '../../template/template-attribute';
 import { planLayout } from './directives/layout.strategy';
 import { describeTailwindDisplay, findTailwindClassConflicts } from './tailwind-class-conflict';
 import { BreakpointCatalog } from '../../breakpoint/breakpoint-catalog';
@@ -72,14 +73,9 @@ function staticLayoutContext(attributes: readonly TemplateAttribute[]): string |
 
 function isBoundClassAttribute(attribute: TemplateAttribute): boolean {
   if (attribute.binding !== 'property') return false;
-  const rawName = attribute.rawName.toLowerCase();
-  const key =
-    rawName.startsWith('[') && rawName.endsWith(']')
-      ? rawName.slice(1, -1)
-      : rawName.startsWith('bind-')
-        ? rawName.slice('bind-'.length)
-        : rawName;
-  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
+  return [...templateAttributeKeys(attribute)].some(
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+  );
 }
 
 function contextUnverified(input: LocatedFlexLayoutInput, reason: string): PlannedConversion {

--- a/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
@@ -121,6 +121,75 @@ describe('DisplayCompositionPlanner', () => {
     expect(classes.get(hidden.input.id)).toEqual([variant('sm', 'hidden')]);
   });
 
+  test('suppresses a responsive layout display inherited under a hidden base state', () => {
+    const hidden = state('hidden');
+    const responsiveLayout = layout(
+      [variant('sm', 'flex'), variant('sm', 'flex-row'), variant('sm', 'box-border')],
+      'sm',
+    );
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [responsiveLayout] }));
+
+    expect(classes.get(responsiveLayout.input.id)).toEqual([variant('sm', 'flex-row'), variant('sm', 'box-border')]);
+  });
+
+  test.each(['lt-md', 'gt-xs'])('suppresses a nested layout fully covered by the hidden %s range', breakpoint => {
+    const hidden = state('hidden', breakpoint);
+    const responsiveLayout = layout(
+      [variant('sm', 'inline-flex'), variant('sm', 'flex-col'), variant('sm', 'box-border')],
+      'sm',
+    );
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [responsiveLayout] }));
+
+    expect(classes.get(responsiveLayout.input.id)).toEqual([variant('sm', 'flex-col'), variant('sm', 'box-border')]);
+  });
+
+  test('suppresses a base layout display when hidden responsive ranges jointly cover its complete activation', () => {
+    const hiddenBelowMd = state('hidden', 'lt-md');
+    const hiddenAboveXs = state('hidden', 'gt-xs');
+    const baseLayout = layout(['flex', 'flex-row', 'box-border']);
+
+    const classes = convertedClasses(
+      compose([hiddenAboveXs, hiddenBelowMd], {
+        layoutPlans: [baseLayout],
+      }),
+    );
+
+    expect(classes.get(baseLayout.input.id)).toEqual(['flex-row', 'box-border']);
+  });
+
+  test('retains a wider responsive layout display when hiding covers only a narrower subrange', () => {
+    const hidden = state('hidden', 'sm');
+    const widerLayout = layout(
+      [variant('lt-md', 'flex'), variant('lt-md', 'flex-row'), variant('lt-md', 'box-border')],
+      'lt-md',
+    );
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [widerLayout] }));
+
+    expect(classes.get(widerLayout.input.id)).toEqual([
+      variant('lt-md', 'flex'),
+      variant('lt-md', 'flex-row'),
+      variant('lt-md', 'box-border'),
+    ]);
+  });
+
+  test('retains a responsive layout display when a shown override interrupts inherited base hiding', () => {
+    const baseHidden = state('hidden');
+    const responsiveShown = state('shown', 'sm');
+    const responsiveLayout = layout([variant('sm', 'flex'), variant('sm', 'flex-row')], 'sm');
+
+    const classes = convertedClasses(
+      compose([responsiveShown, baseHidden], {
+        displayResolution: { status: 'resolved', utility: 'flex' },
+        layoutPlans: [responsiveLayout],
+      }),
+    );
+
+    expect(classes.get(responsiveLayout.input.id)).toEqual([variant('sm', 'flex'), variant('sm', 'flex-row')]);
+  });
+
   test('keeps a base layout display when only a narrower responsive range is hidden', () => {
     const hidden = state('hidden', 'sm');
     const baseLayout = layout(['flex', 'flex-row', 'box-border']);

--- a/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
@@ -1,0 +1,226 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
+import type { PlannedConversion } from '../../conversion-adapter';
+import { ResponsiveVariantEmitter } from '../responsive-variant.emitter';
+import type { VisibilityIntent, VisibilityState } from './visibility.model';
+import type { VisibilityFamilyPlan } from './visibility-state.planner';
+import type { VisibleDisplayResolution } from './visible-display.resolver';
+import { DisplayCompositionPlanner, type DisplayCompositionRequest } from './display-composition.planner';
+
+function input(
+  directive: LocatedFlexLayoutInput['directive'],
+  breakpoint?: string,
+  id = `fixture:${directive}${breakpoint === undefined ? '' : `.${breakpoint}`}`,
+): LocatedFlexLayoutInput {
+  const sourceName = `${directive}${breakpoint === undefined ? '' : `.${breakpoint}`}`;
+  return {
+    id,
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName,
+    directive,
+    value: directive === 'fxLayout' ? 'row' : '',
+    binding: 'literal',
+    breakpoint,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+  };
+}
+
+function state(
+  intent: VisibilityIntent,
+  breakpoint?: string,
+  id?: string,
+  directive: 'fxShow' | 'fxHide' = 'fxShow',
+): VisibilityState {
+  const member = input(directive, breakpoint, id);
+  if (breakpoint === undefined) return { input: member, intent, activation: { kind: 'base' } };
+  const classification = new BreakpointCatalog().classify(breakpoint);
+  if (classification.kind !== 'verified') throw new Error(`Expected ${breakpoint} to be verified.`);
+  return { input: member, intent, activation: { kind: 'media', definition: classification.definition } };
+}
+
+function layout(classNames: readonly string[], breakpoint?: string, id?: string): PlannedConversion {
+  return { status: 'converted', input: input('fxLayout', breakpoint, id), classNames };
+}
+
+function variant(breakpoint: string, utility: string): string {
+  const classification = new BreakpointCatalog().classify(breakpoint);
+  if (classification.kind !== 'verified') throw new Error(`Expected ${breakpoint} to be verified.`);
+  return new ResponsiveVariantEmitter().emit(classification.definition, utility);
+}
+
+function request(
+  states: readonly VisibilityState[],
+  overrides: Partial<DisplayCompositionRequest> = {},
+): DisplayCompositionRequest {
+  return {
+    visibilityPlan: { status: 'converted', states },
+    displayResolution: { status: 'resolved', utility: undefined },
+    layoutPlans: [],
+    ...overrides,
+  };
+}
+
+function compose(states: readonly VisibilityState[], overrides: Partial<DisplayCompositionRequest> = {}) {
+  return new DisplayCompositionPlanner().compose(request(states, overrides));
+}
+
+function convertedClasses(result: ReturnType<typeof compose>): ReadonlyMap<string, readonly string[]> {
+  return new Map(
+    result.plans.flatMap(plan => (plan.status === 'converted' ? [[plan.input.id, plan.classNames] as const] : [])),
+  );
+}
+
+describe('DisplayCompositionPlanner', () => {
+  test('removes an always-shown family as a no-op while still planning its input', () => {
+    const shown = state('shown');
+
+    expect(compose([shown])).toEqual({
+      status: 'converted',
+      plans: [{ status: 'converted', input: shown.input, classNames: [] }],
+    });
+  });
+
+  test('emits a base hide on the canonical visibility owner', () => {
+    const hidden = state('hidden');
+
+    expect(convertedClasses(compose([hidden])).get(hidden.input.id)).toEqual(['hidden']);
+  });
+
+  test('emits an exact responsive hide on the canonical visibility owner', () => {
+    const hidden = state('hidden', 'sm');
+
+    expect(convertedClasses(compose([hidden])).get(hidden.input.id)).toEqual([variant('sm', 'hidden')]);
+  });
+
+  test('emits base hiding and a proven responsive restoration exactly once', () => {
+    const responsive = state('shown', 'sm', 'fixture:z-responsive');
+    const base = state('hidden', undefined, 'fixture:a-base', 'fxHide');
+
+    const classes = convertedClasses(
+      compose([responsive, base], {
+        displayResolution: { status: 'resolved', utility: 'flex' },
+      }),
+    );
+
+    expect(classes.get(base.input.id)).toEqual(['hidden', variant('sm', 'flex')]);
+    expect(classes.get(responsive.input.id)).toEqual([]);
+  });
+
+  test('suppresses a same-range responsive layout display when visibility fully hides that activation', () => {
+    const hidden = state('hidden', 'sm');
+    const responsiveLayout = layout(
+      [variant('sm', 'flex'), variant('sm', 'flex-row'), variant('sm', 'box-border')],
+      'sm',
+    );
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [responsiveLayout] }));
+
+    expect(classes.get(responsiveLayout.input.id)).toEqual([variant('sm', 'flex-row'), variant('sm', 'box-border')]);
+    expect(classes.get(hidden.input.id)).toEqual([variant('sm', 'hidden')]);
+  });
+
+  test('keeps a base layout display when only a narrower responsive range is hidden', () => {
+    const hidden = state('hidden', 'sm');
+    const baseLayout = layout(['flex', 'flex-row', 'box-border']);
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [baseLayout] }));
+
+    expect(classes.get(baseLayout.input.id)).toEqual(['flex', 'flex-row', 'box-border']);
+    expect(classes.get(hidden.input.id)).toEqual([variant('sm', 'hidden')]);
+  });
+
+  test('removes only the owned display token and preserves every non-display layout utility', () => {
+    const hidden = state('hidden');
+    const baseLayout = layout(['flex', 'flex-row', 'flex-wrap', 'items-center', 'basis-auto', 'box-border']);
+
+    const classes = convertedClasses(compose([hidden], { layoutPlans: [baseLayout] }));
+
+    expect(classes.get(baseLayout.input.id)).toEqual([
+      'flex-row',
+      'flex-wrap',
+      'items-center',
+      'basis-auto',
+      'box-border',
+    ]);
+  });
+
+  test('preserves the complete visibility family when restoration is unresolved', () => {
+    const base = state('hidden');
+    const responsive = state('shown', 'sm');
+    const displayResolution: VisibleDisplayResolution = {
+      status: 'unverified',
+      reason: 'The visible display value cannot be proven from one unambiguous source.',
+    };
+
+    const result = compose([responsive, base], { displayResolution });
+
+    expect(result.status).toBe('unresolved');
+    expect(result.plans).toHaveLength(2);
+    expect(result.plans).toMatchObject([
+      { input: base.input, status: 'review', code: 'display-restoration-unverified' },
+      { input: responsive.input, status: 'review', code: 'display-restoration-unverified' },
+    ]);
+  });
+
+  test('produces canonical plans and class ownership independent of request order', () => {
+    const states = [
+      state('shown', 'gt-lg', 'fixture:show-gt-lg'),
+      state('hidden', undefined, 'fixture:hide-base', 'fxHide'),
+      state('shown', 'sm', 'fixture:show-sm'),
+    ];
+    const layouts = [
+      layout([variant('sm', 'inline-flex'), variant('sm', 'flex-row')], 'sm', 'fixture:layout-sm'),
+      layout(['flex', 'flex-col'], undefined, 'fixture:layout-base'),
+    ];
+    const displayResolution: VisibleDisplayResolution = { status: 'resolved', utility: 'inline-flex' };
+
+    const forward = new DisplayCompositionPlanner().compose({
+      visibilityPlan: { status: 'converted', states },
+      displayResolution,
+      layoutPlans: layouts,
+    });
+    const reverse = new DisplayCompositionPlanner().compose({
+      visibilityPlan: { status: 'converted', states: [...states].reverse() },
+      displayResolution,
+      layoutPlans: [...layouts].reverse(),
+    });
+
+    expect(forward).toEqual(reverse);
+    expect(forward.plans).toHaveLength(states.length + layouts.length);
+    expect(convertedClasses(forward).get('fixture:hide-base')).toEqual([
+      'hidden',
+      variant('sm', 'inline-flex'),
+      variant('gt-lg', 'inline-flex'),
+    ]);
+    expect(convertedClasses(forward).get('fixture:show-sm')).toEqual([]);
+    expect(convertedClasses(forward).get('fixture:show-gt-lg')).toEqual([]);
+  });
+
+  test('passes through an already-unresolved visibility family with every layout plan', () => {
+    const unresolvedInput = input('fxShow');
+    const visibilityPlan: VisibilityFamilyPlan = {
+      status: 'unresolved',
+      plans: [
+        {
+          status: 'review',
+          input: unresolvedInput,
+          code: 'dynamic-binding',
+          reason: 'Angular property bindings may depend on runtime state.',
+          suggestion: 'Replace the binding manually.',
+        },
+      ],
+    };
+    const baseLayout = layout(['flex', 'flex-row']);
+
+    const result = new DisplayCompositionPlanner().compose({
+      visibilityPlan,
+      displayResolution: { status: 'resolved', utility: undefined },
+      layoutPlans: [baseLayout],
+    });
+
+    expect(result).toMatchObject({ status: 'unresolved' });
+    expect(result.plans).toHaveLength(2);
+  });
+});

--- a/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
@@ -159,21 +159,27 @@ describe('DisplayCompositionPlanner', () => {
     expect(classes.get(baseLayout.input.id)).toEqual(['flex-row', 'box-border']);
   });
 
-  test('retains a wider responsive layout display when hiding covers only a narrower subrange', () => {
-    const hidden = state('hidden', 'sm');
-    const widerLayout = layout(
-      [variant('lt-md', 'flex'), variant('lt-md', 'flex-row'), variant('lt-md', 'box-border')],
-      'lt-md',
-    );
+  test.each([
+    ['nested max-only ranges', 'lt-md', 'lt-sm'],
+    ['crossing min/max ranges', 'gt-xs', 'lt-md'],
+  ])(
+    'preserves coupled layout and visibility for unsafe partial overlap between %s',
+    (_case, layoutAlias, hideAlias) => {
+      const hidden = state('hidden', hideAlias);
+      const responsiveLayout = layout(
+        [variant(layoutAlias, 'flex'), variant(layoutAlias, 'flex-row'), variant(layoutAlias, 'box-border')],
+        layoutAlias,
+      );
 
-    const classes = convertedClasses(compose([hidden], { layoutPlans: [widerLayout] }));
+      const result = compose([hidden], { layoutPlans: [responsiveLayout] });
 
-    expect(classes.get(widerLayout.input.id)).toEqual([
-      variant('lt-md', 'flex'),
-      variant('lt-md', 'flex-row'),
-      variant('lt-md', 'box-border'),
-    ]);
-  });
+      expect(result).toMatchObject({ status: 'unresolved' });
+      expect(result.plans).toEqual([
+        expect.objectContaining({ input: responsiveLayout.input, status: 'review', code: 'context-unverified' }),
+        expect.objectContaining({ input: hidden.input, status: 'review', code: 'context-unverified' }),
+      ]);
+    },
+  );
 
   test('retains a responsive layout display when a shown override interrupts inherited base hiding', () => {
     const baseHidden = state('hidden');

--- a/src/adapter/tailwind/visibility/display-composition.planner.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.ts
@@ -1,0 +1,143 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
+import type { PlannedConversion } from '../../conversion-adapter';
+import { describeTailwindDisplay, type TailwindActivation } from '../tailwind-class-conflict';
+import { VisibilityEmitter } from './visibility.emitter';
+import type { VisibilityActivation, VisibilityState } from './visibility.model';
+import type { VisibilityFamilyPlan } from './visibility-state.planner';
+import type { VisibleDisplayResolution } from './visible-display.resolver';
+
+export interface DisplayCompositionRequest {
+  readonly visibilityPlan: VisibilityFamilyPlan;
+  readonly displayResolution: VisibleDisplayResolution;
+  readonly layoutPlans: readonly PlannedConversion[];
+}
+
+export type DisplayCompositionResult =
+  | { readonly status: 'converted'; readonly plans: readonly PlannedConversion[] }
+  | { readonly status: 'unresolved'; readonly plans: readonly PlannedConversion[] };
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function sameActivation(left: TailwindActivation, right: VisibilityActivation): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === 'base' || right.kind === 'base') return true;
+  return left.range.min === right.definition.range.min && left.range.max === right.definition.range.max;
+}
+
+function isConvertedLayoutDisplay(className: string): boolean {
+  const descriptor = describeTailwindDisplay(className);
+  return (
+    descriptor !== undefined &&
+    (descriptor.utility === 'flex' || descriptor.utility === 'inline-flex') &&
+    !descriptor.important &&
+    (descriptor.activation.kind === 'media' || descriptor.token === descriptor.utility)
+  );
+}
+
+function restorationUnverified(input: LocatedFlexLayoutInput, reason: string): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'display-restoration-unverified',
+    reason,
+    suggestion: 'Provide one unambiguous visible display value or migrate this visibility family manually.',
+  };
+}
+
+export class DisplayCompositionPlanner {
+  constructor(
+    private readonly catalog = new BreakpointCatalog(),
+    private readonly emitter = new VisibilityEmitter(),
+  ) {}
+
+  compose(request: DisplayCompositionRequest): DisplayCompositionResult {
+    const layoutPlans = [...request.layoutPlans].sort((left, right) => this.compareInputs(left.input, right.input));
+    if (request.visibilityPlan.status === 'unresolved') {
+      return {
+        status: 'unresolved',
+        plans: [
+          ...layoutPlans,
+          ...[...request.visibilityPlan.plans].sort((left, right) => this.compareInputs(left.input, right.input)),
+        ],
+      };
+    }
+
+    const states = [...request.visibilityPlan.states].sort((left, right) => this.compareStates(left, right));
+    const displayResolution = request.displayResolution;
+    if (displayResolution.status === 'unverified') {
+      return {
+        status: 'unresolved',
+        plans: [...layoutPlans, ...states.map(state => restorationUnverified(state.input, displayResolution.reason))],
+      };
+    }
+
+    const composedLayouts = layoutPlans.map(plan => this.composeLayout(plan, states));
+    const visibilityClassNames = [
+      ...new Set(states.flatMap(state => this.emitter.emit(state, displayResolution.utility))),
+    ];
+    const visibilityPlans = states.map((state, index): PlannedConversion => ({
+      status: 'converted',
+      input: state.input,
+      classNames: index === 0 ? visibilityClassNames : [],
+    }));
+    const plans = [...composedLayouts, ...visibilityPlans];
+    return {
+      status: plans.every(plan => plan.status === 'converted') ? 'converted' : 'unresolved',
+      plans,
+    };
+  }
+
+  private composeLayout(plan: PlannedConversion, states: readonly VisibilityState[]): PlannedConversion {
+    if (plan.status !== 'converted' || plan.input.directive !== 'fxLayout') return plan;
+    return {
+      ...plan,
+      classNames: plan.classNames.filter(className => !this.visibilityOwnsHiddenActivation(className, states)),
+    };
+  }
+
+  private visibilityOwnsHiddenActivation(className: string, states: readonly VisibilityState[]): boolean {
+    if (!isConvertedLayoutDisplay(className)) return false;
+    const descriptor = describeTailwindDisplay(className);
+    if (!descriptor) return false;
+    const matchingStates = states.filter(state => sameActivation(descriptor.activation, state.activation));
+    return matchingStates.length > 0 && matchingStates.every(state => state.intent === 'hidden');
+  }
+
+  private compareStates(left: VisibilityState, right: VisibilityState): number {
+    if (left.activation.kind === 'base' && right.activation.kind !== 'base') return -1;
+    if (left.activation.kind !== 'base' && right.activation.kind === 'base') return 1;
+    if (left.activation.kind === 'media' && right.activation.kind === 'media') {
+      if (left.activation.definition.priority !== right.activation.definition.priority) {
+        return right.activation.definition.priority - left.activation.definition.priority;
+      }
+      const aliasOrder = compareText(left.activation.definition.alias, right.activation.definition.alias);
+      if (aliasOrder) return aliasOrder;
+    }
+    return compareText(left.input.id, right.input.id);
+  }
+
+  private compareInputs(left: LocatedFlexLayoutInput, right: LocatedFlexLayoutInput): number {
+    const leftIsBase = left.breakpoint === undefined;
+    const rightIsBase = right.breakpoint === undefined;
+    if (leftIsBase && !rightIsBase) return -1;
+    if (!leftIsBase && rightIsBase) return 1;
+
+    const leftPriority = this.breakpointPriority(left.breakpoint);
+    const rightPriority = this.breakpointPriority(right.breakpoint);
+    if (leftPriority !== rightPriority) return rightPriority - leftPriority;
+
+    const aliasOrder = compareText(left.breakpoint ?? '', right.breakpoint ?? '');
+    return aliasOrder || compareText(left.id, right.id);
+  }
+
+  private breakpointPriority(alias: string | undefined): number {
+    if (alias === undefined) return Number.POSITIVE_INFINITY;
+    const classification = this.catalog.classify(alias);
+    return classification.kind === 'verified' ? classification.definition.priority : Number.NEGATIVE_INFINITY;
+  }
+}

--- a/src/adapter/tailwind/visibility/display-composition.planner.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.ts
@@ -1,9 +1,9 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
-import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
+import { BreakpointCatalog, mediaRangesIntersect, type MediaRange } from '../../../breakpoint/breakpoint-catalog';
 import type { PlannedConversion } from '../../conversion-adapter';
 import { describeTailwindDisplay, type TailwindActivation } from '../tailwind-class-conflict';
 import { VisibilityEmitter } from './visibility.emitter';
-import type { VisibilityActivation, VisibilityState } from './visibility.model';
+import type { VisibilityState } from './visibility.model';
 import type { VisibilityFamilyPlan } from './visibility-state.planner';
 import type { VisibleDisplayResolution } from './visible-display.resolver';
 
@@ -23,10 +23,43 @@ function compareText(left: string, right: string): number {
   return 0;
 }
 
-function sameActivation(left: TailwindActivation, right: VisibilityActivation): boolean {
-  if (left.kind !== right.kind) return false;
-  if (left.kind === 'base' || right.kind === 'base') return true;
-  return left.range.min === right.definition.range.min && left.range.max === right.definition.range.max;
+interface NumericRange {
+  readonly min: number;
+  readonly max: number;
+}
+
+function mediaRange(activation: TailwindActivation): MediaRange {
+  return activation.kind === 'base' ? {} : activation.range;
+}
+
+function numericRange(range: MediaRange): NumericRange {
+  return {
+    min: range.min ?? Number.NEGATIVE_INFINITY,
+    max: range.max ?? Number.POSITIVE_INFINITY,
+  };
+}
+
+function rangesCover(target: MediaRange, ranges: readonly MediaRange[]): boolean {
+  const numericTarget = numericRange(target);
+  const clipped = ranges
+    .filter(range => mediaRangesIntersect(target, range))
+    .map(range => {
+      const numeric = numericRange(range);
+      return {
+        min: Math.max(numericTarget.min, numeric.min),
+        max: Math.min(numericTarget.max, numeric.max),
+      };
+    })
+    .sort((left, right) => left.min - right.min);
+  const first = clipped[0];
+  if (!first || first.min !== numericTarget.min) return false;
+
+  let coveredUntil = first.max;
+  for (const range of clipped.slice(1)) {
+    if (range.min > coveredUntil) return false;
+    coveredUntil = Math.max(coveredUntil, range.max);
+  }
+  return coveredUntil >= numericTarget.max;
 }
 
 function isConvertedLayoutDisplay(className: string): boolean {
@@ -104,8 +137,23 @@ export class DisplayCompositionPlanner {
     if (!isConvertedLayoutDisplay(className)) return false;
     const descriptor = describeTailwindDisplay(className);
     if (!descriptor) return false;
-    const matchingStates = states.filter(state => sameActivation(descriptor.activation, state.activation));
-    return matchingStates.length > 0 && matchingStates.every(state => state.intent === 'hidden');
+    const target = mediaRange(descriptor.activation);
+    const baseStates = states.filter(state => state.activation.kind === 'base');
+    const responsiveStates = states.filter(
+      (state): state is VisibilityState & { readonly activation: { readonly kind: 'media' } } =>
+        state.activation.kind === 'media',
+    );
+    const baseIsHidden = baseStates.length > 0 && baseStates.every(state => state.intent === 'hidden');
+    if (baseIsHidden) {
+      return !responsiveStates.some(
+        state => state.intent === 'shown' && mediaRangesIntersect(target, state.activation.definition.range),
+      );
+    }
+
+    return rangesCover(
+      target,
+      responsiveStates.filter(state => state.intent === 'hidden').map(state => state.activation.definition.range),
+    );
   }
 
   private compareStates(left: VisibilityState, right: VisibilityState): number {

--- a/src/adapter/tailwind/visibility/display-composition.planner.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.ts
@@ -82,6 +82,16 @@ function restorationUnverified(input: LocatedFlexLayoutInput, reason: string): P
   };
 }
 
+function contextUnverified(input: LocatedFlexLayoutInput): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'context-unverified',
+    reason: 'Partially overlapping responsive layout and visibility displays have unverified cascade precedence.',
+    suggestion: 'Migrate the coupled layout and visibility ranges together manually.',
+  };
+}
+
 export class DisplayCompositionPlanner {
   constructor(
     private readonly catalog = new BreakpointCatalog(),
@@ -109,6 +119,18 @@ export class DisplayCompositionPlanner {
       };
     }
 
+    if (this.hasUnsafePartialOverlap(layoutPlans, states)) {
+      return {
+        status: 'unresolved',
+        plans: [
+          ...layoutPlans.map(plan =>
+            plan.status === 'converted' && plan.input.directive === 'fxLayout' ? contextUnverified(plan.input) : plan,
+          ),
+          ...states.map(state => contextUnverified(state.input)),
+        ],
+      };
+    }
+
     const composedLayouts = layoutPlans.map(plan => this.composeLayout(plan, states));
     const visibilityClassNames = [
       ...new Set(states.flatMap(state => this.emitter.emit(state, displayResolution.utility))),
@@ -123,6 +145,30 @@ export class DisplayCompositionPlanner {
       status: plans.every(plan => plan.status === 'converted') ? 'converted' : 'unresolved',
       plans,
     };
+  }
+
+  private hasUnsafePartialOverlap(
+    layoutPlans: readonly PlannedConversion[],
+    states: readonly VisibilityState[],
+  ): boolean {
+    const baseIsHidden = states.some(state => state.activation.kind === 'base' && state.intent === 'hidden');
+    if (baseIsHidden) return false;
+
+    const hiddenRanges = states.flatMap(state =>
+      state.intent === 'hidden' && state.activation.kind === 'media' ? [state.activation.definition.range] : [],
+    );
+    if (!hiddenRanges.length) return false;
+
+    return layoutPlans.some(plan => {
+      if (plan.status !== 'converted' || plan.input.directive !== 'fxLayout') return false;
+      return plan.classNames.some(className => {
+        if (!isConvertedLayoutDisplay(className)) return false;
+        const descriptor = describeTailwindDisplay(className);
+        if (!descriptor || descriptor.activation.kind !== 'media') return false;
+        const target = descriptor.activation.range;
+        return hiddenRanges.some(range => mediaRangesIntersect(target, range)) && !rangesCover(target, hiddenRanges);
+      });
+    });
   }
 
   private composeLayout(plan: PlannedConversion, states: readonly VisibilityState[]): PlannedConversion {

--- a/src/adapter/tailwind/visibility/literal-style-display.ts
+++ b/src/adapter/tailwind/visibility/literal-style-display.ts
@@ -1,0 +1,163 @@
+const cssWhitespace = /[\t\n\f\r ]/u;
+const hexDigit = /[\da-f]/iu;
+
+function splitDeclarations(value: string): readonly string[] | undefined {
+  const declarations: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+  let parentheses = 0;
+  let brackets = 0;
+  let braces = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    const next = value[index + 1];
+    if (character === undefined) continue;
+
+    if (quote) {
+      current += character;
+      if (character === '\\') {
+        if (next === undefined) return undefined;
+        current += next;
+        index += 1;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (character === '/' && next === '*') {
+      const commentEnd = value.indexOf('*/', index + 2);
+      if (commentEnd < 0) return undefined;
+      current += ' ';
+      index = commentEnd + 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (character === '\\') {
+      if (next === undefined || next === '\n' || next === '\r' || next === '\f') return undefined;
+      current += character + next;
+      index += 1;
+      continue;
+    }
+
+    if (character === '(') parentheses += 1;
+    else if (character === ')') {
+      if (parentheses === 0) return undefined;
+      parentheses -= 1;
+    } else if (character === '[') brackets += 1;
+    else if (character === ']') {
+      if (brackets === 0) return undefined;
+      brackets -= 1;
+    } else if (character === '{') braces += 1;
+    else if (character === '}') {
+      if (braces === 0) return undefined;
+      braces -= 1;
+    }
+
+    if (character === ';' && parentheses === 0 && brackets === 0 && braces === 0) {
+      declarations.push(current);
+      current = '';
+    } else {
+      current += character;
+    }
+  }
+
+  if (quote || parentheses !== 0 || brackets !== 0 || braces !== 0) return undefined;
+  declarations.push(current);
+  return declarations;
+}
+
+function declarationColon(declaration: string): number | undefined {
+  let quote: '"' | "'" | undefined;
+  let parentheses = 0;
+  let brackets = 0;
+  let braces = 0;
+
+  for (let index = 0; index < declaration.length; index += 1) {
+    const character = declaration[index];
+    if (character === undefined) continue;
+    if (quote) {
+      if (character === '\\') index += 1;
+      else if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character === '\\') {
+      index += 1;
+      continue;
+    }
+    if (character === '(') parentheses += 1;
+    else if (character === ')') parentheses -= 1;
+    else if (character === '[') brackets += 1;
+    else if (character === ']') brackets -= 1;
+    else if (character === '{') braces += 1;
+    else if (character === '}') braces -= 1;
+    else if (character === ':' && parentheses === 0 && brackets === 0 && braces === 0) return index;
+  }
+  return undefined;
+}
+
+function decodeIdentifier(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  let decoded = '';
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const character = trimmed[index];
+    if (character === undefined) continue;
+    if (cssWhitespace.test(character)) return undefined;
+    if (character !== '\\') {
+      decoded += character;
+      continue;
+    }
+
+    const next = trimmed[index + 1];
+    if (next === undefined || next === '\n' || next === '\r' || next === '\f') return undefined;
+    let hex = '';
+    let cursor = index + 1;
+    while (hex.length < 6 && cursor < trimmed.length && hexDigit.test(trimmed[cursor] ?? '')) {
+      hex += trimmed[cursor];
+      cursor += 1;
+    }
+    if (hex) {
+      const codePoint = Number.parseInt(hex, 16);
+      decoded +=
+        codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)
+          ? '\uFFFD'
+          : String.fromCodePoint(codePoint);
+      if (cssWhitespace.test(trimmed[cursor] ?? '')) {
+        if (trimmed[cursor] === '\r' && trimmed[cursor + 1] === '\n') cursor += 1;
+        cursor += 1;
+      }
+      index = cursor - 1;
+      continue;
+    }
+
+    decoded += next;
+    index += 1;
+  }
+  return decoded;
+}
+
+export function literalStyleMayControlDisplay(value: string): boolean {
+  const declarations = splitDeclarations(value);
+  if (!declarations) return true;
+
+  for (const declaration of declarations) {
+    if (!declaration.trim()) continue;
+    const colon = declarationColon(declaration);
+    if (colon === undefined) return true;
+    const property = decodeIdentifier(declaration.slice(0, colon));
+    if (!property) return true;
+    if (property.toLowerCase() === 'display') return true;
+  }
+  return false;
+}

--- a/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
@@ -182,6 +182,21 @@ describe('VisibilityStatePlanner', () => {
     });
   });
 
+  test('classifies an empty breakpoint alias as custom and preserves convertible siblings atomically', () => {
+    const base = input('fxShow', '', { id: 'fixture:z-base' });
+    const responsive = input('fxHide.sm', '', { id: 'fixture:responsive' });
+    const custom = input('fxShow.', '', { id: 'fixture:a-custom' });
+
+    expect(plan([custom, responsive, base])).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { input: base, code: 'context-unverified' },
+        { input: responsive, code: 'context-unverified' },
+        { input: custom, code: 'custom-breakpoint' },
+      ],
+    });
+  });
+
   test('classifies a dynamic member before its unsupported breakpoint', () => {
     const dynamic = input('[fxShow.cinema]', 'visible');
     const literal = input('fxHide.sm', '');

--- a/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
@@ -1,0 +1,225 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import { VisibilityStatePlanner } from './visibility-state.planner';
+
+function input(
+  sourceName: string,
+  value: string,
+  overrides: Partial<LocatedFlexLayoutInput> = {},
+): LocatedFlexLayoutInput {
+  const normalizedName = sourceName.replace(/^\[/, '').replace(/\]$/, '');
+  const [directive = 'fxShow', breakpoint] = normalizedName.split('.', 2);
+  return {
+    id: `fixture:${sourceName}`,
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName,
+    directive: directive as 'fxShow' | 'fxHide',
+    value,
+    binding: sourceName.startsWith('[') ? 'property' : 'literal',
+    breakpoint,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+    ...overrides,
+  };
+}
+
+function plan(inputs: readonly LocatedFlexLayoutInput[]) {
+  return new VisibilityStatePlanner().plan(inputs);
+}
+
+describe('VisibilityStatePlanner', () => {
+  test('converts a literal base member to a base visibility state', () => {
+    const member = input('fxShow', 'false');
+
+    expect(plan([member])).toEqual({
+      status: 'converted',
+      states: [{ input: member, intent: 'hidden', activation: { kind: 'base' } }],
+    });
+  });
+
+  test('converts a verified responsive member with its exact breakpoint definition', () => {
+    const member = input('fxHide.sm', 'false');
+
+    expect(plan([member])).toEqual({
+      status: 'converted',
+      states: [
+        {
+          input: member,
+          intent: 'shown',
+          activation: {
+            kind: 'media',
+            definition: { alias: 'sm', range: { min: 600, max: 959.98 }, priority: 900 },
+          },
+        },
+      ],
+    });
+  });
+
+  test('converts a base state plus a different responsive override', () => {
+    const responsive = input('fxShow.md', 'false');
+    const base = input('fxShow', '');
+
+    expect(plan([responsive, base])).toEqual({
+      status: 'converted',
+      states: [
+        { input: base, intent: 'shown', activation: { kind: 'base' } },
+        {
+          input: responsive,
+          intent: 'hidden',
+          activation: {
+            kind: 'media',
+            definition: { alias: 'md', range: { min: 960, max: 1279.98 }, priority: 800 },
+          },
+        },
+      ],
+    });
+  });
+
+  test('converts different intents in disjoint responsive ranges', () => {
+    const states = plan([input('fxShow.sm', ''), input('fxShow.xs', 'false')]);
+
+    expect(states).toMatchObject({
+      status: 'converted',
+      states: [
+        { intent: 'hidden', activation: { definition: { alias: 'xs' } } },
+        { intent: 'shown', activation: { definition: { alias: 'sm' } } },
+      ],
+    });
+  });
+
+  test('converts identical intents in intersecting responsive ranges', () => {
+    const result = plan([input('fxShow.gt-xs', ''), input('fxHide.sm', 'false')]);
+
+    expect(result).toMatchObject({
+      status: 'converted',
+      states: [{ intent: 'shown' }, { intent: 'shown' }],
+    });
+  });
+
+  test('preserves every input when intersecting responsive ranges conflict', () => {
+    const members = [input('fxShow', ''), input('fxShow.sm', ''), input('fxHide.gt-xs', '')];
+
+    const result = plan(members);
+
+    expect(result).toMatchObject({ status: 'unresolved' });
+    if (result.status !== 'unresolved') throw new Error('Expected the visibility family to be unresolved.');
+    expect(result.plans).toHaveLength(members.length);
+    expect(result.plans.every(item => item.status === 'review')).toBe(true);
+    expect(
+      result.plans.every(item => item.status !== 'converted' && item.code === 'responsive-precedence-unverified'),
+    ).toBe(true);
+    expect(result.plans.map(item => item.input.id)).toEqual([
+      'fixture:fxShow',
+      'fixture:fxShow.sm',
+      'fixture:fxHide.gt-xs',
+    ]);
+  });
+
+  test('converts identical duplicate base states and orders them by input identity', () => {
+    const laterIdentity = input('fxShow', '', { id: 'fixture:z' });
+    const earlierIdentity = input('fxHide', 'false', { id: 'fixture:a' });
+
+    expect(plan([laterIdentity, earlierIdentity])).toEqual({
+      status: 'converted',
+      states: [
+        { input: earlierIdentity, intent: 'shown', activation: { kind: 'base' } },
+        { input: laterIdentity, intent: 'shown', activation: { kind: 'base' } },
+      ],
+    });
+  });
+
+  test('preserves every input when duplicate base states conflict', () => {
+    const result = plan([input('fxHide', ''), input('fxShow', '')]);
+
+    expect(result).toMatchObject({ status: 'unresolved' });
+    if (result.status !== 'unresolved') throw new Error('Expected the visibility family to be unresolved.');
+    expect(result.plans).toHaveLength(2);
+    expect(
+      result.plans.every(item => item.status !== 'converted' && item.code === 'responsive-precedence-unverified'),
+    ).toBe(true);
+  });
+
+  test('normalizes mixed fxShow and fxHide declarations before comparing their intent', () => {
+    const show = input('fxShow.lt-md', 'false');
+    const hide = input('fxHide.xs', '');
+
+    expect(plan([hide, show])).toMatchObject({
+      status: 'converted',
+      states: [
+        { input: hide, intent: 'hidden' },
+        { input: show, intent: 'hidden' },
+      ],
+    });
+  });
+
+  test('retains a dynamic diagnostic and marks otherwise-convertible family members context-unverified', () => {
+    const literal = input('fxShow', '');
+    const dynamic = input('[fxHide.sm]', 'isHidden');
+
+    expect(plan([literal, dynamic])).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { input: literal, status: 'review', code: 'context-unverified' },
+        { input: dynamic, status: 'review', code: 'dynamic-binding' },
+      ],
+    });
+  });
+
+  test('retains optional, print, and custom breakpoint diagnostics on their originating members', () => {
+    const literal = input('fxShow', '');
+    const optional = input('fxShow.handset', '');
+    const print = input('fxHide.print', '');
+    const custom = input('fxShow.cinema', '');
+
+    expect(plan([custom, print, optional, literal])).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { input: literal, code: 'context-unverified' },
+        { input: custom, code: 'custom-breakpoint' },
+        { input: optional, code: 'breakpoint-unverified' },
+        { input: print, code: 'breakpoint-unverified' },
+      ],
+    });
+  });
+
+  test('classifies a dynamic member before its unsupported breakpoint', () => {
+    const dynamic = input('[fxShow.cinema]', 'visible');
+    const literal = input('fxHide.sm', '');
+
+    expect(plan([dynamic, literal])).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { input: literal, code: 'context-unverified' },
+        { input: dynamic, code: 'dynamic-binding' },
+      ],
+    });
+  });
+
+  test('sorts base first, then descending breakpoint priority, alias, and input identity independent of source order', () => {
+    const members = [
+      input('fxShow.gt-lg', '', { id: 'fixture:gt-lg' }),
+      input('fxShow.sm', '', { id: 'fixture:sm-z' }),
+      input('fxHide', 'false', { id: 'fixture:base' }),
+      input('fxShow.xs', '', { id: 'fixture:xs' }),
+      input('fxShow.sm', '', { id: 'fixture:sm-a' }),
+      input('fxShow.lt-sm', '', { id: 'fixture:lt-sm' }),
+    ];
+
+    const expectedIds = [
+      'fixture:base',
+      'fixture:xs',
+      'fixture:lt-sm',
+      'fixture:sm-a',
+      'fixture:sm-z',
+      'fixture:gt-lg',
+    ];
+    const forward = plan(members);
+    const reverse = plan([...members].reverse());
+
+    expect(forward).toEqual(reverse);
+    expect(forward).toMatchObject({
+      status: 'converted',
+      states: expectedIds.map(id => ({ input: { id } })),
+    });
+  });
+});

--- a/src/adapter/tailwind/visibility/visibility-state.planner.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.ts
@@ -1,0 +1,168 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import {
+  BreakpointCatalog,
+  mediaRangesIntersect,
+  type BreakpointClassification,
+} from '../../../breakpoint/breakpoint-catalog';
+import type { PlannedConversion } from '../../conversion-adapter';
+import type { VisibilityState } from './visibility.model';
+import { parseVisibilityValue } from './visibility-value.parser';
+
+export type VisibilityFamilyPlan =
+  | { readonly status: 'converted'; readonly states: readonly VisibilityState[] }
+  | { readonly status: 'unresolved'; readonly plans: readonly PlannedConversion[] };
+
+type ClassifiedMember =
+  | { readonly input: LocatedFlexLayoutInput; readonly state: VisibilityState }
+  | { readonly input: LocatedFlexLayoutInput; readonly plan: PlannedConversion };
+
+type ClassifiedState = Extract<ClassifiedMember, { readonly state: VisibilityState }>;
+
+function dynamicBinding(input: LocatedFlexLayoutInput): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'dynamic-binding',
+    reason: 'Angular property bindings may depend on runtime state.',
+    suggestion: 'Replace the binding manually or make it a literal before migration.',
+  };
+}
+
+function unresolvedBreakpoint(
+  input: LocatedFlexLayoutInput,
+  classification: Exclude<BreakpointClassification, { readonly kind: 'verified' }>,
+): PlannedConversion {
+  if (classification.kind === 'custom') {
+    return {
+      status: 'review',
+      input,
+      code: 'custom-breakpoint',
+      reason: `The breakpoint alias ${classification.alias} may be registered by the project.`,
+      suggestion: 'Provide its media query or migrate this responsive input manually.',
+    };
+  }
+
+  const kind = classification.kind === 'print' ? 'print' : 'optional';
+  return {
+    status: 'review',
+    input,
+    code: 'breakpoint-unverified',
+    reason: `Exact media-query output for the ${kind} breakpoint alias ${classification.alias} is not implemented.`,
+    suggestion: 'Keep the responsive directive until exact breakpoint support is available.',
+  };
+}
+
+function contextUnverified(input: LocatedFlexLayoutInput): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'context-unverified',
+    reason: 'Another member of this visibility family is unresolved.',
+    suggestion: 'Migrate the complete visibility family together manually.',
+  };
+}
+
+function responsivePrecedenceUnverified(input: LocatedFlexLayoutInput): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'responsive-precedence-unverified',
+    reason: 'The visibility family contains conflicting base or overlapping responsive states.',
+    suggestion: 'Simplify the conflicting declarations or migrate this visibility family manually.',
+  };
+}
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+export class VisibilityStatePlanner {
+  constructor(private readonly catalog = new BreakpointCatalog()) {}
+
+  plan(inputs: readonly LocatedFlexLayoutInput[]): VisibilityFamilyPlan {
+    const members = inputs
+      .map(input => this.classify(input))
+      .sort((left, right) => this.compare(left.input, right.input));
+
+    if (!members.every((member): member is ClassifiedState => 'state' in member)) {
+      return {
+        status: 'unresolved',
+        plans: members.map(member => ('plan' in member ? member.plan : contextUnverified(member.input))),
+      };
+    }
+
+    const states = members.map(member => member.state);
+    if (this.hasConflictingStates(states)) {
+      return {
+        status: 'unresolved',
+        plans: states.map(state => responsivePrecedenceUnverified(state.input)),
+      };
+    }
+
+    return { status: 'converted', states };
+  }
+
+  private classify(input: LocatedFlexLayoutInput): ClassifiedMember {
+    if (input.binding !== 'literal') return { input, plan: dynamicBinding(input) };
+
+    if (!input.breakpoint) {
+      return {
+        input,
+        state: { input, intent: parseVisibilityValue(input), activation: { kind: 'base' } },
+      };
+    }
+
+    const classification = this.catalog.classify(input.breakpoint);
+    if (classification.kind !== 'verified') {
+      return { input, plan: unresolvedBreakpoint(input, classification) };
+    }
+
+    return {
+      input,
+      state: {
+        input,
+        intent: parseVisibilityValue(input),
+        activation: { kind: 'media', definition: classification.definition },
+      },
+    };
+  }
+
+  private hasConflictingStates(states: readonly VisibilityState[]): boolean {
+    const baseStates = states.filter(state => state.activation.kind === 'base');
+    if (baseStates.some(state => state.intent !== baseStates[0]?.intent)) return true;
+
+    const responsiveStates = states.filter(
+      (state): state is VisibilityState & { readonly activation: { readonly kind: 'media' } } =>
+        state.activation.kind === 'media',
+    );
+    return responsiveStates.some((left, leftIndex) =>
+      responsiveStates
+        .slice(leftIndex + 1)
+        .some(
+          right =>
+            left.intent !== right.intent &&
+            mediaRangesIntersect(left.activation.definition.range, right.activation.definition.range),
+        ),
+    );
+  }
+
+  private compare(left: LocatedFlexLayoutInput, right: LocatedFlexLayoutInput): number {
+    if (!left.breakpoint && right.breakpoint) return -1;
+    if (left.breakpoint && !right.breakpoint) return 1;
+
+    const leftPriority = this.breakpointPriority(left.breakpoint);
+    const rightPriority = this.breakpointPriority(right.breakpoint);
+    if (leftPriority !== rightPriority) return rightPriority - leftPriority;
+
+    const aliasOrder = compareText(left.breakpoint ?? '', right.breakpoint ?? '');
+    return aliasOrder || compareText(left.id, right.id);
+  }
+
+  private breakpointPriority(alias: string | undefined): number {
+    if (!alias) return Number.POSITIVE_INFINITY;
+    const classification = this.catalog.classify(alias);
+    return classification.kind === 'verified' ? classification.definition.priority : Number.NEGATIVE_INFINITY;
+  }
+}

--- a/src/adapter/tailwind/visibility/visibility-state.planner.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.ts
@@ -107,7 +107,7 @@ export class VisibilityStatePlanner {
   private classify(input: LocatedFlexLayoutInput): ClassifiedMember {
     if (input.binding !== 'literal') return { input, plan: dynamicBinding(input) };
 
-    if (!input.breakpoint) {
+    if (input.breakpoint === undefined) {
       return {
         input,
         state: { input, intent: parseVisibilityValue(input), activation: { kind: 'base' } },
@@ -149,8 +149,10 @@ export class VisibilityStatePlanner {
   }
 
   private compare(left: LocatedFlexLayoutInput, right: LocatedFlexLayoutInput): number {
-    if (!left.breakpoint && right.breakpoint) return -1;
-    if (left.breakpoint && !right.breakpoint) return 1;
+    const leftIsBase = left.breakpoint === undefined;
+    const rightIsBase = right.breakpoint === undefined;
+    if (leftIsBase && !rightIsBase) return -1;
+    if (!leftIsBase && rightIsBase) return 1;
 
     const leftPriority = this.breakpointPriority(left.breakpoint);
     const rightPriority = this.breakpointPriority(right.breakpoint);
@@ -161,7 +163,7 @@ export class VisibilityStatePlanner {
   }
 
   private breakpointPriority(alias: string | undefined): number {
-    if (!alias) return Number.POSITIVE_INFINITY;
+    if (alias === undefined) return Number.POSITIVE_INFINITY;
     const classification = this.catalog.classify(alias);
     return classification.kind === 'verified' ? classification.definition.priority : Number.NEGATIVE_INFINITY;
   }

--- a/src/adapter/tailwind/visibility/visibility-value.parser.spec.ts
+++ b/src/adapter/tailwind/visibility/visibility-value.parser.spec.ts
@@ -1,0 +1,44 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import { parseVisibilityValue } from './visibility-value.parser';
+
+function input(overrides: Partial<LocatedFlexLayoutInput> = {}): LocatedFlexLayoutInput {
+  return {
+    id: 'fixture:0',
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName: 'fxShow',
+    directive: 'fxShow',
+    value: '',
+    binding: 'literal',
+    breakpoint: undefined,
+    source: { start: 0, end: 8 },
+    nameSource: { start: 0, end: 6 },
+    ...overrides,
+  };
+}
+
+describe('parseVisibilityValue', () => {
+  test.each([
+    ['fxShow', '', 'shown'],
+    ['fxShow', 'false', 'hidden'],
+    ['fxShow', '0', 'shown'],
+    ['fxShow', 'FALSE', 'shown'],
+    ['fxHide', '', 'hidden'],
+    ['fxHide', 'false', 'shown'],
+    ['fxHide', '0', 'hidden'],
+  ] as const)('%s=%j normalizes to %s', (directive, value, expected) => {
+    expect(parseVisibilityValue(input({ directive, value }))).toBe(expected);
+  });
+
+  test('rejects another directive because callers must classify visibility inputs first', () => {
+    expect(() => parseVisibilityValue(input({ directive: 'fxLayout', sourceName: 'fxLayout', value: 'row' }))).toThrow(
+      'Visibility value parser requires a literal fxShow or fxHide input.',
+    );
+  });
+
+  test('rejects property bindings because callers must classify bindings first', () => {
+    expect(() =>
+      parseVisibilityValue(input({ binding: 'property', sourceName: '[fxShow]', value: 'isVisible' })),
+    ).toThrow('Visibility value parser requires a literal fxShow or fxHide input.');
+  });
+});

--- a/src/adapter/tailwind/visibility/visibility-value.parser.ts
+++ b/src/adapter/tailwind/visibility/visibility-value.parser.ts
@@ -1,0 +1,13 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import type { VisibilityIntent } from './visibility.model';
+
+const invariantMessage = 'Visibility value parser requires a literal fxShow or fxHide input.';
+
+export function parseVisibilityValue(input: LocatedFlexLayoutInput): VisibilityIntent {
+  if (input.binding !== 'literal' || (input.directive !== 'fxShow' && input.directive !== 'fxHide')) {
+    throw new Error(invariantMessage);
+  }
+
+  const shown = input.value !== 'false';
+  return input.directive === 'fxHide' ? (shown ? 'hidden' : 'shown') : shown ? 'shown' : 'hidden';
+}

--- a/src/adapter/tailwind/visibility/visibility.emitter.spec.ts
+++ b/src/adapter/tailwind/visibility/visibility.emitter.spec.ts
@@ -1,0 +1,50 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
+import type { VisibilityIntent, VisibilityState } from './visibility.model';
+import { VisibilityEmitter } from './visibility.emitter';
+
+function input(breakpoint?: string): LocatedFlexLayoutInput {
+  const sourceName = `fxShow${breakpoint === undefined ? '' : `.${breakpoint}`}`;
+  return {
+    id: `fixture:${sourceName}`,
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName,
+    directive: 'fxShow',
+    value: '',
+    binding: 'literal',
+    breakpoint,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+  };
+}
+
+function state(intent: VisibilityIntent, breakpoint?: string): VisibilityState {
+  const member = input(breakpoint);
+  if (breakpoint === undefined) return { input: member, intent, activation: { kind: 'base' } };
+  const classification = new BreakpointCatalog().classify(breakpoint);
+  if (classification.kind !== 'verified') throw new Error(`Expected ${breakpoint} to be verified.`);
+  return { input: member, intent, activation: { kind: 'media', definition: classification.definition } };
+}
+
+describe('VisibilityEmitter', () => {
+  test('emits hidden for a base hidden state', () => {
+    expect(new VisibilityEmitter().emit(state('hidden'), undefined)).toEqual(['hidden']);
+  });
+
+  test('decorates hidden with the exact responsive activation', () => {
+    expect(new VisibilityEmitter().emit(state('hidden', 'sm'), undefined)).toEqual([
+      '[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden',
+    ]);
+  });
+
+  test('decorates a proven restoration utility for a responsive shown state', () => {
+    expect(new VisibilityEmitter().emit(state('shown', 'gt-xs'), 'inline-flex')).toEqual([
+      '[@media_screen_and_(min-width:_600px)]:inline-flex',
+    ]);
+  });
+
+  test('emits no restoration token when no restoration utility is required', () => {
+    expect(new VisibilityEmitter().emit(state('shown', 'lt-sm'), undefined)).toEqual([]);
+  });
+});

--- a/src/adapter/tailwind/visibility/visibility.emitter.ts
+++ b/src/adapter/tailwind/visibility/visibility.emitter.ts
@@ -1,0 +1,13 @@
+import { ResponsiveVariantEmitter } from '../responsive-variant.emitter';
+import type { VisibilityState } from './visibility.model';
+
+export class VisibilityEmitter {
+  constructor(private readonly responsiveEmitter = new ResponsiveVariantEmitter()) {}
+
+  emit(state: VisibilityState, restorationUtility: string | undefined): readonly string[] {
+    const utility = state.intent === 'hidden' ? 'hidden' : restorationUtility;
+    if (utility === undefined) return [];
+    if (state.activation.kind === 'base') return [utility];
+    return [this.responsiveEmitter.emit(state.activation.definition, utility)];
+  }
+}

--- a/src/adapter/tailwind/visibility/visibility.model.ts
+++ b/src/adapter/tailwind/visibility/visibility.model.ts
@@ -1,0 +1,13 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import type { BreakpointDefinition } from '../../../breakpoint/breakpoint-catalog';
+
+export type VisibilityIntent = 'shown' | 'hidden';
+
+export type VisibilityActivation =
+  { readonly kind: 'base' } | { readonly kind: 'media'; readonly definition: BreakpointDefinition };
+
+export interface VisibilityState {
+  readonly input: LocatedFlexLayoutInput;
+  readonly intent: VisibilityIntent;
+  readonly activation: VisibilityActivation;
+}

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -1,6 +1,6 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
 import type { PlannedConversion } from '../../conversion-adapter';
-import type { TemplateAttribute } from '../../../template/template.model';
+import { AngularTemplateParser } from '../../../template/angular-template.parser';
 import type { VisibilityActivation, VisibilityIntent, VisibilityState } from './visibility.model';
 import { VisibleDisplayResolver, type VisibleDisplayRequest } from './visible-display.resolver';
 
@@ -43,14 +43,12 @@ function layout(classNames: readonly string[], breakpoint?: string): PlannedConv
   return { status: 'converted', input: input('fxLayout', breakpoint), classNames };
 }
 
-function attribute(name: string, value: string, binding: TemplateAttribute['binding'] = 'literal'): TemplateAttribute {
-  return {
-    name,
-    value,
-    binding,
-    source: { start: 0, end: 1 },
-    nameSource: { start: 0, end: 1 },
-  };
+function parsedAttributes(source: string) {
+  const result = new AngularTemplateParser().parse(source, 'fixture.html');
+  if (result.status !== 'parsed') throw new Error('Expected the attribute fixture to parse.');
+  const element = result.elements[0];
+  if (!element) throw new Error('Expected the attribute fixture to contain one element.');
+  return element.attributes;
 }
 
 function request(overrides: Partial<VisibleDisplayRequest> = {}): VisibleDisplayRequest {
@@ -187,30 +185,40 @@ describe('VisibleDisplayResolver', () => {
     ).toMatchObject({ status: 'unverified' });
   });
 
-  test('blocks a literal inline display declaration even for an otherwise safe no-op', () => {
-    expect(
-      resolve({ states: [state('shown')], attributes: [attribute('style', 'color: red; display: block')] }),
-    ).toMatchObject({ status: 'unverified' });
-  });
+  test.each(['<div style="color: red; display: block"></div>', '<div STYLE="display:block"></div>'])(
+    'blocks a parser-produced literal inline display declaration in %s',
+    source => {
+      expect(resolve({ states: [state('shown')], attributes: parsedAttributes(source) })).toMatchObject({
+        status: 'unverified',
+      });
+    },
+  );
 
   test.each([
-    ['style', 'styles'],
-    ['ngStyle', 'styles'],
-    ['style.display', 'display'],
-  ])('blocks the bound display-controlling attribute [%s]', (name, value) => {
-    expect(resolve({ existingClassNames: ['block'], attributes: [attribute(name, value, 'property')] })).toMatchObject({
+    '<div [style]="styles"></div>',
+    '<div [ngStyle]="styles"></div>',
+    '<div [style.display]="display"></div>',
+    '<div [style.display.important]="display"></div>',
+  ])('blocks the parser-produced bound display-controlling attribute in %s', source => {
+    expect(resolve({ existingClassNames: ['block'], attributes: parsedAttributes(source) })).toMatchObject({
       status: 'unverified',
     });
   });
 
-  test.each(['class', 'ngClass', 'class.hidden'])('blocks bound classes when hiding generates a class: [%s]', name => {
-    expect(
-      resolve({ states: [mediaState('hidden', 'sm')], attributes: [attribute(name, 'classes', 'property')] }),
-    ).toMatchObject({ status: 'unverified' });
+  test.each([
+    '<div [class]="classes"></div>',
+    '<div [ngClass]="classes"></div>',
+    '<div [class.hidden]="isHidden"></div>',
+  ])('blocks parser-produced bound classes when hiding generates a class: %s', source => {
+    expect(resolve({ states: [mediaState('hidden', 'sm')], attributes: parsedAttributes(source) })).toMatchObject({
+      status: 'unverified',
+    });
   });
 
   test('allows bound classes when an always-shown family is a safe no-op', () => {
-    expect(resolve({ states: [state('shown')], attributes: [attribute('class', 'classes', 'property')] })).toEqual({
+    expect(
+      resolve({ states: [state('shown')], attributes: parsedAttributes('<div [class]="classes"></div>') }),
+    ).toEqual({
       status: 'resolved',
       utility: undefined,
     });
@@ -221,7 +229,7 @@ describe('VisibleDisplayResolver', () => {
       resolve({
         states: [state('shown')],
         existingClassNames: ['hidden'],
-        attributes: [attribute('class', 'classes', 'property')],
+        attributes: parsedAttributes('<div [class]="classes"></div>'),
       }),
     ).toEqual({
       status: 'unverified',

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -199,8 +199,10 @@ describe('VisibleDisplayResolver', () => {
     '<div [ngStyle]="styles"></div>',
     '<div [style.display]="display"></div>',
     '<div [style.display.important]="display"></div>',
+    '<div [attr.style]="styles"></div>',
     '<div bind-style="styles"></div>',
     '<div bind-style.display="display"></div>',
+    '<div bind-attr.style="styles"></div>',
   ])('blocks the parser-produced bound display-controlling attribute in %s', source => {
     expect(resolve({ existingClassNames: ['block'], attributes: parsedAttributes(source) })).toMatchObject({
       status: 'unverified',
@@ -211,9 +213,11 @@ describe('VisibleDisplayResolver', () => {
     '<div [class]="classes"></div>',
     '<div [ngClass]="classes"></div>',
     '<div [class.hidden]="isHidden"></div>',
+    '<div [attr.class]="classes"></div>',
     '<div bind-class="classes"></div>',
     '<div bind-ngClass="classes"></div>',
     '<div bind-class.hidden="isHidden"></div>',
+    '<div bind-attr.class="classes"></div>',
   ])('blocks parser-produced bound classes when hiding generates a class: %s', source => {
     expect(resolve({ states: [mediaState('hidden', 'sm')], attributes: parsedAttributes(source) })).toMatchObject({
       status: 'unverified',

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -1,0 +1,231 @@
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
+import type { PlannedConversion } from '../../conversion-adapter';
+import type { TemplateAttribute } from '../../../template/template.model';
+import type { VisibilityActivation, VisibilityIntent, VisibilityState } from './visibility.model';
+import { VisibleDisplayResolver, type VisibleDisplayRequest } from './visible-display.resolver';
+
+const sm = (utility: string) => `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:${utility}`;
+const xs = (utility: string) => `[@media_screen_and_(min-width:_0px)_and_(max-width:_599.98px)]:${utility}`;
+const gtXs = (utility: string) => `[@media_screen_and_(min-width:_600px)]:${utility}`;
+
+function input(directive: LocatedFlexLayoutInput['directive'], breakpoint?: string): LocatedFlexLayoutInput {
+  const sourceName = `${directive}${breakpoint === undefined ? '' : `.${breakpoint}`}`;
+  return {
+    id: `fixture:${sourceName}`,
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName,
+    directive,
+    value: directive === 'fxLayout' ? 'row' : '',
+    binding: 'literal',
+    breakpoint,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+  };
+}
+
+function state(intent: VisibilityIntent, activation: VisibilityActivation = { kind: 'base' }): VisibilityState {
+  const breakpoint = activation.kind === 'media' ? activation.definition.alias : undefined;
+  return { input: input('fxShow', breakpoint), intent, activation };
+}
+
+function mediaState(intent: VisibilityIntent, alias: 'xs' | 'sm'): VisibilityState {
+  return state(intent, {
+    kind: 'media',
+    definition:
+      alias === 'xs'
+        ? { alias: 'xs', range: { min: 0, max: 599.98 }, priority: 1000 }
+        : { alias: 'sm', range: { min: 600, max: 959.98 }, priority: 900 },
+  });
+}
+
+function layout(classNames: readonly string[], breakpoint?: string): PlannedConversion {
+  return { status: 'converted', input: input('fxLayout', breakpoint), classNames };
+}
+
+function attribute(name: string, value: string, binding: TemplateAttribute['binding'] = 'literal'): TemplateAttribute {
+  return {
+    name,
+    value,
+    binding,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+  };
+}
+
+function request(overrides: Partial<VisibleDisplayRequest> = {}): VisibleDisplayRequest {
+  return {
+    states: [state('hidden'), mediaState('shown', 'sm')],
+    layoutPlans: [],
+    existingClassNames: [],
+    attributes: [],
+    ...overrides,
+  };
+}
+
+const resolve = (overrides: Partial<VisibleDisplayRequest> = {}) =>
+  new VisibleDisplayResolver().resolve(request(overrides));
+
+describe('VisibleDisplayResolver', () => {
+  test('restores flex from a converted base layout', () => {
+    expect(resolve({ layoutPlans: [layout(['flex', 'flex-row', 'box-border'])] })).toEqual({
+      status: 'resolved',
+      utility: 'flex',
+    });
+  });
+
+  test('restores inline-flex from a converted layout in the shown activation range', () => {
+    expect(resolve({ layoutPlans: [layout([sm('inline-flex'), sm('flex-row')], 'sm')] })).toEqual({
+      status: 'resolved',
+      utility: 'inline-flex',
+    });
+  });
+
+  test('does not guess from a converted layout in another activation range', () => {
+    expect(resolve({ layoutPlans: [layout([xs('flex'), xs('flex-row')], 'xs')] })).toMatchObject({
+      status: 'unverified',
+    });
+  });
+
+  test('does not fall back to a base layout when another layout range overlaps the shown activation', () => {
+    expect(
+      resolve({
+        layoutPlans: [layout(['flex']), layout([gtXs('inline-flex')], 'gt-xs')],
+      }),
+    ).toMatchObject({ status: 'unverified' });
+  });
+
+  test('does not treat an ordinary-variant layout display as an applicable base value', () => {
+    expect(resolve({ layoutPlans: [layout(['hover:flex'])] })).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each([
+    'inline',
+    'block',
+    'inline-block',
+    'flow-root',
+    'flex',
+    'inline-flex',
+    'grid',
+    'inline-grid',
+    'contents',
+    'table',
+    'inline-table',
+    'table-caption',
+    'table-cell',
+    'table-column',
+    'table-column-group',
+    'table-footer-group',
+    'table-header-group',
+    'table-row-group',
+    'table-row',
+    'list-item',
+  ])('restores the one plain base display utility %s', utility => {
+    expect(resolve({ existingClassNames: [utility, 'text-sm'] })).toEqual({
+      status: 'resolved',
+      utility,
+    });
+  });
+
+  test.each([{ states: [state('shown')] }, { states: [state('hidden')] }, { states: [mediaState('hidden', 'sm')] }])(
+    'does not emit a restoration utility when no hidden-to-shown override exists',
+    ({ states }) => {
+      expect(resolve({ states })).toEqual({ status: 'resolved', utility: undefined });
+    },
+  );
+
+  test('leaves an unknown restoration unresolved instead of guessing a default display', () => {
+    expect(resolve()).toMatchObject({ status: 'unverified' });
+  });
+
+  test('accepts an existing hidden utility only when every effective state is hidden', () => {
+    expect(resolve({ states: [state('hidden')], existingClassNames: ['hidden'] })).toEqual({
+      status: 'resolved',
+      utility: undefined,
+    });
+  });
+
+  test.each([
+    { states: [state('shown')] },
+    { states: [mediaState('hidden', 'sm')] },
+    { states: [state('hidden'), mediaState('shown', 'sm')] },
+  ])('rejects hidden when the element is effectively shown in any range', ({ states }) => {
+    expect(resolve({ states, existingClassNames: ['hidden'] })).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each([
+    ['block', 'flex'],
+    ['block', sm('grid')],
+  ])('rejects multiple or activation-modified display utilities: %s %s', (...existingClassNames) => {
+    expect(resolve({ existingClassNames })).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each(['hover:block', 'sm:grid'])('rejects the variant-prefixed display utility %s', utility => {
+    expect(resolve({ existingClassNames: [utility] })).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each(['!block', 'inline-flex!'])('rejects the important display utility %s', utility => {
+    expect(resolve({ existingClassNames: [utility] })).toMatchObject({ status: 'unverified' });
+  });
+
+  test('rejects an arbitrary display utility as an unverified restoration value', () => {
+    expect(resolve({ existingClassNames: ['[display:block]'] })).toMatchObject({ status: 'unverified' });
+  });
+
+  test('rejects ambiguous applicable layout display values', () => {
+    expect(resolve({ layoutPlans: [layout(['flex']), layout(['inline-flex'])] })).toMatchObject({
+      status: 'unverified',
+    });
+  });
+
+  test('does not fall back to a static class when applicable layout display values are ambiguous', () => {
+    expect(
+      resolve({
+        layoutPlans: [layout([sm('flex')], 'sm'), layout([sm('inline-flex')], 'sm')],
+        existingClassNames: ['block'],
+      }),
+    ).toMatchObject({ status: 'unverified' });
+  });
+
+  test('blocks a literal inline display declaration even for an otherwise safe no-op', () => {
+    expect(
+      resolve({ states: [state('shown')], attributes: [attribute('style', 'color: red; display: block')] }),
+    ).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each([
+    ['style', 'styles'],
+    ['ngStyle', 'styles'],
+    ['style.display', 'display'],
+  ])('blocks the bound display-controlling attribute [%s]', (name, value) => {
+    expect(resolve({ existingClassNames: ['block'], attributes: [attribute(name, value, 'property')] })).toMatchObject({
+      status: 'unverified',
+    });
+  });
+
+  test.each(['class', 'ngClass', 'class.hidden'])('blocks bound classes when hiding generates a class: [%s]', name => {
+    expect(
+      resolve({ states: [mediaState('hidden', 'sm')], attributes: [attribute(name, 'classes', 'property')] }),
+    ).toMatchObject({ status: 'unverified' });
+  });
+
+  test('allows bound classes when an always-shown family is a safe no-op', () => {
+    expect(resolve({ states: [state('shown')], attributes: [attribute('class', 'classes', 'property')] })).toEqual({
+      status: 'resolved',
+      utility: undefined,
+    });
+  });
+
+  test('blocks a bound class when overriding an existing hidden utility requires restoration output', () => {
+    expect(
+      resolve({
+        states: [state('shown')],
+        existingClassNames: ['hidden'],
+        attributes: [attribute('class', 'classes', 'property')],
+      }),
+    ).toEqual({
+      status: 'unverified',
+      reason: 'Generated visibility classes cannot be merged safely with a bound class value.',
+    });
+  });
+});

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -195,6 +195,31 @@ describe('VisibleDisplayResolver', () => {
   );
 
   test.each([
+    '<div style="/* leading */ display: block"></div>',
+    '<div style="color: red; /* before */ display/**/: block"></div>',
+    '<div style="d\\69 splay: block"></div>',
+  ])('blocks CSS-valid display declarations that simple declaration regexes miss in %s', source => {
+    expect(resolve({ states: [state('shown')], attributes: parsedAttributes(source) })).toMatchObject({
+      status: 'unverified',
+    });
+  });
+
+  test('allows a well-formed literal style declaration list proven not to control display', () => {
+    expect(
+      resolve({
+        states: [state('shown')],
+        attributes: parsedAttributes('<div style="color: red; opacity: 0.5"></div>'),
+      }),
+    ).toEqual({ status: 'resolved', utility: undefined });
+  });
+
+  test('preserves an ambiguous literal style declaration list that is not proven display-free', () => {
+    expect(
+      resolve({ states: [state('shown')], attributes: parsedAttributes('<div style="color: red; broken"></div>') }),
+    ).toMatchObject({ status: 'unverified' });
+  });
+
+  test.each([
     '<div [style]="styles"></div>',
     '<div [ngStyle]="styles"></div>',
     '<div [style.display]="display"></div>',

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -199,6 +199,8 @@ describe('VisibleDisplayResolver', () => {
     '<div [ngStyle]="styles"></div>',
     '<div [style.display]="display"></div>',
     '<div [style.display.important]="display"></div>',
+    '<div bind-style="styles"></div>',
+    '<div bind-style.display="display"></div>',
   ])('blocks the parser-produced bound display-controlling attribute in %s', source => {
     expect(resolve({ existingClassNames: ['block'], attributes: parsedAttributes(source) })).toMatchObject({
       status: 'unverified',
@@ -209,6 +211,9 @@ describe('VisibleDisplayResolver', () => {
     '<div [class]="classes"></div>',
     '<div [ngClass]="classes"></div>',
     '<div [class.hidden]="isHidden"></div>',
+    '<div bind-class="classes"></div>',
+    '<div bind-ngClass="classes"></div>',
+    '<div bind-class.hidden="isHidden"></div>',
   ])('blocks parser-produced bound classes when hiding generates a class: %s', source => {
     expect(resolve({ states: [mediaState('hidden', 'sm')], attributes: parsedAttributes(source) })).toMatchObject({
       status: 'unverified',

--- a/src/adapter/tailwind/visibility/visible-display.resolver.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.ts
@@ -1,4 +1,5 @@
 import type { PlannedConversion } from '../../conversion-adapter';
+import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
 import { mediaRangesIntersect } from '../../../breakpoint/breakpoint-catalog';
 import type { TemplateAttribute } from '../../../template/template.model';
 import { templateAttributeKeys } from '../../../template/template-attribute';
@@ -8,6 +9,7 @@ import {
   type TailwindDisplayUtility,
 } from '../tailwind-class-conflict';
 import type { VisibilityActivation, VisibilityState } from './visibility.model';
+import { literalStyleMayControlDisplay } from './literal-style-display';
 
 export type VisibleDisplayResolution =
   | { readonly status: 'resolved'; readonly utility?: string }
@@ -18,6 +20,7 @@ export interface VisibleDisplayRequest {
   readonly layoutPlans: readonly PlannedConversion[];
   readonly existingClassNames: readonly string[];
   readonly attributes: readonly TemplateAttribute[];
+  readonly responsiveStyleInputs?: readonly LocatedFlexLayoutInput[];
 }
 
 const restorationUtilities = new Set([
@@ -50,7 +53,7 @@ const unverifiedDisplayReason = 'The visible display value cannot be proven from
 function controlsDisplay(attribute: TemplateAttribute): boolean {
   const keys = templateAttributeKeys(attribute);
   if (attribute.binding === 'literal') {
-    return keys.has('style') && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
+    return keys.has('style') && literalStyleMayControlDisplay(attribute.value);
   }
 
   return [...keys].some(
@@ -61,7 +64,7 @@ function controlsDisplay(attribute: TemplateAttribute): boolean {
 function controlsClasses(attribute: TemplateAttribute): boolean {
   if (attribute.binding !== 'property') return false;
   return [...templateAttributeKeys(attribute)].some(
-    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.') || key.startsWith('ngclass.'),
   );
 }
 
@@ -121,7 +124,7 @@ function existingRestorationUtility(descriptors: readonly TailwindDisplayUtility
 
 export class VisibleDisplayResolver {
   resolve(request: VisibleDisplayRequest): VisibleDisplayResolution {
-    if (request.attributes.some(controlsDisplay)) {
+    if (request.responsiveStyleInputs?.length || request.attributes.some(controlsDisplay)) {
       return { status: 'unverified', reason: unverifiedStyleReason };
     }
 

--- a/src/adapter/tailwind/visibility/visible-display.resolver.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.ts
@@ -1,6 +1,7 @@
 import type { PlannedConversion } from '../../conversion-adapter';
 import { mediaRangesIntersect } from '../../../breakpoint/breakpoint-catalog';
 import type { TemplateAttribute } from '../../../template/template.model';
+import { templateAttributeKeys } from '../../../template/template-attribute';
 import {
   describeTailwindDisplay,
   type TailwindActivation,
@@ -46,26 +47,22 @@ const unverifiedStyleReason = 'A literal or bound style may control the element 
 const unverifiedClassReason = 'Generated visibility classes cannot be merged safely with a bound class value.';
 const unverifiedDisplayReason = 'The visible display value cannot be proven from one unambiguous source.';
 
-function attributeKey(attribute: TemplateAttribute): string {
-  const rawName = attribute.rawName.toLowerCase();
-  if (attribute.binding !== 'property') return rawName;
-  if (rawName.startsWith('[') && rawName.endsWith(']')) return rawName.slice(1, -1);
-  return rawName.startsWith('bind-') ? rawName.slice('bind-'.length) : rawName;
-}
-
 function controlsDisplay(attribute: TemplateAttribute): boolean {
-  const key = attributeKey(attribute);
+  const keys = templateAttributeKeys(attribute);
   if (attribute.binding === 'literal') {
-    return key === 'style' && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
+    return keys.has('style') && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
   }
 
-  return key === 'style' || key === 'ngstyle' || key === 'style.display' || key.startsWith('style.display.');
+  return [...keys].some(
+    key => key === 'style' || key === 'ngstyle' || key === 'style.display' || key.startsWith('style.display.'),
+  );
 }
 
 function controlsClasses(attribute: TemplateAttribute): boolean {
   if (attribute.binding !== 'property') return false;
-  const key = attributeKey(attribute);
-  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
+  return [...templateAttributeKeys(attribute)].some(
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+  );
 }
 
 function sameActivation(left: TailwindActivation, right: VisibilityActivation): boolean {

--- a/src/adapter/tailwind/visibility/visible-display.resolver.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.ts
@@ -46,24 +46,26 @@ const unverifiedStyleReason = 'A literal or bound style may control the element 
 const unverifiedClassReason = 'Generated visibility classes cannot be merged safely with a bound class value.';
 const unverifiedDisplayReason = 'The visible display value cannot be proven from one unambiguous source.';
 
+function attributeKey(attribute: TemplateAttribute): string {
+  const rawName = attribute.rawName.toLowerCase();
+  return attribute.binding === 'property' && rawName.startsWith('[') && rawName.endsWith(']')
+    ? rawName.slice(1, -1)
+    : rawName;
+}
+
 function controlsDisplay(attribute: TemplateAttribute): boolean {
+  const key = attributeKey(attribute);
   if (attribute.binding === 'literal') {
-    return attribute.name === 'style' && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
+    return key === 'style' && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
   }
 
-  return (
-    attribute.name === 'style' ||
-    attribute.name === 'ngStyle' ||
-    attribute.name === 'style.display' ||
-    attribute.name.startsWith('style.display.')
-  );
+  return key === 'style' || key === 'ngstyle' || key === 'style.display' || key.startsWith('style.display.');
 }
 
 function controlsClasses(attribute: TemplateAttribute): boolean {
-  return (
-    attribute.binding === 'property' &&
-    (attribute.name === 'class' || attribute.name === 'ngClass' || attribute.name.startsWith('class.'))
-  );
+  if (attribute.binding !== 'property') return false;
+  const key = attributeKey(attribute);
+  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
 }
 
 function sameActivation(left: TailwindActivation, right: VisibilityActivation): boolean {

--- a/src/adapter/tailwind/visibility/visible-display.resolver.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.ts
@@ -48,9 +48,9 @@ const unverifiedDisplayReason = 'The visible display value cannot be proven from
 
 function attributeKey(attribute: TemplateAttribute): string {
   const rawName = attribute.rawName.toLowerCase();
-  return attribute.binding === 'property' && rawName.startsWith('[') && rawName.endsWith(']')
-    ? rawName.slice(1, -1)
-    : rawName;
+  if (attribute.binding !== 'property') return rawName;
+  if (rawName.startsWith('[') && rawName.endsWith(']')) return rawName.slice(1, -1);
+  return rawName.startsWith('bind-') ? rawName.slice('bind-'.length) : rawName;
 }
 
 function controlsDisplay(attribute: TemplateAttribute): boolean {

--- a/src/adapter/tailwind/visibility/visible-display.resolver.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.ts
@@ -1,0 +1,167 @@
+import type { PlannedConversion } from '../../conversion-adapter';
+import { mediaRangesIntersect } from '../../../breakpoint/breakpoint-catalog';
+import type { TemplateAttribute } from '../../../template/template.model';
+import {
+  describeTailwindDisplay,
+  type TailwindActivation,
+  type TailwindDisplayUtility,
+} from '../tailwind-class-conflict';
+import type { VisibilityActivation, VisibilityState } from './visibility.model';
+
+export type VisibleDisplayResolution =
+  | { readonly status: 'resolved'; readonly utility?: string }
+  | { readonly status: 'unverified'; readonly reason: string };
+
+export interface VisibleDisplayRequest {
+  readonly states: readonly VisibilityState[];
+  readonly layoutPlans: readonly PlannedConversion[];
+  readonly existingClassNames: readonly string[];
+  readonly attributes: readonly TemplateAttribute[];
+}
+
+const restorationUtilities = new Set([
+  'inline',
+  'block',
+  'inline-block',
+  'flow-root',
+  'flex',
+  'inline-flex',
+  'grid',
+  'inline-grid',
+  'contents',
+  'table',
+  'inline-table',
+  'table-caption',
+  'table-cell',
+  'table-column',
+  'table-column-group',
+  'table-footer-group',
+  'table-header-group',
+  'table-row-group',
+  'table-row',
+  'list-item',
+]);
+
+const unverifiedStyleReason = 'A literal or bound style may control the element display value.';
+const unverifiedClassReason = 'Generated visibility classes cannot be merged safely with a bound class value.';
+const unverifiedDisplayReason = 'The visible display value cannot be proven from one unambiguous source.';
+
+function controlsDisplay(attribute: TemplateAttribute): boolean {
+  if (attribute.binding === 'literal') {
+    return attribute.name === 'style' && /(?:^|;)\s*display\s*:/iu.test(attribute.value);
+  }
+
+  return (
+    attribute.name === 'style' ||
+    attribute.name === 'ngStyle' ||
+    attribute.name === 'style.display' ||
+    attribute.name.startsWith('style.display.')
+  );
+}
+
+function controlsClasses(attribute: TemplateAttribute): boolean {
+  return (
+    attribute.binding === 'property' &&
+    (attribute.name === 'class' || attribute.name === 'ngClass' || attribute.name.startsWith('class.'))
+  );
+}
+
+function sameActivation(left: TailwindActivation, right: VisibilityActivation): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === 'base' || right.kind === 'base') return true;
+  return left.range.min === right.definition.range.min && left.range.max === right.definition.range.max;
+}
+
+function isPlainBase(descriptor: TailwindDisplayUtility): boolean {
+  return descriptor.activation.kind === 'base' && !descriptor.important && descriptor.token === descriptor.utility;
+}
+
+function layoutDisplays(plans: readonly PlannedConversion[]): readonly TailwindDisplayUtility[] {
+  return plans
+    .filter(
+      (plan): plan is Extract<PlannedConversion, { readonly status: 'converted' }> =>
+        plan.status === 'converted' && plan.input.directive === 'fxLayout',
+    )
+    .flatMap(plan => plan.classNames.map(describeTailwindDisplay).filter(descriptor => descriptor !== undefined))
+    .filter(
+      descriptor =>
+        (descriptor.utility === 'flex' || descriptor.utility === 'inline-flex') &&
+        !descriptor.important &&
+        (descriptor.activation.kind === 'media' || descriptor.token === descriptor.utility),
+    );
+}
+
+function matchingLayoutUtility(
+  displays: readonly TailwindDisplayUtility[],
+  state: VisibilityState,
+): string | null | undefined {
+  if (state.activation.kind === 'media') {
+    const stateRange = state.activation.definition.range;
+    const hasOverlappingLayout = displays.some(
+      display =>
+        display.activation.kind === 'media' &&
+        !sameActivation(display.activation, state.activation) &&
+        mediaRangesIntersect(display.activation.range, stateRange),
+    );
+    if (hasOverlappingLayout) return null;
+  }
+
+  const exact = displays.filter(display => sameActivation(display.activation, state.activation));
+  const applicable = exact.length > 0 ? exact : displays.filter(display => display.activation.kind === 'base');
+  if (applicable.length === 0) return undefined;
+  const utilities = [...new Set(applicable.map(display => display.utility))];
+  return utilities.length === 1 ? utilities[0] : null;
+}
+
+function existingRestorationUtility(descriptors: readonly TailwindDisplayUtility[]): string | undefined {
+  if (descriptors.length !== 1) return undefined;
+  const descriptor = descriptors[0];
+  if (!descriptor || !isPlainBase(descriptor) || !restorationUtilities.has(descriptor.utility)) return undefined;
+  return descriptor.utility;
+}
+
+export class VisibleDisplayResolver {
+  resolve(request: VisibleDisplayRequest): VisibleDisplayResolution {
+    if (request.attributes.some(controlsDisplay)) {
+      return { status: 'unverified', reason: unverifiedStyleReason };
+    }
+
+    const baseIsHidden = request.states.some(state => state.activation.kind === 'base' && state.intent === 'hidden');
+    const shownOverrides = baseIsHidden
+      ? request.states.filter(state => state.activation.kind === 'media' && state.intent === 'shown')
+      : [];
+    const displayDescriptors = request.existingClassNames
+      .map(describeTailwindDisplay)
+      .filter(descriptor => descriptor !== undefined);
+    const hasEffectiveShownRange = !baseIsHidden || request.states.some(state => state.intent === 'shown');
+    const classOutputRequired =
+      request.states.some(state => state.intent === 'hidden') ||
+      (hasEffectiveShownRange && displayDescriptors.some(descriptor => descriptor.utility === 'hidden'));
+
+    if (classOutputRequired && request.attributes.some(controlsClasses)) {
+      return { status: 'unverified', reason: unverifiedClassReason };
+    }
+
+    if (displayDescriptors.some(descriptor => descriptor.utility === 'hidden')) {
+      return hasEffectiveShownRange
+        ? { status: 'unverified', reason: unverifiedDisplayReason }
+        : { status: 'resolved', utility: undefined };
+    }
+
+    if (shownOverrides.length === 0) return { status: 'resolved', utility: undefined };
+
+    const displays = layoutDisplays(request.layoutPlans);
+    const existingUtility = existingRestorationUtility(displayDescriptors);
+    const utilities = shownOverrides.map(state => {
+      const layoutUtility = matchingLayoutUtility(displays, state);
+      return layoutUtility === undefined ? existingUtility : layoutUtility;
+    });
+    const distinctUtilities = [...new Set(utilities)];
+    const utility = distinctUtilities[0];
+    if (distinctUtilities.length !== 1 || typeof utility !== 'string') {
+      return { status: 'unverified', reason: unverifiedDisplayReason };
+    }
+
+    return { status: 'resolved', utility };
+  }
+}

--- a/src/analyzer/conversion-result.ts
+++ b/src/analyzer/conversion-result.ts
@@ -9,6 +9,7 @@ export type DiagnosticCode =
   | 'breakpoint-unverified'
   | 'custom-breakpoint'
   | 'dynamic-binding'
+  | 'display-restoration-unverified'
   | 'invalid-value'
   | 'context-unverified'
   | 'responsive-precedence-unverified'

--- a/src/analyzer/template.analyzer.spec.ts
+++ b/src/analyzer/template.analyzer.spec.ts
@@ -40,4 +40,50 @@ describe('TemplateAnalyzer', () => {
       }),
     ]);
   });
+
+  test('does not reinterpret class, style, or attribute binding targets as directive inputs', () => {
+    const source =
+      '<div [class.fxShow]="classFlag" [style.fxShow]="styleValue" [attr.fxShow]="attributeValue" [fxShow]="shown"></div>';
+    const parsed = new AngularTemplateParser().parse(source, 'targets.component.html');
+    expect(parsed.status).toBe('parsed');
+    if (parsed.status !== 'parsed') throw new Error('Expected the fixture to parse');
+
+    const inputs = new TemplateAnalyzer().analyze('targets.component.html', parsed.elements);
+
+    expect(inputs).toEqual([
+      expect.objectContaining({
+        directive: 'fxShow',
+        sourceName: '[fxShow]',
+        binding: 'property',
+        value: 'shown',
+      }),
+    ]);
+  });
+
+  test('recognizes responsive class and style binding targets without admitting similarly named targets', () => {
+    const source =
+      '<div [class.sm]="classFlag" bind-class.md="otherClass" [style.lg]="styleValue" bind-style.xl="otherStyle" [class.fxShow]="wrong" [style.fxHide]="wrong" [attr.fxShow]="wrong"></div>';
+    const parsed = new AngularTemplateParser().parse(source, 'responsive-authorities.component.html');
+    expect(parsed.status).toBe('parsed');
+    if (parsed.status !== 'parsed') throw new Error('Expected the fixture to parse');
+
+    const inputs = new TemplateAnalyzer().analyze('responsive-authorities.component.html', parsed.elements);
+
+    expect(inputs).toEqual([
+      expect.objectContaining({ directive: 'class', breakpoint: 'sm', binding: 'property' }),
+      expect.objectContaining({ directive: 'class', breakpoint: 'md', binding: 'property' }),
+      expect.objectContaining({ directive: 'style', breakpoint: 'lg', binding: 'property' }),
+      expect.objectContaining({ directive: 'style', breakpoint: 'xl', binding: 'property' }),
+    ]);
+  });
+
+  test('continues to classify a two-way directive input as dynamic', () => {
+    const parsed = new AngularTemplateParser().parse('<div [(fxShow)]="shown"></div>', 'two-way.component.html');
+    expect(parsed.status).toBe('parsed');
+    if (parsed.status !== 'parsed') throw new Error('Expected the fixture to parse');
+
+    expect(new TemplateAnalyzer().analyze('two-way.component.html', parsed.elements)).toEqual([
+      expect.objectContaining({ directive: 'fxShow', sourceName: '[fxShow]', binding: 'property', value: 'shown' }),
+    ]);
+  });
 });

--- a/src/analyzer/template.analyzer.ts
+++ b/src/analyzer/template.analyzer.ts
@@ -1,5 +1,18 @@
 import type { TemplateElement } from '../template/template.model';
 import { analyzeFlexLayoutAttribute, LocatedFlexLayoutInput } from './flex-layout-attribute.analyzer';
+import { isKnownBreakpoint } from './flex-layout.catalog';
+
+function sourceNameFor(attribute: TemplateElement['attributes'][number]): string | undefined {
+  if (attribute.binding === 'literal') return attribute.name;
+  if (attribute.bindingTarget === 'property' || attribute.bindingTarget === 'two-way') return `[${attribute.name}]`;
+  if (
+    (attribute.bindingTarget === 'class' || attribute.bindingTarget === 'style') &&
+    isKnownBreakpoint(attribute.name)
+  ) {
+    return `[${attribute.bindingTarget}.${attribute.name}]`;
+  }
+  return undefined;
+}
 
 export class TemplateAnalyzer {
   analyze(fileName: string, elements: readonly TemplateElement[]): readonly LocatedFlexLayoutInput[] {
@@ -7,7 +20,8 @@ export class TemplateAnalyzer {
 
     for (const element of elements) {
       for (const attribute of element.attributes) {
-        const sourceName = attribute.binding === 'property' ? `[${attribute.name}]` : attribute.name;
+        const sourceName = sourceNameFor(attribute);
+        if (!sourceName) continue;
         const input = analyzeFlexLayoutAttribute(sourceName, attribute.value);
         if (!input) continue;
 

--- a/src/migrator/file.migrator.spec.ts
+++ b/src/migrator/file.migrator.spec.ts
@@ -63,6 +63,34 @@ describe('FileMigrator', () => {
     expect(result.results.map(item => item.status)).toEqual(['converted']);
   });
 
+  test('returns exact public results for mixed converted and unresolved visibility inputs', async () => {
+    await writeFile(
+      input,
+      '<div fxHide></div>\n<div class="block" fxShow="false" fxShow.sm></div>\n<div fxShow="false" fxShow.sm></div>\n<div [fxHide]="hidden"></div>',
+      'utf8',
+    );
+
+    const result = await new FileMigrator(new TailwindAdapter(), input, output).migrate();
+
+    expect(await readFile(output, 'utf8')).toBe(
+      '<div class="hidden"></div>\n<div class="block hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>\n<div fxShow="false" fxShow.sm></div>\n<div [fxHide]="hidden"></div>',
+    );
+    expect(
+      result.results.map(item => ({
+        status: item.status,
+        sourceName: item.status === 'parse-error' ? undefined : item.input.sourceName,
+        code: item.status === 'converted' || item.status === 'parse-error' ? undefined : item.code,
+      })),
+    ).toEqual([
+      { status: 'converted', sourceName: 'fxHide', code: undefined },
+      { status: 'converted', sourceName: 'fxShow', code: undefined },
+      { status: 'converted', sourceName: 'fxShow.sm', code: undefined },
+      { status: 'review', sourceName: 'fxShow', code: 'display-restoration-unverified' },
+      { status: 'review', sourceName: 'fxShow.sm', code: 'display-restoration-unverified' },
+      { status: 'review', sourceName: '[fxHide]', code: 'dynamic-binding' },
+    ]);
+  });
+
   test('returns an unchanged parse diagnostic and does not write malformed templates', async () => {
     await writeFile(input, '<span fxLayout="row" />', 'utf8');
 

--- a/src/planner/conversion-planner.spec.ts
+++ b/src/planner/conversion-planner.spec.ts
@@ -175,15 +175,137 @@ describe('ConversionPlanner', () => {
     expect(result.results).toContainEqual(expect.objectContaining({ status: 'review', code: 'bound-class' }));
   });
 
-  test('preserves inputs the adapter does not support', () => {
-    const source = '<div fxShow="false"></div>';
+  test.each([
+    ['fxShow', '<div fxShow></div>', '<div></div>'],
+    ['fxShow false', '<div fxShow="false"></div>', '<div class="hidden"></div>'],
+    ['fxHide', '<div fxHide></div>', '<div class="hidden"></div>'],
+    ['fxHide false', '<div fxHide="false"></div>', '<div></div>'],
+  ])('converts static visibility semantics for %s', (_case, source, expected) => {
+    const result = migrate(source);
 
+    expect(result.output).toBe(expected);
+    expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
+  });
+
+  test('converts a responsive-only hide without guessing a restoration display', () => {
+    const result = migrate('<div fxHide.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>',
+    );
+    expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
+  });
+
+  test('restores a hidden base state from converted layout semantics', () => {
+    const result = migrate('<div fxLayout="column" fxShow="false" fxShow.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="flex flex-col box-border hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex"></div>',
+    );
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test('restores a hidden base state from one existing display utility', () => {
+    const result = migrate('<div class="block" fxShow="false" fxShow.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="block hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>',
+    );
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test.each([
+    '<div style="display:block" fxShow></div>',
+    '<div [style.display]="display" fxShow></div>',
+    '<div [style.display]="display" fxHide></div>',
+  ])('preserves visibility when parser-provided style evidence controls display: %s', source => {
     const result = migrate(source);
 
     expect(result.output).toBe(source);
     expect(result.results).toContainEqual(
-      expect.objectContaining({ status: 'unsupported', code: 'target-unsupported' }),
+      expect.objectContaining({ status: 'review', code: 'display-restoration-unverified' }),
     );
+  });
+
+  test('preserves a hiding family when bound classes block generated output', () => {
+    const source = '<div [class]="classes" fxHide></div>';
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([expect.objectContaining({ status: 'review', code: 'bound-class' })]);
+  });
+
+  test('removes an all-shown no-op family beside a bound class without inserting an empty class', () => {
+    const result = migrate('<div [class]="classes" fxShow></div>');
+
+    expect(result.output).toBe('<div [class]="classes"></div>');
+    expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
+  });
+
+  test('preserves layout and visibility atomically when visibility is dynamic', () => {
+    const source = '<div fxLayout="row" [fxHide]="hidden"></div>';
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'dynamic-binding' }),
+    ]);
+  });
+
+  test('lets visibility own display when layout and hiding share one responsive range', () => {
+    const result = migrate('<div fxLayout.sm="column" fxHide.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-col [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:box-border [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>',
+    );
+    expect(result.output).not.toContain(']:flex ');
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test('preserves a competing existing display class and closes the layout dependency afterward', () => {
+    const source = '<div class="block" fxLayout="row" fxHide></div>';
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'class-conflict' }),
+    ]);
+  });
+
+  test('closes visibility dependencies after a non-display layout class conflict', () => {
+    const source = '<div class="flex-col" fxLayout="row" fxShow="false" fxShow.sm></div>';
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'class-conflict' }),
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+    ]);
+  });
+
+  test('keeps parent gap conversion independent from a hidden child', () => {
+    const result = migrate('<div fxLayout="row" fxLayoutGap="4"><span fxHide></span></div>');
+
+    expect(result.output).toBe('<div class="flex flex-row box-border gap-[4px]"><span class="hidden"></span></div>');
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test.each([
+    ['dynamic', '<div fxLayout="row" [fxHide]="hidden"></div>', ['context-unverified', 'dynamic-binding']],
+    [
+      'optional breakpoint',
+      '<div fxLayout="row" fxShow.handset></div>',
+      ['context-unverified', 'breakpoint-unverified'],
+    ],
+    ['custom breakpoint', '<div fxLayout="row" fxHide.cinema></div>', ['context-unverified', 'custom-breakpoint']],
+  ] as const)('retains intrinsic visibility diagnostic precedence for %s input', (_case, source, codes) => {
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results.map(item => (item.status === 'converted' ? undefined : item.code))).toEqual(codes);
   });
 
   test('plans fxFlex, fxGrow, and fxShrink as one atomic semantic group', () => {

--- a/src/planner/conversion-planner.spec.ts
+++ b/src/planner/conversion-planner.spec.ts
@@ -218,6 +218,8 @@ describe('ConversionPlanner', () => {
     '<div style="display:block" fxShow></div>',
     '<div [style.display]="display" fxShow></div>',
     '<div [style.display]="display" fxHide></div>',
+    '<div [attr.style]="styles" fxShow></div>',
+    '<div bind-attr.style="styles" fxShow></div>',
   ])('preserves visibility when parser-provided style evidence controls display: %s', source => {
     const result = migrate(source);
 
@@ -227,12 +229,31 @@ describe('ConversionPlanner', () => {
     );
   });
 
-  test('preserves a hiding family when bound classes block generated output', () => {
-    const source = '<div [class]="classes" fxHide></div>';
+  test.each([
+    '<div [class]="classes" fxHide></div>',
+    '<div [attr.class]="classes" fxHide></div>',
+    '<div bind-attr.class="classes" fxHide></div>',
+  ])('preserves a hiding family when parser-produced bound classes block generated output: %s', source => {
     const result = migrate(source);
 
     expect(result.output).toBe(source);
     expect(result.results).toEqual([expect.objectContaining({ status: 'review', code: 'bound-class' })]);
+  });
+
+  test.each(['CLASS', 'Class'])('merges generated visibility output into the existing %s attribute', classKey => {
+    const result = migrate(`<div ${classKey}="card" fxHide></div>`);
+
+    expect(result.output).toBe(`<div ${classKey}="card hidden"></div>`);
+    expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
+  });
+
+  test('uses an uppercase literal CLASS display utility as restoration evidence', () => {
+    const result = migrate('<div CLASS="block" fxShow="false" fxShow.sm></div>');
+
+    expect(result.output).toBe(
+      '<div CLASS="block hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>',
+    );
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
   });
 
   test('removes an all-shown no-op family beside a bound class without inserting an empty class', () => {

--- a/src/planner/conversion-planner.spec.ts
+++ b/src/planner/conversion-planner.spec.ts
@@ -187,6 +187,56 @@ describe('ConversionPlanner', () => {
     expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
   });
 
+  test.each([
+    ['fxShow', '<div fxShow="fals&#101;"></div>', '<div class="hidden"></div>'],
+    ['fxHide', '<div fxHide="fals&#101;"></div>', '<div></div>'],
+  ])('uses Angular-decoded entity semantics for %s literals', (_case, source, expected) => {
+    const result = migrate(source);
+
+    expect(result.output).toBe(expected);
+    expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
+  });
+
+  test('uses a decoded entity class as restoration evidence while preserving its raw spelling', () => {
+    const result = migrate('<div class="bl&#111;ck" fxShow="false" fxShow.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="bl&#111;ck hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>',
+    );
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test('keeps generated classes separated after entity-encoded class whitespace', () => {
+    const result = migrate('<div class="bl&#111;ck&#32;" fxShow="false" fxShow.sm></div>');
+
+    expect(result.output).toBe(
+      '<div class="bl&#111;ck&#32;hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>',
+    );
+  });
+
+  test('uses a decoded entity style declaration as blocking display evidence', () => {
+    const source = '<div style="displa&#121;:block" fxShow></div>';
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'display-restoration-unverified' }),
+    ]);
+  });
+
+  test.each([
+    '<div style="/* leading */ display:block" fxHide></div>',
+    '<div style="color:red; display/**/:block" fxHide></div>',
+    '<div style="d\\69 splay:block" fxHide></div>',
+  ])('preserves visibility when CSS-aware inline-style evidence controls display: %s', source => {
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'display-restoration-unverified' }),
+    ]);
+  });
+
   test('converts a responsive-only hide without guessing a restoration display', () => {
     const result = migrate('<div fxHide.sm></div>');
 
@@ -263,6 +313,23 @@ describe('ConversionPlanner', () => {
     expect(result.results).toEqual([expect.objectContaining({ status: 'converted' })]);
   });
 
+  test.each([
+    ['zero generated output', '<div class="card" fxShow></div>', '<div class="card"></div>'],
+    [
+      'replacement-identical generated output',
+      '<div class="flex flex-row box-border" fxLayout="row"></div>',
+      '<div class="flex flex-row box-border"></div>',
+    ],
+  ])('does not enqueue an identical literal class edit for %s', (_case, source, expected) => {
+    const result = migrate(source);
+
+    expect(result.output).toBe(expected);
+    expect(result.edits).toHaveLength(1);
+    expect(result.edits).toEqual([
+      expect.objectContaining({ text: '', inputId: expect.not.stringContaining(':classes') }),
+    ]);
+  });
+
   test('preserves layout and visibility atomically when visibility is dynamic', () => {
     const source = '<div fxLayout="row" [fxHide]="hidden"></div>';
     const result = migrate(source);
@@ -283,6 +350,44 @@ describe('ConversionPlanner', () => {
     expect(result.output).not.toContain(']:flex ');
     expect(result.results.every(item => item.status === 'converted')).toBe(true);
   });
+
+  test.each([
+    ['nested max-only ranges', '<div fxLayout.lt-md="row" fxHide.lt-sm></div>'],
+    ['crossing min/max ranges', '<div fxLayout.gt-xs="row" fxHide.lt-md></div>'],
+  ])('preserves coupled directives for unsafe partial layout/visibility overlap across %s', (_case, source) => {
+    const result = migrate(source);
+
+    expect(result.output).toBe(source);
+    expect(result.results).toEqual([
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'context-unverified' }),
+    ]);
+  });
+
+  test.each([
+    ['literal class', 'class.sm="hidden"', 'target-unsupported', 'context-unverified'],
+    ['literal style', 'style.sm="display:block"', 'target-unsupported', 'display-restoration-unverified'],
+    ['bound ngClass', '[ngClass.sm]="classes"', 'dynamic-binding', 'bound-class'],
+    ['bind ngClass', 'bind-ngClass.sm="classes"', 'dynamic-binding', 'bound-class'],
+    ['bound class target', '[class.sm]="flag"', 'dynamic-binding', 'bound-class'],
+    ['bind class target', 'bind-class.sm="flag"', 'dynamic-binding', 'bound-class'],
+    ['bound ngStyle', '[ngStyle.sm]="styles"', 'dynamic-binding', 'display-restoration-unverified'],
+    ['bind ngStyle', 'bind-ngStyle.sm="styles"', 'dynamic-binding', 'display-restoration-unverified'],
+    ['bound style target', '[style.sm]="value"', 'dynamic-binding', 'display-restoration-unverified'],
+    ['bind style target', 'bind-style.sm="value"', 'dynamic-binding', 'display-restoration-unverified'],
+  ])(
+    'preserves generated hiding beside unsupported responsive %s authority',
+    (_case, authority, authorityCode, visibilityCode) => {
+      const source = `<div ${authority} fxHide.sm></div>`;
+      const result = migrate(source);
+
+      expect(result.output).toBe(source);
+      expect(result.results).toEqual([
+        expect.objectContaining({ status: expect.not.stringMatching('converted'), code: authorityCode }),
+        expect.objectContaining({ status: 'review', code: visibilityCode }),
+      ]);
+    },
+  );
 
   test('preserves a competing existing display class and closes the layout dependency afterward', () => {
     const source = '<div class="block" fxLayout="row" fxHide></div>';

--- a/src/planner/conversion-planner.ts
+++ b/src/planner/conversion-planner.ts
@@ -50,7 +50,7 @@ function boundClassBlocked(input: LocatedFlexLayoutInput): PlannedConversion {
 function isBoundClassAttribute(attribute: TemplateElement['attributes'][number]): boolean {
   if (attribute.binding !== 'property') return false;
   return [...templateAttributeKeys(attribute)].some(
-    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.') || key.startsWith('ngclass.'),
   );
 }
 
@@ -170,12 +170,24 @@ export class ConversionPlanner {
 
       const classAttribute = literalClassAttribute(conversion.element);
       if (classAttribute?.valueSource) {
-        const classNames = [...new Set([...classAttribute.value.split(/\s+/).filter(Boolean), ...generatedClassNames])];
-        edits.push({
-          range: classAttribute.valueSource,
-          text: classNames.join(' '),
-          inputId: `${conversion.element.id}:classes`,
-        });
+        const existingClassNames = classAttribute.value.split(/\s+/).filter(Boolean);
+        const classNames = [...new Set([...existingClassNames, ...generatedClassNames])];
+        const missingClassNames = generatedClassNames.filter(className => !existingClassNames.includes(className));
+        const text =
+          classAttribute.rawValue === classAttribute.value
+            ? classNames.join(' ')
+            : `${classAttribute.rawValue}${
+                classAttribute.value.length > 0 && !/\s$/u.test(classAttribute.value) && missingClassNames.length > 0
+                  ? ' '
+                  : ''
+              }${missingClassNames.join(' ')}`;
+        if (text !== classAttribute.rawValue) {
+          edits.push({
+            range: classAttribute.valueSource,
+            text,
+            inputId: `${conversion.element.id}:classes`,
+          });
+        }
       } else if (generatedClassNames.length > 0) {
         const startTag = source.slice(conversion.element.startTag.start, conversion.element.startTag.end);
         const selfClosing = startTag.endsWith('/>');

--- a/src/planner/conversion-planner.ts
+++ b/src/planner/conversion-planner.ts
@@ -2,6 +2,7 @@ import type { ConversionAdapter, ConversionContext, PlannedConversion } from '..
 import type { ConversionResult } from '../analyzer/conversion-result';
 import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
 import type { SourceEdit } from '../edit/source-edit';
+import { templateAttributeKeys } from '../template/template-attribute';
 import type { SourceRange, TemplateElement } from '../template/template.model';
 
 export interface FilePlan {
@@ -48,14 +49,15 @@ function boundClassBlocked(input: LocatedFlexLayoutInput): PlannedConversion {
 
 function isBoundClassAttribute(attribute: TemplateElement['attributes'][number]): boolean {
   if (attribute.binding !== 'property') return false;
-  const rawName = attribute.rawName.toLowerCase();
-  const key =
-    rawName.startsWith('[') && rawName.endsWith(']')
-      ? rawName.slice(1, -1)
-      : rawName.startsWith('bind-')
-        ? rawName.slice('bind-'.length)
-        : rawName;
-  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
+  return [...templateAttributeKeys(attribute)].some(
+    key => key === 'class' || key === 'ngclass' || key.startsWith('class.'),
+  );
+}
+
+function literalClassAttribute(element: TemplateElement) {
+  return element.attributes.find(
+    attribute => attribute.binding === 'literal' && templateAttributeKeys(attribute).has('class'),
+  );
 }
 
 function removalRange(source: string, input: LocatedFlexLayoutInput): SourceRange {
@@ -90,9 +92,7 @@ export class ConversionPlanner {
       const elementInputs = inputsByElementId.get(element.id) ?? [];
       if (!elementInputs.length) continue;
       const parent = element.parentId ? elementById.get(element.parentId) : undefined;
-      const literalClass = element.attributes.find(
-        attribute => attribute.name === 'class' && attribute.binding === 'literal',
-      );
+      const literalClass = literalClassAttribute(element);
       const existingClassNames = literalClass?.value.split(/\s+/).filter(Boolean) ?? [];
       const context: ConversionContext = {
         element,
@@ -168,9 +168,7 @@ export class ConversionPlanner {
         })),
       );
 
-      const classAttribute = conversion.element.attributes.find(
-        attribute => attribute.name === 'class' && attribute.binding === 'literal',
-      );
+      const classAttribute = literalClassAttribute(conversion.element);
       if (classAttribute?.valueSource) {
         const classNames = [...new Set([...classAttribute.value.split(/\s+/).filter(Boolean), ...generatedClassNames])];
         edits.push({

--- a/src/planner/conversion-planner.ts
+++ b/src/planner/conversion-planner.ts
@@ -31,8 +31,32 @@ const directiveOrder = new Map(
     'fxFill',
     'fxFlexOffset',
     'fxFlexOrder',
+    'fxShow',
+    'fxHide',
   ].map((directive, index) => [directive, index]),
 );
+
+function boundClassBlocked(input: LocatedFlexLayoutInput): PlannedConversion {
+  return {
+    status: 'review',
+    input,
+    code: 'bound-class',
+    reason: 'Generated classes cannot be merged safely with a bound class value.',
+    suggestion: 'Merge the generated classes into the binding manually.',
+  };
+}
+
+function isBoundClassAttribute(attribute: TemplateElement['attributes'][number]): boolean {
+  if (attribute.binding !== 'property') return false;
+  const rawName = attribute.rawName.toLowerCase();
+  const key =
+    rawName.startsWith('[') && rawName.endsWith(']')
+      ? rawName.slice(1, -1)
+      : rawName.startsWith('bind-')
+        ? rawName.slice('bind-'.length)
+        : rawName;
+  return key === 'class' || key === 'ngclass' || key.startsWith('class.');
+}
 
 function removalRange(source: string, input: LocatedFlexLayoutInput): SourceRange {
   const start =
@@ -66,19 +90,27 @@ export class ConversionPlanner {
       const elementInputs = inputsByElementId.get(element.id) ?? [];
       if (!elementInputs.length) continue;
       const parent = element.parentId ? elementById.get(element.parentId) : undefined;
+      const literalClass = element.attributes.find(
+        attribute => attribute.name === 'class' && attribute.binding === 'literal',
+      );
+      const existingClassNames = literalClass?.value.split(/\s+/).filter(Boolean) ?? [];
       const context: ConversionContext = {
         element,
         inputs: elementInputs,
+        existingClassNames,
+        attributeEvidence: element.attributes,
         ...(parent
           ? { parent, parentInputs: inputsByElementId.get(parent.id) ?? [] }
           : { parentInputs: [] as readonly LocatedFlexLayoutInput[] }),
       };
       let plans =
         adapter.planElement?.(elementInputs, context) ?? elementInputs.map(input => adapter.plan(input, context));
-      const literalClass = element.attributes.find(
-        attribute => attribute.name === 'class' && attribute.binding === 'literal',
-      );
-      const existingClassNames = literalClass?.value.split(/\s+/).filter(Boolean) ?? [];
+      const hasBoundClass = element.attributes.some(isBoundClassAttribute);
+      if (hasBoundClass) {
+        plans = plans.map(plan =>
+          plan.status === 'converted' && plan.classNames.length > 0 ? boundClassBlocked(plan.input) : plan,
+        );
+      }
       plans = adapter.resolveClassConflicts?.(plans, existingClassNames) ?? plans;
       contextsByElementId.set(element.id, context);
       plansByElementId.set(element.id, plans);
@@ -103,20 +135,6 @@ export class ConversionPlanner {
 
       if (planned.status !== 'converted') {
         results.push(planned);
-        continue;
-      }
-
-      const hasBoundClass = element.attributes.some(
-        attribute => attribute.name === 'class' && attribute.binding === 'property',
-      );
-      if (hasBoundClass) {
-        results.push({
-          status: 'review',
-          input,
-          code: 'bound-class',
-          reason: 'Generated classes cannot be merged safely with a bound class value.',
-          suggestion: 'Merge the generated classes into the binding manually.',
-        });
         continue;
       }
 
@@ -160,7 +178,7 @@ export class ConversionPlanner {
           text: classNames.join(' '),
           inputId: `${conversion.element.id}:classes`,
         });
-      } else {
+      } else if (generatedClassNames.length > 0) {
         const startTag = source.slice(conversion.element.startTag.start, conversion.element.startTag.end);
         const selfClosing = startTag.endsWith('/>');
         const insertionOffset = conversion.element.startTag.end - (selfClosing ? 2 : 1);

--- a/src/report/json-report.writer.spec.ts
+++ b/src/report/json-report.writer.spec.ts
@@ -50,6 +50,33 @@ function reviewResult(fileName: string): ConversionResult {
   };
 }
 
+function visibilityReviewResult(
+  fileName: string,
+  sourceName: 'fxShow' | 'fxShow.sm',
+  offset: number,
+): ConversionResult {
+  const input: LocatedFlexLayoutInput = {
+    id: `${fileName}:${offset}`,
+    fileName,
+    elementId: 'visibility-element',
+    sourceName,
+    directive: 'fxShow',
+    value: sourceName === 'fxShow' ? 'false' : '',
+    binding: 'literal',
+    breakpoint: sourceName === 'fxShow' ? undefined : 'sm',
+    source: { start: offset, end: offset + sourceName.length },
+    nameSource: { start: offset, end: offset + sourceName.length },
+  };
+
+  return {
+    status: 'review',
+    input,
+    code: 'display-restoration-unverified',
+    reason: 'The visible display value cannot be proven from one unambiguous source.',
+    suggestion: 'Provide one unambiguous visible display value or migrate this visibility family manually.',
+  };
+}
+
 function file(inputPath: string): FileMigrationResult {
   return {
     inputPath,
@@ -123,6 +150,56 @@ describe('JsonReportWriter', () => {
                 status: 'review',
                 sourceName: 'fxFlexAlign.gt-xs',
                 code: 'responsive-precedence-unverified',
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves exact visibility restoration diagnostics and counts in the public report', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'json-report-writer-'));
+    const inputRoot = '/private/checkout/templates';
+    const outputRoot = '/private/checkout/generated';
+    const inputPath = `${inputRoot}/visibility.component.html`;
+    const report = new MigrationReportBuilder().build(inputRoot, outputRoot, 'tailwind', false, 0, [
+      {
+        ...file(inputPath),
+        changed: false,
+        results: [visibilityReviewResult(inputPath, 'fxShow', 12), visibilityReviewResult(inputPath, 'fxShow.sm', 27)],
+      },
+    ]);
+    const target = join(directory, 'reports', 'migration.json');
+
+    try {
+      await new JsonReportWriter().write(target, report);
+
+      expect(JSON.parse(await readFile(target, 'utf8'))).toMatchObject({
+        summary: {
+          filesScanned: 1,
+          filesChanged: 0,
+          converted: 0,
+          review: 2,
+          unsupported: 0,
+          invalid: 0,
+          parseErrors: 0,
+        },
+        files: [
+          {
+            changed: false,
+            results: [
+              {
+                status: 'review',
+                sourceName: 'fxShow',
+                code: 'display-restoration-unverified',
+              },
+              {
+                status: 'review',
+                sourceName: 'fxShow.sm',
+                code: 'display-restoration-unverified',
               },
             ],
           },

--- a/src/template/angular-template.parser.spec.ts
+++ b/src/template/angular-template.parser.spec.ts
@@ -17,6 +17,7 @@ describe('AngularTemplateParser', () => {
             {
               name: 'fxLayout',
               rawName: 'fxLayout',
+              rawValue: 'row',
               value: 'row',
               binding: 'literal',
               source: { start: 5, end: 19 },
@@ -26,8 +27,10 @@ describe('AngularTemplateParser', () => {
             {
               name: 'fxFlex',
               rawName: '[fxFlex]',
+              rawValue: 'basis',
               value: 'basis',
               binding: 'property',
+              bindingTarget: 'property',
               source: { start: 20, end: 36 },
               nameSource: { start: 20, end: 28 },
               valueSource: { start: 30, end: 35 },
@@ -68,6 +71,46 @@ describe('AngularTemplateParser', () => {
             { name: 'display', rawName: '[style.display]', binding: 'property' },
             { name: 'display', rawName: '[style.display.important]', binding: 'property' },
             { name: 'hidden', rawName: '[class.hidden]', binding: 'property' },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('keeps raw literal edit evidence separate from Angular-decoded semantic values', () => {
+    const source = '<div fxShow="fals&#101;" class="bl&#111;ck" style="displa&#121;: block"></div>';
+
+    const result = new AngularTemplateParser().parse(source, 'entities.component.html');
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        {
+          attributes: [
+            { name: 'fxShow', value: 'false', rawValue: 'fals&#101;' },
+            { name: 'class', value: 'block', rawValue: 'bl&#111;ck' },
+            { name: 'style', value: 'display: block', rawValue: 'displa&#121;: block' },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('retains Angular bound target types after normalized class, style, and attribute names', () => {
+    const result = new AngularTemplateParser().parse(
+      '<div [fxShow]="shown" [class.fxShow]="flag" [style.fxShow]="value" [attr.fxShow]="value"></div>',
+      'targets.component.html',
+    );
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        {
+          attributes: [
+            { name: 'fxShow', rawName: '[fxShow]', bindingTarget: 'property' },
+            { name: 'fxShow', rawName: '[class.fxShow]', bindingTarget: 'class' },
+            { name: 'fxShow', rawName: '[style.fxShow]', bindingTarget: 'style' },
+            { name: 'fxShow', rawName: '[attr.fxShow]', bindingTarget: 'attribute' },
           ],
         },
       ],

--- a/src/template/angular-template.parser.spec.ts
+++ b/src/template/angular-template.parser.spec.ts
@@ -16,6 +16,7 @@ describe('AngularTemplateParser', () => {
           attributes: [
             {
               name: 'fxLayout',
+              rawName: 'fxLayout',
               value: 'row',
               binding: 'literal',
               source: { start: 5, end: 19 },
@@ -24,6 +25,7 @@ describe('AngularTemplateParser', () => {
             },
             {
               name: 'fxFlex',
+              rawName: '[fxFlex]',
               value: 'basis',
               binding: 'property',
               source: { start: 20, end: 36 },
@@ -47,6 +49,27 @@ describe('AngularTemplateParser', () => {
         { id: '0', name: 'section' },
         { id: '22', name: 'article', parentId: '0' },
         { id: '31', name: 'app-item', parentId: '22' },
+      ],
+    });
+  });
+
+  test('preserves raw attribute keys when Angular normalizes style and class binding names', () => {
+    const result = new AngularTemplateParser().parse(
+      '<div STYLE="display:block" [style.display]="display" [style.display.important]="display" [class.hidden]="hidden"></div>',
+      'bindings.component.html',
+    );
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        {
+          attributes: [
+            { name: 'STYLE', rawName: 'STYLE', binding: 'literal' },
+            { name: 'display', rawName: '[style.display]', binding: 'property' },
+            { name: 'display', rawName: '[style.display.important]', binding: 'property' },
+            { name: 'hidden', rawName: '[class.hidden]', binding: 'property' },
+          ],
+        },
       ],
     });
   });

--- a/src/template/angular-template.parser.ts
+++ b/src/template/angular-template.parser.ts
@@ -1,4 +1,5 @@
 import {
+  BindingType,
   parseTemplate,
   TmplAstBoundAttribute,
   TmplAstElement,
@@ -29,20 +30,38 @@ function normalizeAttribute(
   const valueSource = attribute.valueSpan
     ? range(attribute.valueSpan.start.offset, attribute.valueSpan.end.offset)
     : undefined;
+  const rawValue = valueSource ? source.slice(valueSource.start, valueSource.end) : '';
 
   return {
     name: attribute.name,
     rawName: source.slice(nameSource.start, nameSource.end),
-    value: valueSource
-      ? source.slice(valueSource.start, valueSource.end)
-      : attribute instanceof TmplAstTextAttribute
-        ? attribute.value
-        : '',
+    rawValue,
+    value: attribute instanceof TmplAstTextAttribute ? attribute.value : rawValue,
     binding,
+    ...(attribute instanceof TmplAstBoundAttribute ? { bindingTarget: boundTarget(attribute.type) } : {}),
     source: range(attribute.sourceSpan.start.offset, attribute.sourceSpan.end.offset),
     nameSource,
     ...(valueSource ? { valueSource } : {}),
   };
+}
+
+function boundTarget(type: BindingType): NonNullable<TemplateAttribute['bindingTarget']> {
+  switch (type) {
+    case BindingType.Attribute:
+      return 'attribute';
+    case BindingType.Class:
+      return 'class';
+    case BindingType.Style:
+      return 'style';
+    case BindingType.LegacyAnimation:
+    case BindingType.Animation:
+      return 'animation';
+    case BindingType.TwoWay:
+      return 'two-way';
+    case BindingType.Property:
+    default:
+      return 'property';
+  }
 }
 
 class ElementCollector extends TmplAstRecursiveVisitor {

--- a/src/template/angular-template.parser.ts
+++ b/src/template/angular-template.parser.ts
@@ -25,12 +25,14 @@ function normalizeAttribute(
   attribute: TmplAstTextAttribute | TmplAstBoundAttribute,
   binding: TemplateAttribute['binding'],
 ): TemplateAttribute {
+  const nameSource = attributeNameRange(source, attribute);
   const valueSource = attribute.valueSpan
     ? range(attribute.valueSpan.start.offset, attribute.valueSpan.end.offset)
     : undefined;
 
   return {
     name: attribute.name,
+    rawName: source.slice(nameSource.start, nameSource.end),
     value: valueSource
       ? source.slice(valueSource.start, valueSource.end)
       : attribute instanceof TmplAstTextAttribute
@@ -38,7 +40,7 @@ function normalizeAttribute(
         : '',
     binding,
     source: range(attribute.sourceSpan.start.offset, attribute.sourceSpan.end.offset),
-    nameSource: attributeNameRange(source, attribute),
+    nameSource,
     ...(valueSource ? { valueSource } : {}),
   };
 }

--- a/src/template/template-attribute.ts
+++ b/src/template/template-attribute.ts
@@ -1,0 +1,15 @@
+import type { TemplateAttribute } from './template.model';
+
+export function templateAttributeKeys(attribute: TemplateAttribute): ReadonlySet<string> {
+  const semanticKey = attribute.name.toLowerCase();
+  const rawName = attribute.rawName.toLowerCase();
+  const rawKey =
+    attribute.binding !== 'property'
+      ? rawName
+      : rawName.startsWith('[') && rawName.endsWith(']')
+        ? rawName.slice(1, -1)
+        : rawName.startsWith('bind-')
+          ? rawName.slice('bind-'.length)
+          : rawName;
+  return new Set([rawKey, semanticKey]);
+}

--- a/src/template/template.model.ts
+++ b/src/template/template.model.ts
@@ -5,6 +5,7 @@ export interface SourceRange {
 
 export interface TemplateAttribute {
   readonly name: string;
+  readonly rawName: string;
   readonly value: string;
   readonly binding: 'literal' | 'property';
   readonly source: SourceRange;

--- a/src/template/template.model.ts
+++ b/src/template/template.model.ts
@@ -6,8 +6,10 @@ export interface SourceRange {
 export interface TemplateAttribute {
   readonly name: string;
   readonly rawName: string;
+  readonly rawValue: string;
   readonly value: string;
   readonly binding: 'literal' | 'property';
+  readonly bindingTarget?: 'property' | 'attribute' | 'class' | 'style' | 'animation' | 'two-way';
   readonly source: SourceRange;
   readonly nameSource: SourceRange;
   readonly valueSource?: SourceRange;

--- a/test/compatibility/angular-template-engine.test.ts
+++ b/test/compatibility/angular-template-engine.test.ts
@@ -16,11 +16,26 @@ function migrate(source: string, fileName = 'fixture.html') {
   const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter());
   const edited = new SourceEditor().apply(source, plan.edits);
   if (edited.status !== 'applied') throw new Error(edited.diagnostics.map(item => item.message).join('\n'));
-  return { output: edited.output, results: plan.results };
+  return { output: edited.output, results: plan.results, editCount: plan.edits.length };
 }
 
 function unresolvedCodes(results: readonly ConversionResult[]): readonly string[] {
   return results.flatMap(result => (result.status === 'converted' ? [] : [result.code]));
+}
+
+function resultCounts(results: readonly ConversionResult[]) {
+  const counts = { converted: 0, review: 0, unsupported: 0, invalid: 0, parseError: 0 };
+  for (const result of results) {
+    if (result.status === 'parse-error') counts.parseError += 1;
+    else counts[result.status] += 1;
+  }
+  return counts;
+}
+
+function diagnosticCounts(results: readonly ConversionResult[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const code of unresolvedCodes(results)) counts[code] = (counts[code] ?? 0) + 1;
+  return counts;
 }
 
 function equivalentResults(results: readonly ConversionResult[]) {
@@ -60,7 +75,6 @@ describe('Angular template engine compatibility', () => {
     unresolved: [
       'dynamic-binding',
       'custom-breakpoint',
-      'target-unsupported',
       'bound-class',
       'context-unverified',
       'semantic-unsupported',
@@ -68,9 +82,38 @@ describe('Angular template engine compatibility', () => {
       'dynamic-binding',
       'context-unverified',
     ],
+    visibility: [
+      'responsive-precedence-unverified',
+      'responsive-precedence-unverified',
+      'responsive-precedence-unverified',
+      'responsive-precedence-unverified',
+      'class-conflict',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'display-restoration-unverified',
+      'bound-class',
+      'bound-class',
+      'dynamic-binding',
+      'dynamic-binding',
+      'context-unverified',
+      'breakpoint-unverified',
+      'breakpoint-unverified',
+      'custom-breakpoint',
+      'dynamic-binding',
+      'context-unverified',
+      'dynamic-binding',
+      'class-conflict',
+      'context-unverified',
+      'context-unverified',
+    ],
   };
 
-  test.each(['static', 'angular-syntax', 'responsive', 'unresolved'])(
+  test.each(['static', 'angular-syntax', 'responsive', 'unresolved', 'visibility'])(
     'matches the %s fixture and is idempotent',
     async name => {
       const input = await fixture(name, 'input');
@@ -80,6 +123,7 @@ describe('Angular template engine compatibility', () => {
       expect(first.output).toBe(expected);
       const second = migrate(first.output, `${name}.html`);
       expect(second.output).toBe(expected);
+      expect(second.editCount).toBe(0);
       expect(unresolvedCodes(first.results)).toEqual(preservedCodes[name] ?? []);
       expect(unresolvedCodes(second.results)).toEqual(preservedCodes[name] ?? []);
     },
@@ -99,6 +143,60 @@ describe('Angular template engine compatibility', () => {
 
     expect(baseFirst.output).toBe(responsiveFirst.output);
     expect(equivalentResults(baseFirst.results)).toEqual(equivalentResults(responsiveFirst.results));
+  });
+
+  test('emits the same composed visibility family for equivalent attribute orders', () => {
+    const layoutFirst = migrate('<div fxLayout="row" fxShow="false" fxShow.sm></div>');
+    const visibilityFirst = migrate('<div fxShow.sm fxShow="false" fxLayout="row"></div>');
+
+    expect(layoutFirst.output).toBe(visibilityFirst.output);
+    expect(equivalentResults(layoutFirst.results)).toEqual(equivalentResults(visibilityFirst.results));
+  });
+
+  test('reports the exact visibility compatibility totals and diagnostic histogram', async () => {
+    const result = migrate(await fixture('visibility', 'input'), 'visibility.html');
+    const convertedVisibilityNames = new Set(
+      result.results.flatMap(item =>
+        item.status === 'converted' && (item.input.directive === 'fxShow' || item.input.directive === 'fxHide')
+          ? [item.input.sourceName]
+          : [],
+      ),
+    );
+
+    expect(resultCounts(result.results)).toEqual({
+      converted: 48,
+      review: 27,
+      unsupported: 0,
+      invalid: 0,
+      parseError: 0,
+    });
+    expect(diagnosticCounts(result.results)).toEqual({
+      'responsive-precedence-unverified': 4,
+      'class-conflict': 2,
+      'display-restoration-unverified': 8,
+      'bound-class': 2,
+      'dynamic-binding': 4,
+      'context-unverified': 4,
+      'breakpoint-unverified': 2,
+      'custom-breakpoint': 1,
+    });
+    expect([...convertedVisibilityNames]).toEqual(
+      expect.arrayContaining([
+        'fxHide.xs',
+        'fxHide.sm',
+        'fxHide.md',
+        'fxHide.lg',
+        'fxHide.xl',
+        'fxHide.lt-sm',
+        'fxHide.lt-md',
+        'fxHide.lt-lg',
+        'fxHide.lt-xl',
+        'fxHide.gt-xs',
+        'fxHide.gt-sm',
+        'fxHide.gt-md',
+        'fxHide.gt-lg',
+      ]),
+    );
   });
 
   test('classifies every unresolved syntax family without modifying it', async () => {

--- a/test/fixtures/compatibility/unresolved.expected.html
+++ b/test/fixtures/compatibility/unresolved.expected.html
@@ -1,6 +1,5 @@
 <div [fxFlex]="basis"></div>
 <div fxLayout.cinema="row"></div>
-<div fxShow="false"></div>
 <div [class]="classes" fxLayout="row"></div>
 <div fxLayout="row wrap" fxLayoutGap="4"></div>
 <div fxLayoutGap="8px grid"></div>

--- a/test/fixtures/compatibility/unresolved.input.html
+++ b/test/fixtures/compatibility/unresolved.input.html
@@ -1,6 +1,5 @@
 <div [fxFlex]="basis"></div>
 <div fxLayout.cinema="row"></div>
-<div fxShow="false"></div>
 <div [class]="classes" fxLayout="row"></div>
 <div fxLayout="row wrap" fxLayoutGap="4"></div>
 <div fxLayoutGap="8px grid"></div>

--- a/test/fixtures/compatibility/visibility.expected.html
+++ b/test/fixtures/compatibility/visibility.expected.html
@@ -1,0 +1,63 @@
+<!-- literal coercion -->
+<div></div>
+<div></div>
+<div class="hidden"></div>
+<div></div>
+<div></div>
+<div class="hidden"></div>
+<div class="hidden"></div>
+<div></div>
+<div class="hidden"></div>
+<div class="hidden"></div>
+
+<!-- standard viewport aliases -->
+<div class="[@media_screen_and_(min-width:_0px)_and_(max-width:_599.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_960px)_and_(max-width:_1279.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_1280px)_and_(max-width:_1919.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_1920px)_and_(max-width:_4999.98px)]:hidden"></div>
+<div class="[@media_screen_and_(max-width:_599.98px)]:hidden"></div>
+<div class="[@media_screen_and_(max-width:_959.98px)]:hidden"></div>
+<div class="[@media_screen_and_(max-width:_1279.98px)]:hidden"></div>
+<div class="[@media_screen_and_(max-width:_1919.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_600px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_960px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_1280px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_1920px)]:hidden"></div>
+
+<!-- complete-family state planning -->
+<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_0px)_and_(max-width:_599.98px)]:hidden"></div>
+<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden [@media_screen_and_(max-width:_959.98px)]:hidden"></div>
+<div fxHide.gt-xs fxShow.sm></div>
+<div></div>
+<div fxShow fxHide></div>
+
+<!-- restoration, layout composition, and safe no-ops -->
+<div class="block hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:block"></div>
+<div class="flex flex-col box-border hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex"></div>
+<div class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-col [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:box-border [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>
+<div class="flex-row box-border hidden"></div>
+<div class="inline-flex flex-row box-border hidden [@media_screen_and_(min-width:_600px)]:inline-flex"></div>
+<div></div>
+
+<!-- existing display and class behavior -->
+<div class="hidden"></div>
+<div class="block [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hidden"></div>
+<div class="block" fxHide></div>
+<div class="hidden" fxShow></div>
+<div class="block flex" fxShow="false" fxShow.sm></div>
+<div class="hover:block" fxShow="false" fxShow.sm></div>
+<div style="display: inline" fxHide></div>
+<div [style.display]="display" fxHide></div>
+<div [style]="styles" fxShow></div>
+<div [class]="classes" fxHide></div>
+<div [class]="classes"></div>
+<div [class.hidden]="hidden" fxShow="false"></div>
+
+<!-- dynamic and unsupported family members -->
+<div [fxShow]="visible"></div>
+<div fxHide="{{ hidden }}"></div>
+<div fxShow fxHide.handset.landscape fxShow.print fxHide.cinema [fxShow.sm]="visible"></div>
+<div fxLayout="row" [fxHide]="hidden"></div>
+<div class="flex-col" fxLayout="row" fxShow="false" fxShow.sm></div>

--- a/test/fixtures/compatibility/visibility.input.html
+++ b/test/fixtures/compatibility/visibility.input.html
@@ -1,0 +1,63 @@
+<!-- literal coercion -->
+<div fxShow></div>
+<div fxShow=""></div>
+<div fxShow="false"></div>
+<div fxShow="0"></div>
+<div fxShow="FALSE"></div>
+<div fxHide></div>
+<div fxHide=""></div>
+<div fxHide="false"></div>
+<div fxHide="0"></div>
+<div fxHide="FALSE"></div>
+
+<!-- standard viewport aliases -->
+<div fxHide.xs></div>
+<div fxHide.sm></div>
+<div fxHide.md></div>
+<div fxHide.lg></div>
+<div fxHide.xl></div>
+<div fxHide.lt-sm></div>
+<div fxHide.lt-md></div>
+<div fxHide.lt-lg></div>
+<div fxHide.lt-xl></div>
+<div fxHide.gt-xs></div>
+<div fxHide.gt-sm></div>
+<div fxHide.gt-md></div>
+<div fxHide.gt-lg></div>
+
+<!-- complete-family state planning -->
+<div fxShow fxHide.sm></div>
+<div fxHide.xs fxShow.md></div>
+<div fxHide.lt-md fxShow.sm="false"></div>
+<div fxHide.gt-xs fxShow.sm></div>
+<div fxShow fxHide="false"></div>
+<div fxShow fxHide></div>
+
+<!-- restoration, layout composition, and safe no-ops -->
+<div class="block" fxShow="false" fxShow.sm></div>
+<div fxLayout="column" fxShow="false" fxShow.sm></div>
+<div fxLayout.sm="column" fxHide.sm></div>
+<div fxLayout="row" fxHide></div>
+<div fxLayout="row inline" fxShow="false" fxShow.gt-xs></div>
+<div fxShow fxHide.sm="false"></div>
+
+<!-- existing display and class behavior -->
+<div class="hidden" fxHide></div>
+<div class="block" fxHide.sm></div>
+<div class="block" fxHide></div>
+<div class="hidden" fxShow></div>
+<div class="block flex" fxShow="false" fxShow.sm></div>
+<div class="hover:block" fxShow="false" fxShow.sm></div>
+<div style="display: inline" fxHide></div>
+<div [style.display]="display" fxHide></div>
+<div [style]="styles" fxShow></div>
+<div [class]="classes" fxHide></div>
+<div [class]="classes" fxShow></div>
+<div [class.hidden]="hidden" fxShow="false"></div>
+
+<!-- dynamic and unsupported family members -->
+<div [fxShow]="visible"></div>
+<div fxHide="{{ hidden }}"></div>
+<div fxShow fxHide.handset.landscape fxShow.print fxHide.cinema [fxShow.sm]="visible"></div>
+<div fxLayout="row" [fxHide]="hidden"></div>
+<div class="flex-col" fxLayout="row" fxShow="false" fxShow.sm></div>

--- a/test/tailwind/responsive-variant-compilation.test.ts
+++ b/test/tailwind/responsive-variant-compilation.test.ts
@@ -67,6 +67,14 @@ function composedCandidates(states: readonly VisibilityState[], layout: PlannedC
   return result.plans.flatMap(plan => (plan.status === 'converted' ? plan.classNames : []));
 }
 
+function compose(states: readonly VisibilityState[], layout: PlannedConversion) {
+  return new DisplayCompositionPlanner().compose({
+    visibilityPlan: { status: 'converted', states },
+    displayResolution: { status: 'resolved', utility: undefined },
+    layoutPlans: [layout],
+  });
+}
+
 function mediaBlock(css: string, query: string): string {
   const marker = `@media ${query} {`;
   const start = css.indexOf(marker);
@@ -138,4 +146,26 @@ describe('Tailwind CSS v4 arbitrary media variants', () => {
     expect(responsiveRule).toContain('flex-direction: row');
     expect(responsiveRule).not.toContain('display: flex');
   });
+
+  test.each([
+    ['nested max-only', 'lt-md', 'lt-sm', 'screen and (max-width: 959.98px)', 'screen and (max-width: 599.98px)'],
+    ['crossing min/max', 'gt-xs', 'lt-md', 'screen and (min-width: 600px)', 'screen and (max-width: 959.98px)'],
+  ])(
+    'preserves %s partial overlap when compiled layout display can override hiding',
+    async (_case, layoutAlias, hideAlias, layoutQuery, hideQuery) => {
+      const responsiveFlex = responsiveUtility(layoutAlias, 'flex');
+      const responsiveHidden = responsiveUtility(hideAlias, 'hidden');
+      const unsafeCss = await compileCandidates([responsiveFlex, responsiveHidden]);
+      const flexRule = mediaBlock(unsafeCss, layoutQuery);
+      const hiddenRule = mediaBlock(unsafeCss, hideQuery);
+
+      expect(flexRule).toContain('display: flex');
+      expect(hiddenRule).toContain('display: none');
+      expect(unsafeCss.indexOf(flexRule)).toBeGreaterThan(unsafeCss.indexOf(hiddenRule));
+
+      const result = compose([visibilityState('hidden', hideAlias)], layoutPlan(layoutAlias));
+      expect(result).toMatchObject({ status: 'unresolved' });
+      expect(result.plans.every(plan => plan.status === 'review' && plan.code === 'context-unverified')).toBe(true);
+    },
+  );
 });

--- a/test/tailwind/responsive-variant-compilation.test.ts
+++ b/test/tailwind/responsive-variant-compilation.test.ts
@@ -1,6 +1,9 @@
 import { compile } from 'tailwindcss';
 import { BreakpointCatalog, type BreakpointDefinition } from '../../src/breakpoint/breakpoint-catalog';
+import type { LocatedFlexLayoutInput } from '../../src/analyzer/flex-layout-attribute.analyzer';
 import { ResponsiveVariantEmitter } from '../../src/adapter/tailwind/responsive-variant.emitter';
+import { VisibilityEmitter } from '../../src/adapter/tailwind/visibility/visibility.emitter';
+import type { VisibilityIntent, VisibilityState } from '../../src/adapter/tailwind/visibility/visibility.model';
 
 function definition(alias: string): BreakpointDefinition {
   const classification = new BreakpointCatalog().classify(alias);
@@ -13,6 +16,40 @@ function definition(alias: string): BreakpointDefinition {
 async function compileCandidates(candidates: readonly string[]): Promise<string> {
   const compiler = await compile('@tailwind utilities;');
   return compiler.build([...candidates]);
+}
+
+function visibilityState(intent: VisibilityIntent, alias?: string): VisibilityState {
+  const sourceName = `fxShow${alias === undefined ? '' : `.${alias}`}`;
+  const input: LocatedFlexLayoutInput = {
+    id: `fixture:${sourceName}`,
+    fileName: 'fixture.html',
+    elementId: '0',
+    sourceName,
+    directive: 'fxShow',
+    value: '',
+    binding: 'literal',
+    breakpoint: alias,
+    source: { start: 0, end: 1 },
+    nameSource: { start: 0, end: 1 },
+  };
+  return alias === undefined
+    ? { input, intent, activation: { kind: 'base' } }
+    : { input, intent, activation: { kind: 'media', definition: definition(alias) } };
+}
+
+function mediaBlock(css: string, query: string): string {
+  const marker = `@media ${query} {`;
+  const start = css.indexOf(marker);
+  if (start < 0) throw new Error(`Expected compiled CSS to contain ${marker}`);
+
+  let depth = 0;
+  for (let index = start; index < css.length; index += 1) {
+    if (css[index] === '{') depth += 1;
+    if (css[index] !== '}') continue;
+    depth -= 1;
+    if (depth === 0) return css.slice(start, index + 1);
+  }
+  throw new Error(`Expected ${marker} to contain a complete block.`);
 }
 
 describe('Tailwind CSS v4 arbitrary media variants', () => {
@@ -28,5 +65,30 @@ describe('Tailwind CSS v4 arbitrary media variants', () => {
     expect(css).toContain('@media screen and (max-width: 599.98px)');
     expect(css).toContain('@media screen and (min-width: 600px) and (max-width: 959.98px)');
     expect(css).toContain('flex-direction: column');
+  });
+
+  test('compiles visibility display ownership in base, bounded, min-only, and max-only activations', async () => {
+    const emitter = new VisibilityEmitter();
+    const css = await compileCandidates([
+      ...emitter.emit(visibilityState('hidden'), undefined),
+      ...emitter.emit(visibilityState('hidden', 'sm'), undefined),
+      ...emitter.emit(visibilityState('shown', 'gt-xs'), 'flex'),
+      ...emitter.emit(visibilityState('shown', 'lt-sm'), 'inline-flex'),
+    ]);
+
+    expect(css).toMatch(/\.hidden\s*\{\s*display: none;\s*\}/u);
+    expect(mediaBlock(css, 'screen and (min-width: 600px) and (max-width: 959.98px)')).toContain('display: none');
+    expect(mediaBlock(css, 'screen and (min-width: 600px)')).toContain('display: flex');
+    expect(mediaBlock(css, 'screen and (max-width: 599.98px)')).toContain('display: inline-flex');
+  });
+
+  test('keeps a base layout display while responsive hidden owns the exact bounded range', async () => {
+    const emitter = new VisibilityEmitter();
+    const css = await compileCandidates(['flex', ...emitter.emit(visibilityState('hidden', 'sm'), undefined)]);
+    const responsiveRule = mediaBlock(css, 'screen and (min-width: 600px) and (max-width: 959.98px)');
+
+    expect(css).toMatch(/\.flex\s*\{\s*display: flex;\s*\}/u);
+    expect(responsiveRule).toContain('display: none');
+    expect(css.indexOf(responsiveRule)).toBeGreaterThan(css.indexOf('.flex'));
   });
 });

--- a/test/tailwind/responsive-variant-compilation.test.ts
+++ b/test/tailwind/responsive-variant-compilation.test.ts
@@ -1,7 +1,9 @@
 import { compile } from 'tailwindcss';
 import { BreakpointCatalog, type BreakpointDefinition } from '../../src/breakpoint/breakpoint-catalog';
 import type { LocatedFlexLayoutInput } from '../../src/analyzer/flex-layout-attribute.analyzer';
+import type { PlannedConversion } from '../../src/adapter/conversion-adapter';
 import { ResponsiveVariantEmitter } from '../../src/adapter/tailwind/responsive-variant.emitter';
+import { DisplayCompositionPlanner } from '../../src/adapter/tailwind/visibility/display-composition.planner';
 import { VisibilityEmitter } from '../../src/adapter/tailwind/visibility/visibility.emitter';
 import type { VisibilityIntent, VisibilityState } from '../../src/adapter/tailwind/visibility/visibility.model';
 
@@ -35,6 +37,34 @@ function visibilityState(intent: VisibilityIntent, alias?: string): VisibilitySt
   return alias === undefined
     ? { input, intent, activation: { kind: 'base' } }
     : { input, intent, activation: { kind: 'media', definition: definition(alias) } };
+}
+
+function responsiveUtility(alias: string, utility: string): string {
+  return new ResponsiveVariantEmitter().emit(definition(alias), utility);
+}
+
+function layoutPlan(alias: string): PlannedConversion {
+  return {
+    status: 'converted',
+    input: {
+      ...visibilityState('shown', alias).input,
+      id: `fixture:fxLayout.${alias}`,
+      sourceName: `fxLayout.${alias}`,
+      directive: 'fxLayout',
+      value: 'row',
+    },
+    classNames: [responsiveUtility(alias, 'flex'), responsiveUtility(alias, 'flex-row')],
+  };
+}
+
+function composedCandidates(states: readonly VisibilityState[], layout: PlannedConversion): readonly string[] {
+  const result = new DisplayCompositionPlanner().compose({
+    visibilityPlan: { status: 'converted', states },
+    displayResolution: { status: 'resolved', utility: undefined },
+    layoutPlans: [layout],
+  });
+  if (result.status !== 'converted') throw new Error('Expected display composition to convert.');
+  return result.plans.flatMap(plan => (plan.status === 'converted' ? plan.classNames : []));
 }
 
 function mediaBlock(css: string, query: string): string {
@@ -90,5 +120,22 @@ describe('Tailwind CSS v4 arbitrary media variants', () => {
     expect(css).toMatch(/\.flex\s*\{\s*display: flex;\s*\}/u);
     expect(responsiveRule).toContain('display: none');
     expect(css.indexOf(responsiveRule)).toBeGreaterThan(css.indexOf('.flex'));
+  });
+
+  test('suppresses a responsive layout display that would otherwise override inherited base hiding', async () => {
+    const responsiveFlex = responsiveUtility('sm', 'flex');
+    const unsafeCss = await compileCandidates(['hidden', responsiveFlex]);
+    const unsafeResponsiveRule = mediaBlock(unsafeCss, 'screen and (min-width: 600px) and (max-width: 959.98px)');
+
+    expect(unsafeResponsiveRule).toContain('display: flex');
+    expect(unsafeCss.indexOf(unsafeResponsiveRule)).toBeGreaterThan(unsafeCss.indexOf('.hidden'));
+
+    const candidates = composedCandidates([visibilityState('hidden')], layoutPlan('sm'));
+    const css = await compileCandidates(candidates);
+    const responsiveRule = mediaBlock(css, 'screen and (min-width: 600px) and (max-width: 959.98px)');
+
+    expect(candidates).not.toContain(responsiveFlex);
+    expect(responsiveRule).toContain('flex-direction: row');
+    expect(responsiveRule).not.toContain('display: flex');
   });
 });


### PR DESCRIPTION
## Summary

Add exact, conservative Tailwind CSS v4 conversion for literal `fxShow` and `fxHide` families.

- model visibility as an atomic element-level state machine across base and all 13 verified viewport aliases
- prove visible display restoration from converted layout output or an unambiguous existing display utility
- compose layout and visibility display ownership before class/style conflict checks and dependency closure
- preserve dynamic, custom, print, orientation, ambiguous overlap, unsafe restoration, and responsive class/style authority cases for review
- document the supported boundary and add a minor Changeset

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

Final local evidence:

- 47 test files and 536 tests passed
- coverage: 92.12% statements, 87.50% branches, 97.29% functions, 94.76% lines
- `npm audit --audit-level=high`: 0 vulnerabilities
- package dry run: exactly 6 intended files
- tracked control-file and executable Tailwind-import scans: no matches

## Migration example

Before:

```html
<div fxLayout="row" fxHide.lt-md fxShow.lt-sm="false"></div>
```

After:

```html
<div class="flex flex-row max-[959.98px]:hidden"></div>
```

Conversions are emitted only when visibility state, responsive precedence, and visible display restoration are fully provable. Unsafe partial overlaps remain unchanged for manual review.

## Dependencies and compatibility

- No runtime dependencies added.
- Tailwind CSS v4 remains the sole output target.
- Node.js, Angular compiler, and package boundaries are unchanged.
- Literal `fxShow` and `fxHide` support is limited to base plus the 13 verified standard viewport aliases.
