### PR TITLE
docs: improve onboarding and compatibility inventory

### DIFF
--- a/.changeset/clear-guides-map.md
+++ b/.changeset/clear-guides-map.md
@@ -1,0 +1,5 @@
+---
+'@nipe-solutions/flex-layout-codemod': patch
+---
+
+Add an executable compatibility inventory and rewrite beta onboarding around safe previews, pinned team installation, exact support boundaries, and copyable CLI workflows.

--- a/README.md
+++ b/README.md
@@ -1,90 +1,100 @@
 # Angular Flex-Layout Codemod
 
-A safety-first codemod for migrating projects away from the archived Angular Flex-Layout library.
+Version 2 remains a prerelease. This beta migrates supported Angular Flex-Layout template attributes to Tailwind CSS v4 utilities. It uses the Angular compiler and source-range edits, preserving unrelated template text, comments, interpolation, control flow, and line endings.
 
-Version 2 remains a prerelease under active development. It does not claim production-ready conversion coverage. See the [compatibility reference](docs/compatibility.md) for the current directive-by-directive status and safety limitations.
+## Why this exists
 
-Install a published v2 beta as a development dependency with `npm install --save-dev @nipe-solutions/flex-layout-codemod@beta`. Maintainers should follow the reviewed [release process](docs/architecture/release-process.md); merging a version pull request does not publish the package.
+Angular Flex-Layout is archived. Replacing it safely requires more than substituting class names: responsive aliases, display restoration, existing classes, inline styles, and runtime bindings can change the result. This codemod converts only cases it can represent exactly and leaves the rest in place with diagnostics for review.
 
-## Current scope
+## Compatibility at a glance
 
-The v2 engine parses templates with the Angular compiler and applies validated source-range edits. It preserves comments, control-flow syntax, interpolation, line endings, and all unrelated source text instead of serializing the template as generic HTML.
+The current target is Tailwind CSS v4. It converts supported static Flex-Layout inputs and literal responsive inputs using the standard viewport aliases. Conversion is deliberately limited: dynamic bindings, ambiguous responsive precedence, unsafe class or style ownership, and unsupported directives are preserved for review.
 
-The current prerelease converts documented static inputs and literal responsive inputs using the standard Angular Flex-Layout viewport aliases (`xs` through `xl`, `lt-*`, and `gt-*`) to exact Tailwind CSS v4 arbitrary media variants. For example, `fxLayout.sm="row"` becomes `[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-row` alongside the other layout utilities. Dynamic bindings, orientation, print, and custom breakpoints, unsupported directives, and responsive families with conflicting overlapping values remain unchanged with structured review results. Ambiguous behavior is never approximated silently.
+The complete directive-by-directive status, including grid, image, breakpoint, and class/style boundaries, is in [docs/compatibility.md](docs/compatibility.md). Treat that reference as the beta’s compatibility contract.
 
-Literal responsive `ngClass.<alias>` and `ngStyle.<alias>` values use the same 13-alias boundary. Class values are split with Angular `NgClass`'s ECMAScript-whitespace rule and convert only when every token is in the compiler-proven built-in Tailwind CSS v4 surface, retains the host element as its CSS target, and can be emitted byte-for-byte for Tailwind's raw template scanner. Style declarations convert to arbitrary-property utilities only when Flex-Layout's quote removal, semicolon splitting, exact-key application order, Angular unit handling, CSS priority, fallback ownership, and responsive precedence can be represented exactly. Distinct exact ordinary keys that apply to the same CSS property, including `font-size` and `font-size.px`, are preserved because their result can depend on `NgStyle` activation history. Unsuffixed `ngClass` and `ngStyle` siblings are treated as replaceable fallback authorities rather than silently left as always-active values.
+## Quick start
+
+Evaluate the published beta without installing it. This safely previews the migration and does not write templates:
+
+```bash
+npx @nipe-solutions/flex-layout-codemod@beta ./src --dry-run
+```
+
+Read the terminal summary and diagnostics before applying any migration. A clean Git worktree makes the resulting template diff easy to inspect.
+
+## Install for a team or CI
+
+Install the beta as an exact development dependency. `--save-exact` records the prerelease resolved from the `beta` tag, so the package manifest and lockfile keep the team on that reviewed version:
+
+```bash
+npm install --save-dev --save-exact @nipe-solutions/flex-layout-codemod@beta
+```
+
+Use `npm ci` in CI to install the committed lockfile. The package exposes the `flex-layout-codemod` executable through the local npm binary path; no global installation is required.
+
+## Preview, review, and apply
+
+Preview the local dependency and write a JSON report for review:
+
+```bash
+npx flex-layout-codemod ./src --dry-run --report ./reports/flex-layout.json
+```
+
+`--dry-run` validates the planned edits in memory and does not write template output. `--report` is intentional reporting output and is written even during a dry run.
+
+After reviewing the report and committing or branching your work, apply the migration in place:
+
+```bash
+npx flex-layout-codemod ./src --target tailwind
+```
+
+The current beta writes changed templates in place when neither `--dry-run` nor `--output` is supplied. To write migrated templates to a different location, add `--output ./migrated-src`. Review the Git diff before accepting the changes.
+
+## Examples
+
+This converted example is the same static layout and gap case exercised by the migration fixtures:
 
 ```html
 <!-- input -->
-<div ngClass.sm="flex items-center"></div>
-<div ngStyle.lt-md="font-size.px: 14; color: #334155"></div>
+<div fxLayout="column" fxLayoutGap="4"></div>
 
 <!-- output -->
-<div
-  class="[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:items-center"
-></div>
-<div
-  class="[@media_screen_and_(max-width:_959.98px)]:[font-size:14px] [@media_screen_and_(max-width:_959.98px)]:[color:#334155]"
-></div>
+<div class="flex flex-col box-border gap-[4px]"></div>
 ```
 
-Application classes, project plugin utilities, custom-theme-dependent candidates such as `bg-brand-500`, unsafe style values, bindings, interpolation, and deprecated `class.<alias>` or `style.<alias>` selectors remain in place with review diagnostics. The current mode does not inspect project styles or Tailwind configuration and does not generate a companion stylesheet.
-
-Existing literal classes use a broader conservative ownership check than generated-candidate admission. Compiler-modeled Tailwind utilities contribute every stable declaration they emit, including inferred arbitrary text sizes, directional border style/width pairs, and shadow color custom properties. A recognized pinned Tailwind utility whose complete property set is not modeled is treated as an unknown CSS authority and blocks an intersecting conversion instead of being silently ignored; ordinary application classes such as `card` remain additive.
-
-Literal `fxShow` and `fxHide` inputs are converted when the element's complete display behavior is provable. The conversion follows Angular Flex-Layout coercion: `fxShow="false"` hides, `fxHide="false"` shows, and other literal strings, including `"0"`, are truthy before `fxHide` inversion. Literal values use Angular-decoded text, so an entity-spelled value such as `fals&#101;` has the same semantics as `false`. Hiding uses `hidden`; a responsive shown state after base hiding restores only a display value proven by a converted `fxLayout` or one unambiguous base Tailwind display utility.
+This fixture is intentionally preserved because the value is a runtime Angular expression. The report records a `dynamic-binding` review diagnostic and the source remains unchanged:
 
 ```html
-<!-- input -->
-<div fxLayout="column" fxShow="false" fxShow.sm></div>
-
-<!-- output -->
-<div
-  class="flex flex-col box-border hidden [@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex"
-></div>
+<div [fxFlex]="basis"></div>
 ```
 
-The complete visibility family is preserved when it contains a binding or interpolation, an orientation, print, or custom alias, conflicting overlapping states, an unverified restoration display, a partially overlapping responsive layout display without safe ownership, or an unsafe class/style interaction. A literal or bound style that can control `display` always blocks conversion. An unresolved responsive class or style authority also preserves related visibility output when it may control `display`. A bound class blocks a family that needs generated classes, but does not block an all-shown no-op whose attributes can simply be removed. See the [compatibility reference](docs/compatibility.md) and [visibility architecture](docs/architecture/visibility-semantics.md) for the exact boundary.
+## Reports and exit codes
 
-## CLI workflow
+Reports use JSON schema version `1` and include per-file results, diagnostics, and a summary. Use them to review preserved cases and to track the migration over multiple branches.
 
-Run the codemod for one Angular template or a directory:
+The default exit policy is strict:
+
+| Code | Meaning                                                                               |
+| ---: | ------------------------------------------------------------------------------------- |
+|  `0` | Migration completed without unresolved results.                                       |
+|  `1` | Configuration, parsing, template I/O, report writing, or an internal error failed.    |
+|  `2` | Migration completed safely, but `review`, `unsupported`, or `invalid` results remain. |
+
+For an informational CI report that accepts unresolved work while retaining every diagnostic, use:
 
 ```bash
-flex-layout-codemod ./src --target tailwind --output ./migrated-src
+npx flex-layout-codemod ./src --dry-run --report ./reports/flex-layout.json --allow-unresolved
 ```
 
-Preview the same migration plan without writing templates, while also creating a JSON report:
+`--allow-unresolved` changes only the final exit code; it does not hide diagnostics or alter the migration output.
 
-```bash
-flex-layout-codemod ./src --target tailwind --output ./migrated-src --dry-run --report ./reports/flex-layout.json
-```
+## Known boundaries
 
-Only changed `.html` files are written during a real migration. For a single-file input, the planned output path must end in `.html` (case-insensitive); omitting `--output` keeps the default in-place behavior. For a folder input, `--output` remains a directory and each derived template output retains its `.html` path. `--dry-run` applies and validates edits in memory but does not write template output or create its missing parent directories. A requested `--report <path>` is an explicit reporting side effect and is still written atomically during a dry-run. The report path must be nonblank and end in `.json` (case-insensitive). Migratable inputs and planned template outputs exclusively use `.html`, so this structural rule prevents report collisions while allowing reports anywhere, including inside input or output trees. Invalid output and report paths are rejected before migration without creating output or report directories.
+This beta has a Tailwind CSS v4 target only; a native CSS target is not implemented. Grid directives and responsive `imgSrc` are recognized and reported but remain unchanged. Orientation, print, and custom breakpoint aliases are preserved. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
 
-Unresolved `review`, `unsupported`, or `invalid` results are strict by default. To preserve the same diagnostics and migration output while accepting unresolved work in automation, use:
+The codemod does not inspect project styles, Tailwind configuration, Sass, Less, or CSS, and it does not generate a companion stylesheet. Dynamic Angular bindings are not evaluated.
 
-```bash
-flex-layout-codemod ./src --dry-run --allow-unresolved
-```
-
-The CLI uses these exit codes:
-
-| Code | Meaning                                                                                |
-| ---: | -------------------------------------------------------------------------------------- |
-|  `0` | Migration completed with no unresolved results, or `--allow-unresolved` accepted them. |
-|  `1` | Configuration, parsing, template I/O, report writing, or an internal invariant failed. |
-|  `2` | Migration completed safely, but unresolved results remain in strict mode.              |
-
-JSON reports use schema version `1`. Report paths use forward slashes and are relative to the input root; a single-file input is represented by its basename, never an absolute checkout path. Files are path-sorted, results retain source order, and the summary is derived from those file results.
-
-Each non-parse report result represents one source directive occurrence. Measure responsive class and style adoption by counting `ngClass`, `ngStyle`, `class`, and `style` results by status in a representative migration report. This occurrence ratio is an inventory of the scanned templates, not a claim that the same percentage of an application or its runtime behavior was converted.
-
-Use version control and review the generated diff before replacing application templates. Native CSS output remains outside the current scope.
-
-The TypeScript extension API changed in v2: mutable Cheerio converters were replaced by immutable `ConversionAdapter` plans and structured `ConversionResult` values. These prerelease APIs may continue to evolve before v2 is stable.
-
-## Development
+## Contributing and support
 
 The repository requires Node.js 24 and npm 11.
 
@@ -93,7 +103,7 @@ npm ci
 npm run verify
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Security reports belong in [GitHub private vulnerability reporting](https://github.com/NIPE-Solutions/flex-layout-migrator/security/advisories/new); other support routes are documented in [docs/SUPPORT.md](docs/SUPPORT.md).
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Security reports belong in [GitHub private vulnerability reporting](https://github.com/NIPE-Solutions/flex-layout-migrator/security/advisories/new); other support routes are listed in [docs/SUPPORT.md](docs/SUPPORT.md). Maintainers should follow the reviewed [release process](docs/architecture/release-process.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ After reviewing the report and committing or branching your work, apply the migr
 npx flex-layout-codemod ./src --target tailwind
 ```
 
-The current beta writes changed templates in place when neither `--dry-run` nor `--output` is supplied. To write migrated templates to a different location, add `--output ./migrated-src`. Review the Git diff before accepting the changes.
+The current beta writes changed templates in place when neither `--dry-run` nor `--output` is supplied. To write migrated templates to a different location, add `--output ./migrated-src`. Review the Git diff before accepting the changes. If an in-place run is unwanted, inspect `git diff` before taking further action, then restore only the intended files deliberately through your normal Git workflow from a clean worktree or committed branch.
 
 ## Examples
 
@@ -74,11 +74,11 @@ Reports use JSON schema version `1` and include per-file results, diagnostics, a
 
 The default exit policy is strict:
 
-| Code | Meaning                                                                               |
-| ---: | ------------------------------------------------------------------------------------- |
-|  `0` | Migration completed without unresolved results.                                       |
-|  `1` | Configuration, parsing, template I/O, report writing, or an internal error failed.    |
-|  `2` | Migration completed safely, but `review`, `unsupported`, or `invalid` results remain. |
+| Code | Meaning                                                                                 |
+| ---: | --------------------------------------------------------------------------------------- |
+|  `0` | Migration completed cleanly, or unresolved work was accepted with `--allow-unresolved`. |
+|  `1` | Configuration, parsing, template I/O, report writing, or an internal invariant failed.  |
+|  `2` | Migration completed safely, but `review`, `unsupported`, or `invalid` results remain.   |
 
 For an informational CI report that accepts unresolved work while retaining every diagnostic, use:
 
@@ -90,7 +90,7 @@ npx flex-layout-codemod ./src --dry-run --report ./reports/flex-layout.json --al
 
 ## Known boundaries
 
-This beta has a Tailwind CSS v4 target only; a native CSS target is not implemented. Grid directives and responsive `imgSrc` are recognized and reported but remain unchanged. Orientation, print, and custom breakpoint aliases are preserved. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
+This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Grid directives and responsive `imgSrc` are recognized, reported, and remain unchanged. Orientation, print, and custom breakpoint aliases remain preserved for review. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
 
 The codemod does not inspect project styles, Tailwind configuration, Sass, Less, or CSS, and it does not generate a companion stylesheet. Dynamic Angular bindings are not evaluated.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,31 +4,52 @@ Version 2 is prerelease software. Its current conversion coverage is deliberatel
 
 The source contract and classification rules are documented in [Conversion safety model](architecture/conversion-safety.md).
 
-## Status definitions
+## Current compatibility status
 
-- **Limited**: unbound literal values are converted for the cases described below and covered by the compatibility corpus. Standard responsive viewport aliases are supported when their complete semantic family is safe.
-- **Planned**: the analyzer recognizes the input, but no target adapter converts it yet.
-- **Preserved**: the input is intentionally left unchanged and reported for review.
+- **Limited**: available now for the literal, safety-proven cases described below. Standard responsive viewport aliases convert only when their complete semantic family is safe.
+- **Preserved**: recognized input intentionally left unchanged and reported for review.
+- **Planned**: recognized input for which that target has no conversion available now.
+- **Not applicable**: the directive does not have a conversion in that target category.
 
-No native CSS conversions are available yet. The CLI currently accepts only the `tailwind` target, and generated classes target Tailwind CSS v4.
+The Tailwind CSS 4 column identifies current target behavior. Native CSS and responsive-image statuses marked Planned are not current capabilities; their product direction is described in the [Version 2 product roadmap](architecture/v2-product-roadmap.md). No native CSS conversions are available yet. The CLI currently accepts only the `tailwind` target, and generated classes target Tailwind CSS v4.
 
-## Flex directives
+<!-- compatibility-inventory:start -->
 
-| Directive       | Tailwind | Notes                                                                                                                       |
-| --------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `fxLayout`      | Limited  | Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.                              |
-| `fxLayoutAlign` | Limited  | Static main/cross axes with layout, content alignment, sizing, and border-box semantics.                                    |
-| `fxLayoutGap`   | Limited  | Static nonnegative non-wrapping gaps; unitless values remain pixels. Grid, computed, negative, and wrapped gaps are review. |
-| `fxFlex`        | Limited  | Static basis, keyword, and three-part forms with parent-axis min/max sizing.                                                |
-| `fxGrow`        | Limited  | Converted atomically with a static `fxFlex`; standalone use is invalid.                                                     |
-| `fxShrink`      | Limited  | Converted atomically with a static `fxFlex`; standalone use is invalid.                                                     |
-| `fxFlexAlign`   | Limited  | Static `align-self` keywords.                                                                                               |
-| `fxFlexFill`    | Limited  | Static full-size rule including its zero-margin behavior.                                                                   |
-| `fxFill`        | Limited  | Non-responsive alias of `fxFlexFill`.                                                                                       |
-| `fxFlexOffset`  | Limited  | Static values with a statically known parent axis; unitless values remain percentages.                                      |
-| `fxFlexOrder`   | Limited  | Static integer values emitted independently of the Tailwind theme.                                                          |
-| `fxShow`        | Limited  | Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.     |
-| `fxHide`        | Limited  | Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.  |
+| Directive        | Family      | Tailwind CSS 4 | Native CSS     | Responsive image |
+| ---------------- | ----------- | -------------- | -------------- | ---------------- |
+| `fxLayout`       | Flex        | Limited        | Planned        | Not applicable   |
+| `fxLayoutAlign`  | Flex        | Limited        | Planned        | Not applicable   |
+| `fxLayoutGap`    | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFlex`         | Flex        | Limited        | Planned        | Not applicable   |
+| `fxGrow`         | Flex        | Limited        | Planned        | Not applicable   |
+| `fxShrink`       | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFlexAlign`    | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFlexFill`     | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFill`         | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFlexOffset`   | Flex        | Limited        | Planned        | Not applicable   |
+| `fxFlexOrder`    | Flex        | Limited        | Planned        | Not applicable   |
+| `fxShow`         | Visibility  | Limited        | Planned        | Not applicable   |
+| `fxHide`         | Visibility  | Limited        | Planned        | Not applicable   |
+| `gdAlignColumns` | Grid        | Planned        | Planned        | Not applicable   |
+| `gdAlignRows`    | Grid        | Planned        | Planned        | Not applicable   |
+| `gdArea`         | Grid        | Planned        | Planned        | Not applicable   |
+| `gdAreas`        | Grid        | Planned        | Planned        | Not applicable   |
+| `gdAuto`         | Grid        | Planned        | Planned        | Not applicable   |
+| `gdColumn`       | Grid        | Planned        | Planned        | Not applicable   |
+| `gdColumns`      | Grid        | Planned        | Planned        | Not applicable   |
+| `gdGap`          | Grid        | Planned        | Planned        | Not applicable   |
+| `gdGridAlign`    | Grid        | Planned        | Planned        | Not applicable   |
+| `gdRow`          | Grid        | Planned        | Planned        | Not applicable   |
+| `gdRows`         | Grid        | Planned        | Planned        | Not applicable   |
+| `class`          | Class/style | Preserved      | Preserved      | Not applicable   |
+| `ngClass`        | Class/style | Limited        | Planned        | Not applicable   |
+| `style`          | Class/style | Preserved      | Preserved      | Not applicable   |
+| `ngStyle`        | Class/style | Limited        | Planned        | Not applicable   |
+| `imgSrc`         | Image       | Not applicable | Not applicable | Planned          |
+
+<!-- compatibility-inventory:end -->
+
+## Current Tailwind CSS 4 safety boundaries
 
 All generated lengths that originate in the template use Tailwind arbitrary values. This prevents a project spacing scale from changing `fxLayoutGap="4"` from Angular Flex-Layout's `4px`, or `fxFlexOffset="4"` from its `4%` meaning.
 
@@ -65,29 +86,7 @@ When layout and visibility both control `display`, the planner composes them bef
 
 All grid directives are recognized and preserved. Target conversion has not been implemented.
 
-| Directive        | Tailwind |
-| ---------------- | -------- |
-| `gdAlignColumns` | Planned  |
-| `gdAlignRows`    | Planned  |
-| `gdArea`         | Planned  |
-| `gdAreas`        | Planned  |
-| `gdAuto`         | Planned  |
-| `gdColumn`       | Planned  |
-| `gdColumns`      | Planned  |
-| `gdGap`          | Planned  |
-| `gdGridAlign`    | Planned  |
-| `gdRow`          | Planned  |
-| `gdRows`         | Planned  |
-
-## Extended responsive inputs
-
-| Input                      | Tailwind  | Notes                                                                                |
-| -------------------------- | --------- | ------------------------------------------------------------------------------------ |
-| literal `ngClass.<alias>`  | Limited   | Converts complete families whose class tokens are proven Tailwind CSS v4 candidates. |
-| literal `ngStyle.<alias>`  | Limited   | Converts complete, sanitizer-safe declaration lists with exact CSS ownership.        |
-| deprecated `class.<alias>` | Preserved | Version-dependent replacement and merge behavior is not inferred.                    |
-| deprecated `style.<alias>` | Preserved | Version-dependent replacement and merge behavior is not inferred.                    |
-| responsive `imgSrc`        | Planned   | Recognized and reported; no target conversion is implemented.                        |
+## Responsive class and style inputs
 
 The supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`. Each emitted class contains the exact Angular Flex-Layout media range rather than a project-defined Tailwind breakpoint.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -51,6 +51,21 @@ The Tailwind CSS 4 column identifies current target behavior. Native CSS and res
 
 ## Current Tailwind CSS 4 safety boundaries
 
+### Available now: directive-specific boundaries
+
+- `fxLayout`: Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.
+- `fxLayoutAlign`: Static main/cross axes with layout, content alignment, sizing, and border-box semantics.
+- `fxLayoutGap`: Static nonnegative non-wrapping gaps; unitless values remain pixels. Grid, computed, negative, and wrapped gaps are review.
+- `fxFlex`: Static basis, keyword, and three-part forms with parent-axis min/max sizing.
+- `fxGrow` and `fxShrink`: Converted atomically with a static `fxFlex`; standalone use is invalid.
+- `fxFlexAlign`: Static `align-self` keywords.
+- `fxFlexFill`: Static full-size rule including its zero-margin behavior.
+- `fxFill`: Non-responsive alias of `fxFlexFill`.
+- `fxFlexOffset`: Static values with a statically known parent axis; unitless values remain percentages.
+- `fxFlexOrder`: Static integer values emitted independently of the Tailwind theme.
+- `fxShow`: Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.
+- `fxHide`: Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.
+
 All generated lengths that originate in the template use Tailwind arbitrary values. This prevents a project spacing scale from changing `fxLayoutGap="4"` from Angular Flex-Layout's `4px`, or `fxFlexOffset="4"` from its `4%` meaning.
 
 The complete static semantic and diagnostic contract is documented in [Tailwind CSS v4 static conversion semantics](architecture/tailwind-v4-static-semantics.md).
@@ -59,7 +74,7 @@ If an existing recognized Tailwind utility conflicts with a generated class in a
 
 ## Visibility semantics
 
-`fxShow` and `fxHide` are planned together as one atomic visibility family per element. Literal values use Angular Flex-Layout's coercion and inversion rules:
+`fxShow` and `fxHide` are currently converted together as one atomic visibility family per element. Literal values use Angular Flex-Layout's coercion and inversion rules. Additional visibility behavior that cannot meet these current safety conditions remains preserved for review:
 
 | Input            | Resulting state |
 | ---------------- | --------------- |
@@ -87,6 +102,11 @@ When layout and visibility both control `display`, the planner composes them bef
 All grid directives are recognized and preserved. Target conversion has not been implemented.
 
 ## Responsive class and style inputs
+
+- literal `ngClass.<alias>`: Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.
+- literal `ngStyle.<alias>`: Converts complete, sanitizer-safe declaration lists with exact CSS ownership.
+- deprecated `class.<alias>` and `style.<alias>`: Version-dependent replacement and merge behavior is not inferred.
+- responsive `imgSrc`: Recognized and reported; no target conversion is implemented.
 
 The supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`. Each emitted class contains the exact Angular Flex-Layout media range rather than a project-defined Tailwind breakpoint.
 

--- a/src/analyzer/compatibility-inventory.spec.ts
+++ b/src/analyzer/compatibility-inventory.spec.ts
@@ -1,0 +1,31 @@
+import { FLEX_LAYOUT_DIRECTIVES } from './flex-layout.catalog';
+import { COMPATIBILITY_INVENTORY } from './compatibility-inventory';
+
+describe('compatibility inventory', () => {
+  it('classifies every recognized directive exactly once', () => {
+    const names = COMPATIBILITY_INVENTORY.map(entry => entry.directive);
+    expect(names).toHaveLength(new Set(names).size);
+    expect([...names].sort()).toEqual([...FLEX_LAYOUT_DIRECTIVES].sort());
+  });
+
+  it('records the current implemented and planned boundaries', () => {
+    expect(COMPATIBILITY_INVENTORY).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ directive: 'fxLayout', tailwind: 'limited', css: 'planned' }),
+        expect.objectContaining({ directive: 'gdColumns', tailwind: 'planned', css: 'planned' }),
+        expect.objectContaining({ directive: 'imgSrc', tailwind: 'not-applicable', image: 'planned' }),
+        expect.objectContaining({ directive: 'class', tailwind: 'preserved', css: 'preserved' }),
+      ]),
+    );
+  });
+
+  it('distinguishes standard, orientation, print, and custom breakpoint coverage', () => {
+    const layout = COMPATIBILITY_INVENTORY.find(entry => entry.directive === 'fxLayout');
+    expect(layout?.breakpoints).toEqual({
+      standard: 'limited',
+      orientation: 'planned',
+      print: 'planned',
+      custom: 'preserved',
+    });
+  });
+});

--- a/src/analyzer/compatibility-inventory.ts
+++ b/src/analyzer/compatibility-inventory.ts
@@ -1,0 +1,329 @@
+import {
+  DEFAULT_BREAKPOINTS,
+  FLEX_LAYOUT_DIRECTIVES,
+  ORIENTATION_BREAKPOINTS,
+  SPECIAL_BREAKPOINTS,
+} from './flex-layout.catalog';
+import type { FlexLayoutDirective } from './flex-layout.catalog';
+
+export type CompatibilityLevel = 'limited' | 'planned' | 'preserved' | 'not-applicable';
+
+export interface BreakpointCoverage {
+  readonly standard: CompatibilityLevel;
+  readonly orientation: CompatibilityLevel;
+  readonly print: CompatibilityLevel;
+  readonly custom: CompatibilityLevel;
+}
+
+export interface CompatibilityEntry {
+  readonly directive: FlexLayoutDirective;
+  readonly family: 'flex' | 'grid' | 'visibility' | 'class-style' | 'image';
+  readonly tailwind: CompatibilityLevel;
+  readonly css: CompatibilityLevel;
+  readonly image: CompatibilityLevel;
+  readonly breakpoints: BreakpointCoverage;
+  readonly note: string;
+}
+
+const breakpointCatalog = {
+  standard: DEFAULT_BREAKPOINTS,
+  orientation: ORIENTATION_BREAKPOINTS,
+  print: SPECIAL_BREAKPOINTS,
+} as const;
+
+const standardLimited: BreakpointCoverage = {
+  standard: 'limited',
+  orientation: 'planned',
+  print: 'planned',
+  custom: 'preserved',
+};
+
+const allPlanned: BreakpointCoverage = {
+  standard: 'planned',
+  orientation: 'planned',
+  print: 'planned',
+  custom: 'preserved',
+};
+
+const imagePlanned: BreakpointCoverage = {
+  standard: 'planned',
+  orientation: 'not-applicable',
+  print: 'not-applicable',
+  custom: 'preserved',
+};
+
+const classStylePreserved: BreakpointCoverage = {
+  standard: 'preserved',
+  orientation: 'preserved',
+  print: 'preserved',
+  custom: 'preserved',
+};
+
+const entries: CompatibilityEntry[] = [
+  {
+    directive: 'fxLayout',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.',
+  },
+  {
+    directive: 'fxLayoutAlign',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static main/cross axes with layout, content alignment, sizing, and border-box semantics.',
+  },
+  {
+    directive: 'fxLayoutGap',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static nonnegative non-wrapping gaps; unitless values remain pixels.',
+  },
+  {
+    directive: 'fxFlex',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static basis, keyword, and three-part forms with parent-axis min/max sizing.',
+  },
+  {
+    directive: 'fxGrow',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Converted atomically with a static fxFlex; standalone use is invalid.',
+  },
+  {
+    directive: 'fxShrink',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Converted atomically with a static fxFlex; standalone use is invalid.',
+  },
+  {
+    directive: 'fxFlexAlign',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static align-self keywords.',
+  },
+  {
+    directive: 'fxFlexFill',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static full-size rule including its zero-margin behavior.',
+  },
+  {
+    directive: 'fxFill',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Non-responsive alias of fxFlexFill.',
+  },
+  {
+    directive: 'fxFlexOffset',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static values with a statically known parent axis; unitless values remain percentages.',
+  },
+  {
+    directive: 'fxFlexOrder',
+    family: 'flex',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Static integer values emitted independently of the Tailwind theme.',
+  },
+  {
+    directive: 'fxShow',
+    family: 'visibility',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.',
+  },
+  {
+    directive: 'fxHide',
+    family: 'visibility',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Literal base and standard viewport states convert with fxShow; hiding emits exact base or responsive hidden utilities.',
+  },
+  {
+    directive: 'gdAlignColumns',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdAlignRows',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdArea',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdAreas',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdAuto',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdColumn',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdColumns',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdGap',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdGridAlign',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdRow',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'gdRows',
+    family: 'grid',
+    tailwind: 'planned',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: allPlanned,
+    note: 'Recognized and preserved; target conversion has not been implemented.',
+  },
+  {
+    directive: 'class',
+    family: 'class-style',
+    tailwind: 'preserved',
+    css: 'preserved',
+    image: 'not-applicable',
+    breakpoints: classStylePreserved,
+    note: 'Version-dependent replacement and merge behavior is not inferred.',
+  },
+  {
+    directive: 'ngClass',
+    family: 'class-style',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.',
+  },
+  {
+    directive: 'style',
+    family: 'class-style',
+    tailwind: 'preserved',
+    css: 'preserved',
+    image: 'not-applicable',
+    breakpoints: classStylePreserved,
+    note: 'Version-dependent replacement and merge behavior is not inferred.',
+  },
+  {
+    directive: 'ngStyle',
+    family: 'class-style',
+    tailwind: 'limited',
+    css: 'planned',
+    image: 'not-applicable',
+    breakpoints: standardLimited,
+    note: 'Converts complete, sanitizer-safe declaration lists with exact CSS ownership.',
+  },
+  {
+    directive: 'imgSrc',
+    family: 'image',
+    tailwind: 'not-applicable',
+    css: 'not-applicable',
+    image: 'planned',
+    breakpoints: imagePlanned,
+    note: 'Recognized and reported; no target conversion is implemented.',
+  },
+];
+
+FLEX_LAYOUT_DIRECTIVES satisfies readonly FlexLayoutDirective[];
+void breakpointCatalog;
+
+export const COMPATIBILITY_INVENTORY = Object.freeze(entries satisfies readonly CompatibilityEntry[]);

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -12,6 +12,13 @@ const statusLabels = new Map([
   ['Preserved', 'preserved'],
   ['Not applicable', 'not-applicable'],
 ]);
+const familyLabels = new Map([
+  ['Flex', 'flex'],
+  ['Grid', 'grid'],
+  ['Visibility', 'visibility'],
+  ['Class/style', 'class-style'],
+  ['Image', 'image'],
+]);
 
 function tableCells(row: string): string[] | undefined {
   if (!row.startsWith('|') || !row.endsWith('|')) return undefined;
@@ -30,9 +37,13 @@ function parseCompatibilityRows(markdown: string) {
 
   const tableLines = markdown
     .slice(start + startMarker.length, end)
-    .trim()
     .split('\n')
-    .filter(line => line.startsWith('|'));
+    .filter(line => line.trim().length > 0);
+  for (const line of tableLines) {
+    if (!line.startsWith('|')) {
+      throw new Error(`Unexpected compatibility inventory content: ${line.trim()}`);
+    }
+  }
   const [header, separator, ...dataRows] = tableLines;
 
   const headerCells = header ? tableCells(header) : undefined;
@@ -54,7 +65,7 @@ function parseCompatibilityRows(markdown: string) {
       throw new Error(`Malformed compatibility inventory row ${index + 1}`);
     }
 
-    const [directiveCell, _family, tailwindCell, cssCell, imageCell] = cells;
+    const [directiveCell, familyCell, tailwindCell, cssCell, imageCell] = cells;
     const directive = directiveCell.match(/^`(.+)`$/u)?.[1];
     if (!directive) throw new Error(`Malformed compatibility inventory row ${index + 1}`);
     if (directives.has(directive)) {
@@ -67,9 +78,12 @@ function parseCompatibilityRows(markdown: string) {
       if (!status) throw new Error(`Unknown compatibility status "${label}"`);
       return status;
     };
+    const family = familyLabels.get(familyCell);
+    if (!family) throw new Error(`Unknown compatibility family "${familyCell}"`);
 
     return {
       directive,
+      family,
       tailwind: parseStatus(tailwindCell),
       css: parseStatus(cssCell),
       image: parseStatus(imageCell),
@@ -84,6 +98,7 @@ describe('compatibility reference contract', () => {
     expect(rows).toEqual(
       COMPATIBILITY_INVENTORY.map(entry => ({
         directive: entry.directive,
+        family: entry.family,
         tailwind: entry.tailwind,
         css: entry.css,
         image: entry.image,
@@ -100,6 +115,11 @@ describe('compatibility reference contract', () => {
       'Malformed compatibility inventory row 1',
     ],
     [
+      'unexpected nonblank content',
+      `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\nunexpected markdown\n| \`fxLayout\` | Flex | Limited | Planned | Not applicable |\n${endMarker}`,
+      'Unexpected compatibility inventory content: unexpected markdown',
+    ],
+    [
       'unknown status label',
       `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Available | Planned | Not applicable |\n${endMarker}`,
       'Unknown compatibility status "Available"',
@@ -111,5 +131,33 @@ describe('compatibility reference contract', () => {
     ],
   ])('rejects %s', (_description, markdown, message) => {
     expect(() => parseCompatibilityRows(markdown)).toThrow(message);
+  });
+
+  it('retains the detailed current Tailwind safety boundaries', async () => {
+    const markdown = await readFile(compatibilityUrl, 'utf8');
+
+    for (const safetyBoundary of [
+      'Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.',
+      'Static main/cross axes with layout, content alignment, sizing, and border-box semantics.',
+      'Static nonnegative non-wrapping gaps; unitless values remain pixels. Grid, computed, negative, and wrapped gaps are review.',
+      'Static basis, keyword, and three-part forms with parent-axis min/max sizing.',
+      'Converted atomically with a static `fxFlex`; standalone use is invalid.',
+      'Static `align-self` keywords.',
+      'Static full-size rule including its zero-margin behavior.',
+      'Non-responsive alias of `fxFlexFill`.',
+      'Static values with a statically known parent axis; unitless values remain percentages.',
+      'Static integer values emitted independently of the Tailwind theme.',
+      'Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.',
+      'Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
+      'Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.',
+      'Converts complete, sanitizer-safe declaration lists with exact CSS ownership.',
+      'Version-dependent replacement and merge behavior is not inferred.',
+      'Recognized and reported; no target conversion is implemented.',
+    ]) {
+      expect(markdown).toContain(safetyBoundary);
+    }
+
+    expect(markdown).toContain('are currently converted together as one atomic visibility family per element');
+    expect(markdown).not.toContain('are planned together as one atomic visibility family per element');
   });
 });

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -1,0 +1,115 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { COMPATIBILITY_INVENTORY } from '../../src/analyzer/compatibility-inventory';
+
+const compatibilityUrl = new URL('../../docs/compatibility.md', import.meta.url);
+const startMarker = '<!-- compatibility-inventory:start -->';
+const endMarker = '<!-- compatibility-inventory:end -->';
+
+const statusLabels = new Map([
+  ['Limited', 'limited'],
+  ['Planned', 'planned'],
+  ['Preserved', 'preserved'],
+  ['Not applicable', 'not-applicable'],
+]);
+
+function tableCells(row: string): string[] | undefined {
+  if (!row.startsWith('|') || !row.endsWith('|')) return undefined;
+  return row
+    .slice(1, -1)
+    .split('|')
+    .map(cell => cell.trim());
+}
+
+function parseCompatibilityRows(markdown: string) {
+  const start = markdown.indexOf(startMarker);
+  if (start === -1) throw new Error('Missing compatibility inventory start marker');
+
+  const end = markdown.indexOf(endMarker, start + startMarker.length);
+  if (end === -1) throw new Error('Missing compatibility inventory end marker');
+
+  const tableLines = markdown
+    .slice(start + startMarker.length, end)
+    .trim()
+    .split('\n')
+    .filter(line => line.startsWith('|'));
+  const [header, separator, ...dataRows] = tableLines;
+
+  const headerCells = header ? tableCells(header) : undefined;
+  const separatorCells = separator ? tableCells(separator) : undefined;
+  if (
+    !headerCells ||
+    headerCells.join('|') !== 'Directive|Family|Tailwind CSS 4|Native CSS|Responsive image' ||
+    !separatorCells ||
+    separatorCells.length !== 5 ||
+    !separatorCells.every(cell => /^:?-{3,}:?$/u.test(cell))
+  ) {
+    throw new Error('Malformed compatibility inventory table header');
+  }
+
+  const directives = new Set<string>();
+  return dataRows.map((row, index) => {
+    const cells = tableCells(row);
+    if (!cells || cells.length !== 5 || cells.some(cell => cell.length === 0)) {
+      throw new Error(`Malformed compatibility inventory row ${index + 1}`);
+    }
+
+    const [directiveCell, _family, tailwindCell, cssCell, imageCell] = cells;
+    const directive = directiveCell.match(/^`(.+)`$/u)?.[1];
+    if (!directive) throw new Error(`Malformed compatibility inventory row ${index + 1}`);
+    if (directives.has(directive)) {
+      throw new Error(`Duplicate compatibility directive "${directive}"`);
+    }
+    directives.add(directive);
+
+    const parseStatus = (label: string) => {
+      const status = statusLabels.get(label);
+      if (!status) throw new Error(`Unknown compatibility status "${label}"`);
+      return status;
+    };
+
+    return {
+      directive,
+      tailwind: parseStatus(tailwindCell),
+      css: parseStatus(cssCell),
+      image: parseStatus(imageCell),
+    };
+  });
+}
+
+describe('compatibility reference contract', () => {
+  it('documents every recognized directive with the executable target statuses', async () => {
+    const markdown = await readFile(compatibilityUrl, 'utf8');
+    const rows = parseCompatibilityRows(markdown);
+    expect(rows).toEqual(
+      COMPATIBILITY_INVENTORY.map(entry => ({
+        directive: entry.directive,
+        tailwind: entry.tailwind,
+        css: entry.css,
+        image: entry.image,
+      })),
+    );
+  });
+
+  it.each([
+    ['missing start marker', `${endMarker}\n`, 'Missing compatibility inventory start marker'],
+    ['missing end marker', `${startMarker}\n`, 'Missing compatibility inventory end marker'],
+    [
+      'malformed cells',
+      `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Limited | Planned |\n${endMarker}`,
+      'Malformed compatibility inventory row 1',
+    ],
+    [
+      'unknown status label',
+      `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Available | Planned | Not applicable |\n${endMarker}`,
+      'Unknown compatibility status "Available"',
+    ],
+    [
+      'duplicate directive',
+      `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Limited | Planned | Not applicable |\n| \`fxLayout\` | Flex | Limited | Planned | Not applicable |\n${endMarker}`,
+      'Duplicate compatibility directive "fxLayout"',
+    ],
+  ])('rejects %s', (_description, markdown, message) => {
+    expect(() => parseCompatibilityRows(markdown)).toThrow(message);
+  });
+});

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -32,8 +32,46 @@ function hasFiveNonemptyCells(cells: string[] | undefined): cells is [string, st
   return cells !== undefined && cells.length === 5 && cells.every(cell => cell.length > 0);
 }
 
+function visibleMarkdownLines(markdown: string): string[] {
+  const lines: string[] = [];
+  let line = '';
+  let commentDepth = 0;
+
+  for (let index = 0; index < markdown.length;) {
+    if (commentDepth > 0) {
+      if (markdown.startsWith('<!--', index)) {
+        commentDepth += 1;
+        index += 4;
+        continue;
+      }
+      if (markdown.startsWith('-->', index)) {
+        commentDepth -= 1;
+        index += 3;
+        continue;
+      }
+    } else if (markdown.startsWith('<!--', index)) {
+      commentDepth = 1;
+      index += 4;
+      continue;
+    }
+
+    const character = markdown[index];
+    if (character === undefined) throw new Error('Markdown scan reached an invalid index');
+    if (character === '\n') {
+      lines.push(line);
+      line = '';
+    } else if (commentDepth === 0) {
+      line += character;
+    }
+    index += 1;
+  }
+
+  lines.push(line);
+  return lines;
+}
+
 function sectionBody(markdown: string, heading: string): string[] {
-  const lines = markdown.replace(/<!--[\s\S]*?-->/gu, '').split('\n');
+  const lines = visibleMarkdownLines(markdown);
   const headingLine = lines.findIndex(line => line.trim() === heading);
   if (headingLine === -1) throw new Error(`Missing compatibility section: ${heading}`);
 
@@ -260,5 +298,18 @@ describe('compatibility reference contract', () => {
     expect(() => parseAvailableNowSafetyEntries(duplicate)).toThrow(
       'Duplicate compatibility safety entry "fxFlexFill"',
     );
+  });
+
+  it('does not treat nested or adjacent HTML-comment content as visible safety entries', async () => {
+    const markdown = await readFile(compatibilityUrl, 'utf8');
+    const crafted = markdown.replace(
+      '- `fxFlexFill`: Static full-size rule including its zero-margin behavior.',
+      '<!-- outer comment <!-- nested opener -->\n- `fxFlexFill`: Static full-size rule including its zero-margin behavior.\n--><!-- adjacent comment -->',
+    );
+
+    expect(sectionBody(crafted, '### Available now: directive-specific boundaries')).not.toContain(
+      '- `fxFlexFill`: Static full-size rule including its zero-margin behavior.',
+    );
+    expect(parseAvailableNowSafetyEntries(crafted).has('fxFlexFill')).toBe(false);
   });
 });

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -42,18 +42,46 @@ function sectionBody(markdown: string, heading: string): string[] {
   return nextHeading === -1 ? body : body.slice(0, nextHeading);
 }
 
+function leadingSafetyBullets(markdown: string, heading: string): string[] {
+  const body = sectionBody(markdown, heading);
+  const firstEntry = body.findIndex(line => line.trim().length > 0);
+  if (firstEntry === -1) throw new Error(`Missing visible safety entries: ${heading}`);
+
+  const entries: string[] = [];
+  for (const line of body.slice(firstEntry)) {
+    if (line.trim().length === 0) break;
+    if (!line.startsWith('- ')) throw new Error(`Malformed visible safety entry: ${line}`);
+    entries.push(line);
+  }
+  return entries;
+}
+
 function parseAvailableNowSafetyEntries(markdown: string): Map<string, string> {
   const entries = new Map<string, string>();
-  for (const line of sectionBody(markdown, '### Available now: directive-specific boundaries')) {
-    const match = line.match(/^- ((?:`[^`]+`(?: and )?)+): (.+)$/u);
-    if (!match) continue;
+  const knownDirectives = new Set<string>(COMPATIBILITY_INVENTORY.map(entry => entry.directive));
+  for (const heading of ['### Available now: directive-specific boundaries', '## Responsive class and style inputs']) {
+    for (const line of leadingSafetyBullets(markdown, heading)) {
+      const match = line.match(/^- (.+?): (.+)$/u);
+      if (!match) throw new Error(`Malformed visible safety entry: ${line}`);
 
-    const [label, note] = match.slice(1);
-    if (label === undefined || note === undefined) throw new Error('Malformed available-now safety entry');
-    for (const directive of label.matchAll(/`([^`]+)`/gu)) {
-      const name = directive[1];
-      if (name === undefined) throw new Error('Malformed available-now directive');
-      entries.set(name, note);
+      const [label, note] = match.slice(1);
+      if (label === undefined || note === undefined) throw new Error('Malformed visible safety entry');
+      const codeLabels = [...label.matchAll(/`([^`]+)`/gu)].map(labelMatch => labelMatch[1]);
+      const names = codeLabels
+        .map(name => name?.replace(/\.<alias>$/u, ''))
+        .filter((name): name is string => name !== undefined);
+      if (names.length !== codeLabels.length) throw new Error(`Malformed compatibility safety label: ${label}`);
+      if (names.length === 0) {
+        names.push(...[...knownDirectives].filter(directive => new RegExp(`\\b${directive}\\b`, 'u').test(label)));
+      }
+      if (names.length === 0 || names.some(name => !knownDirectives.has(name))) {
+        throw new Error(`Unknown compatibility safety label: ${label}`);
+      }
+
+      for (const name of names) {
+        if (entries.has(name)) throw new Error(`Duplicate compatibility safety entry "${name}"`);
+        entries.set(name, note);
+      }
     }
   }
   return entries;
@@ -210,10 +238,27 @@ describe('compatibility reference contract', () => {
           'fxHide',
           'Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
         ],
+        ['ngClass', 'Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.'],
+        ['ngStyle', 'Converts complete, sanitizer-safe declaration lists with exact CSS ownership.'],
+        ['class', 'Version-dependent replacement and merge behavior is not inferred.'],
+        ['style', 'Version-dependent replacement and merge behavior is not inferred.'],
+        ['imgSrc', 'Recognized and reported; no target conversion is implemented.'],
       ]),
     );
 
     expect(markdown).toContain('are currently converted together as one atomic visibility family per element');
     expect(markdown).not.toContain('are planned together as one atomic visibility family per element');
+  });
+
+  it('rejects duplicate visible safety entries', async () => {
+    const markdown = await readFile(compatibilityUrl, 'utf8');
+    const duplicate = markdown.replace(
+      '- `fxFlexFill`: Static full-size rule including its zero-margin behavior.',
+      '- `fxFlexFill`: Incorrect behavior.\n- `fxFlexFill`: Static full-size rule including its zero-margin behavior.',
+    );
+
+    expect(() => parseAvailableNowSafetyEntries(duplicate)).toThrow(
+      'Duplicate compatibility safety entry "fxFlexFill"',
+    );
   });
 });

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -32,16 +32,51 @@ function hasFiveNonemptyCells(cells: string[] | undefined): cells is [string, st
   return cells !== undefined && cells.length === 5 && cells.every(cell => cell.length > 0);
 }
 
-function parseCompatibilityRows(markdown: string) {
-  const start = markdown.indexOf(startMarker);
-  if (start === -1) throw new Error('Missing compatibility inventory start marker');
+function sectionBody(markdown: string, heading: string): string[] {
+  const lines = markdown.replace(/<!--[\s\S]*?-->/gu, '').split('\n');
+  const headingLine = lines.findIndex(line => line.trim() === heading);
+  if (headingLine === -1) throw new Error(`Missing compatibility section: ${heading}`);
 
-  const end = markdown.indexOf(endMarker, start + startMarker.length);
-  if (end === -1) throw new Error('Missing compatibility inventory end marker');
+  const body = lines.slice(headingLine + 1);
+  const nextHeading = body.findIndex(line => /^#{1,3} /u.test(line));
+  return nextHeading === -1 ? body : body.slice(0, nextHeading);
+}
+
+function parseAvailableNowSafetyEntries(markdown: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const line of sectionBody(markdown, '### Available now: directive-specific boundaries')) {
+    const match = line.match(/^- ((?:`[^`]+`(?: and )?)+): (.+)$/u);
+    if (!match) continue;
+
+    const [label, note] = match.slice(1);
+    if (label === undefined || note === undefined) throw new Error('Malformed available-now safety entry');
+    for (const directive of label.matchAll(/`([^`]+)`/gu)) {
+      const name = directive[1];
+      if (name === undefined) throw new Error('Malformed available-now directive');
+      entries.set(name, note);
+    }
+  }
+  return entries;
+}
+
+function parseCompatibilityRows(markdown: string) {
+  const lines = markdown.split('\n');
+  const startLines = lines.flatMap((line, index) => (line.trim() === startMarker ? [index] : []));
+  const endLines = lines.flatMap((line, index) => (line.trim() === endMarker ? [index] : []));
+  if (startLines.length === 0) throw new Error('Missing compatibility inventory start marker');
+  if (endLines.length === 0) throw new Error('Missing compatibility inventory end marker');
+  if (startLines.length !== 1) throw new Error('Expected exactly one compatibility inventory start marker');
+  if (endLines.length !== 1) throw new Error('Expected exactly one compatibility inventory end marker');
+  const startLine = startLines.at(0);
+  const endLine = endLines.at(0);
+  if (startLine === undefined || endLine === undefined) {
+    throw new Error('Compatibility inventory marker lookup failed');
+  }
+  if (startLine > endLine) throw new Error('Compatibility inventory markers are out of order');
 
   const tableLines = markdown
-    .slice(start + startMarker.length, end)
     .split('\n')
+    .slice(startLine + 1, endLine)
     .filter(line => line.trim().length > 0);
   for (const line of tableLines) {
     if (!line.startsWith('|')) {
@@ -114,6 +149,17 @@ describe('compatibility reference contract', () => {
     ['missing start marker', `${endMarker}\n`, 'Missing compatibility inventory start marker'],
     ['missing end marker', `${startMarker}\n`, 'Missing compatibility inventory end marker'],
     [
+      'duplicate start marker',
+      `${startMarker}\n${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Limited | Planned | Not applicable |\n${endMarker}`,
+      'Expected exactly one compatibility inventory start marker',
+    ],
+    [
+      'duplicate end marker',
+      `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Limited | Planned | Not applicable |\n${endMarker}\n${endMarker}`,
+      'Expected exactly one compatibility inventory end marker',
+    ],
+    ['out-of-order markers', `${endMarker}\n${startMarker}`, 'Compatibility inventory markers are out of order'],
+    [
       'malformed cells',
       `${startMarker}\n| Directive | Family | Tailwind CSS 4 | Native CSS | Responsive image |\n| --- | --- | --- | --- | --- |\n| \`fxLayout\` | Flex | Limited | Planned |\n${endMarker}`,
       'Malformed compatibility inventory row 1',
@@ -140,26 +186,32 @@ describe('compatibility reference contract', () => {
   it('retains the detailed current Tailwind safety boundaries', async () => {
     const markdown = await readFile(compatibilityUrl, 'utf8');
 
-    for (const safetyBoundary of [
-      'Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.',
-      'Static main/cross axes with layout, content alignment, sizing, and border-box semantics.',
-      'Static nonnegative non-wrapping gaps; unitless values remain pixels. Grid, computed, negative, and wrapped gaps are review.',
-      'Static basis, keyword, and three-part forms with parent-axis min/max sizing.',
-      'Converted atomically with a static `fxFlex`; standalone use is invalid.',
-      'Static `align-self` keywords.',
-      'Static full-size rule including its zero-margin behavior.',
-      'Non-responsive alias of `fxFlexFill`.',
-      'Static values with a statically known parent axis; unitless values remain percentages.',
-      'Static integer values emitted independently of the Tailwind theme.',
-      'Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.',
-      'Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
-      'Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.',
-      'Converts complete, sanitizer-safe declaration lists with exact CSS ownership.',
-      'Version-dependent replacement and merge behavior is not inferred.',
-      'Recognized and reported; no target conversion is implemented.',
-    ]) {
-      expect(markdown).toContain(safetyBoundary);
-    }
+    expect(parseAvailableNowSafetyEntries(markdown)).toEqual(
+      new Map([
+        ['fxLayout', 'Static directions plus wrap and inline modifiers; coupled unresolved gaps preserve the layout.'],
+        ['fxLayoutAlign', 'Static main/cross axes with layout, content alignment, sizing, and border-box semantics.'],
+        [
+          'fxLayoutGap',
+          'Static nonnegative non-wrapping gaps; unitless values remain pixels. Grid, computed, negative, and wrapped gaps are review.',
+        ],
+        ['fxFlex', 'Static basis, keyword, and three-part forms with parent-axis min/max sizing.'],
+        ['fxGrow', 'Converted atomically with a static `fxFlex`; standalone use is invalid.'],
+        ['fxShrink', 'Converted atomically with a static `fxFlex`; standalone use is invalid.'],
+        ['fxFlexAlign', 'Static `align-self` keywords.'],
+        ['fxFlexFill', 'Static full-size rule including its zero-margin behavior.'],
+        ['fxFill', 'Non-responsive alias of `fxFlexFill`.'],
+        ['fxFlexOffset', 'Static values with a statically known parent axis; unitless values remain percentages.'],
+        ['fxFlexOrder', 'Static integer values emitted independently of the Tailwind theme.'],
+        [
+          'fxShow',
+          'Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.',
+        ],
+        [
+          'fxHide',
+          'Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
+        ],
+      ]),
+    );
 
     expect(markdown).toContain('are currently converted together as one atomic visibility family per element');
     expect(markdown).not.toContain('are planned together as one atomic visibility family per element');

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -28,6 +28,10 @@ function tableCells(row: string): string[] | undefined {
     .map(cell => cell.trim());
 }
 
+function hasFiveNonemptyCells(cells: string[] | undefined): cells is [string, string, string, string, string] {
+  return cells !== undefined && cells.length === 5 && cells.every(cell => cell.length > 0);
+}
+
 function parseCompatibilityRows(markdown: string) {
   const start = markdown.indexOf(startMarker);
   if (start === -1) throw new Error('Missing compatibility inventory start marker');
@@ -61,7 +65,7 @@ function parseCompatibilityRows(markdown: string) {
   const directives = new Set<string>();
   return dataRows.map((row, index) => {
     const cells = tableCells(row);
-    if (!cells || cells.length !== 5 || cells.some(cell => cell.length === 0)) {
+    if (!hasFiveNonemptyCells(cells)) {
       throw new Error(`Malformed compatibility inventory row ${index + 1}`);
     }
 

--- a/test/package/docs-contract.test.ts
+++ b/test/package/docs-contract.test.ts
@@ -72,7 +72,7 @@ describe('maintainer documentation', () => {
     const contributingRelease = sectionAfter(contributing, '## Releasing a beta');
     const architectureRelease = sectionAfter(releaseProcess, '## Repository automation');
 
-    expect(readme).toContain('npm install --save-dev @nipe-solutions/flex-layout-codemod@beta');
+    expect(readme).toContain('npm install --save-dev --save-exact @nipe-solutions/flex-layout-codemod@beta');
     expect(readme).toContain('docs/architecture/release-process.md');
 
     const exactTrustInputs = [
@@ -148,6 +148,36 @@ describe('maintainer documentation', () => {
     expect(releaseProcess).toContain('computes SHA-512 SRI from the generated tarball bytes');
     expect(releaseProcess).toContain('smoke-installs and executes that exact tarball');
     expect(releaseProcess).toContain('rehashes the retained tarball immediately before staging');
+  });
+
+  it('documents a safe and reproducible beta onboarding path', async () => {
+    const readme = await readRepositoryFile('README.md');
+
+    expectInOrder(readme, [
+      'npx @nipe-solutions/flex-layout-codemod@beta ./src --dry-run',
+      'npm install --save-dev --save-exact @nipe-solutions/flex-layout-codemod@beta',
+      'npx flex-layout-codemod ./src --dry-run',
+      'npx flex-layout-codemod ./src --target tailwind',
+    ]);
+    expect(readme).toContain('docs/compatibility.md');
+    expect(readme).toContain('--report ./reports/flex-layout.json');
+    expect(readme).toContain('--allow-unresolved');
+    expect(readme).not.toContain('npm install -g');
+    expect(readme).not.toContain('production-ready conversion coverage');
+  });
+
+  it('does not represent unavailable conversion targets as current beta behavior', async () => {
+    const readme = await readRepositoryFile('README.md');
+
+    for (const unavailableClaim of [
+      /native CSS conversion is available/u,
+      /Grid conversion is available/u,
+      /orientation conversion is available/u,
+      /print conversion is available/u,
+      /imgSrc conversion is available/u,
+    ]) {
+      expect(readme).not.toMatch(unavailableClaim);
+    }
   });
 
   it('requires byte-for-byte staged artifact verification before approval and finalization', async () => {

--- a/test/package/docs-contract.test.ts
+++ b/test/package/docs-contract.test.ts
@@ -31,6 +31,13 @@ function expectInOrder(source: string, markers: string[]): void {
   }
 }
 
+function expectCurrentBetaBoundaries(readme: string): void {
+  expect(readme).toContain('writes changed templates in place when neither `--dry-run` nor `--output` is supplied');
+  expect(readme).toContain('a native CSS target is not available');
+  expect(readme).toContain('Grid directives and responsive `imgSrc` are recognized, reported, and remain unchanged');
+  expect(readme).toContain('Orientation, print, and custom breakpoint aliases remain preserved for review');
+}
+
 describe('maintainer documentation', () => {
   it('provides contribution, security, support, and governance files', async () => {
     const required = [
@@ -166,8 +173,18 @@ describe('maintainer documentation', () => {
     expect(readme).not.toContain('production-ready conversion coverage');
   });
 
-  it('does not represent unavailable conversion targets as current beta behavior', async () => {
+  it('documents the current beta safety boundaries', async () => {
     const readme = await readRepositoryFile('README.md');
+
+    expectCurrentBetaBoundaries(readme);
+  });
+
+  it('rejects a paraphrased false-current-capability claim that the former blacklist misses', async () => {
+    const readme = await readRepositoryFile('README.md');
+    const falseCurrentCapability = readme.replace(
+      'This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Grid directives and responsive `imgSrc` are recognized, reported, and remain unchanged. Orientation, print, and custom breakpoint aliases remain preserved for review.',
+      'This beta has native CSS and Tailwind CSS targets. Grid directives, responsive `imgSrc`, orientation, print, and custom breakpoint aliases convert directly.',
+    );
 
     for (const unavailableClaim of [
       /native CSS conversion is available/u,
@@ -176,8 +193,10 @@ describe('maintainer documentation', () => {
       /print conversion is available/u,
       /imgSrc conversion is available/u,
     ]) {
-      expect(readme).not.toMatch(unavailableClaim);
+      expect(falseCurrentCapability).not.toMatch(unavailableClaim);
     }
+
+    expect(() => expectCurrentBetaBoundaries(falseCurrentCapability)).toThrow();
   });
 
   it('requires byte-for-byte staged artifact verification before approval and finalization', async () => {

--- a/test/package/release-policy.test.ts
+++ b/test/package/release-policy.test.ts
@@ -9,6 +9,16 @@ import { parse } from 'yaml';
 const execFileAsync = promisify(execFile);
 const repository = resolve(import.meta.dirname, '../..');
 
+function nextBetaVersion(version: string): string {
+  const match = /^(?<base>\d+\.\d+\.\d+)-beta\.(?<sequence>\d+)$/u.exec(version);
+  const base = match?.groups?.base;
+  const sequence = match?.groups?.sequence;
+  if (base === undefined || sequence === undefined) {
+    throw new Error(`Expected current package version to be a beta prerelease, got ${version}`);
+  }
+  return `${base}-beta.${Number(sequence) + 1}`;
+}
+
 describe('release policy', () => {
   it('keeps the release pull request workflow inside the preparation trust boundary', async () => {
     const source = await readFile(new URL('../../.github/workflows/release-pr.yml', import.meta.url), 'utf8');
@@ -179,10 +189,18 @@ describe('release policy', () => {
     expect(lockfile.packages[''].packageManager).toBeUndefined();
   });
 
-  it('versions the pending changesets as the first public beta', async () => {
+  it('versions the pending changesets as the next public beta', async () => {
     const temporaryDirectory = await mkdtemp(join(tmpdir(), 'flex-layout-changeset-version-'));
 
     try {
+      const [manifest, lockfile] = await Promise.all(
+        ['package.json', 'package-lock.json'].map(async path =>
+          JSON.parse(await readFile(join(repository, path), 'utf8')),
+        ),
+      );
+      const expectedVersion = nextBetaVersion(manifest.version);
+      expect(lockfile.packages[''].version).toBe(manifest.version);
+
       await Promise.all(
         ['package.json', 'package-lock.json', 'CHANGELOG.md', '.changeset'].map(path =>
           cp(join(repository, path), join(temporaryDirectory, path), { recursive: true }),
@@ -202,8 +220,9 @@ describe('release policy', () => {
           JSON.parse(await readFile(join(temporaryDirectory, path), 'utf8')),
         ),
       );
-      expect(versionedManifest.version).toBe('2.0.0-beta.1');
-      expect(versionedLockfile.packages[''].version).toBe('2.0.0-beta.1');
+      expect(versionedManifest.version).toBe(expectedVersion);
+      expect(versionedLockfile.packages[''].version).toBe(expectedVersion);
+      expect(versionedLockfile.packages[''].version).toBe(versionedManifest.version);
     } finally {
       await rm(temporaryDirectory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Add a typed, executable inventory for all 29 recognized Angular Flex-Layout directives.
- Make the public compatibility table and visible safety notes mechanically match that inventory.
- Rewrite beta onboarding around safe dry-run evaluation, exact team installation, current support boundaries, reports, exit codes, and recovery guidance.
- Add a patch Changeset for the documentation and compatibility-contract improvements.

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally: 62 test files and 2,019 tests passed; coverage thresholds, build, and exact-six-file package verification passed.
- [x] `npm audit --audit-level=high` reports 0 vulnerabilities.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

## Migration example

Not applicable. This pull request documents and contract-tests existing migration behavior; it does not change conversion output.

## Dependencies and compatibility

No dependency changes. The executable inventory records the current Tailwind CSS 4, planned native CSS, and responsive-image boundaries without presenting roadmap work as available. The team install command uses `@beta` with `--save-exact`, pinning the resolved prerelease in the project manifest and lockfile.