### PR TITLE
test: keep CLI version assertion release-safe

### DIFF
--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -3,6 +3,7 @@ import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { promisify } from 'node:util';
+import packageJson from '../../package.json' with { type: 'json' };
 
 const execFileAsync = promisify(execFile);
 const repository = resolve(import.meta.dirname, '../..');
@@ -52,7 +53,7 @@ describe('packaged CLI execution', () => {
   test('prints the package version without rendering a banner', async () => {
     const result = await execute(['--version']);
 
-    expect(result).toMatchObject({ status: 0, stdout: '2.0.0-beta.0\n', stderr: '' });
+    expect(result).toMatchObject({ status: 0, stdout: `${packageJson.version}\n`, stderr: '' });
     expect(result.stdout).not.toContain('Flex-Layout Migrator');
   });
 


### PR DESCRIPTION
## Summary

Fix the packaged CLI integration test so `--version` is checked against the repository manifest instead of a hardcoded prerelease number.

The first Changesets release PR correctly changes the version to `2.0.0-beta.1`; the old assertion incorrectly required `2.0.0-beta.0` and blocked every future version bump.

## Verification

- [x] The original failure was observed on release PR #33: expected `2.0.0-beta.0`, received `2.0.0-beta.1`.
- [x] Focused packaged CLI suite passes: 4/4.
- [x] `npm run verify` passes: 60 files, 2,001 tests.
- [x] `npm audit --audit-level=high` reports zero vulnerabilities.
- [x] Diff is limited to the release-sensitive assertion.

## Migration example

Not applicable.

## Dependencies and compatibility

None.