### PR TITLE
feat: migrate orientation and print breakpoints

### DIFF
--- a/.changeset/calm-orientation-print.md
+++ b/.changeset/calm-orientation-print.md
@@ -1,0 +1,5 @@
+---
+'@nipe-solutions/flex-layout-codemod': minor
+---
+
+Add opt-in Tailwind conversion for the archived orientation breakpoints and project-configured print fallback behavior.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Literal Grid containers and children use compiler-verified arbitrary properties 
 <section class="grid [grid-template-columns:12rem_1fr] [grid-gap:1rem]"><div class="[grid-column:2]"></div></section>
 ```
 
+Orientation and print conversion require explicit source-configuration evidence. These flags assert settings you have already verified in the Angular application's Flex-Layout configuration; the codemod does not discover them:
+
+```bash
+# Source uses addOrientationBps: true and printWithBreakpoints: ['md', 'handset']
+npx flex-layout-codemod ./src --orientation-breakpoints --print-with-breakpoints md,handset
+
+# Source explicitly uses printWithBreakpoints: []
+npx flex-layout-codemod ./src --print-with-breakpoints none
+```
+
+With orientation enabled, all nine archived aliases are available: `handset`, `handset.portrait`, `handset.landscape`, `tablet`, `tablet.portrait`, `tablet.landscape`, `web`, `web.portrait`, and `web.landscape`. Print conversion reproduces configured responsive fallback values, while an explicit `.print` value takes precedence.
+
 This fixture is intentionally preserved because the value is a runtime Angular expression. The report records a `dynamic-binding` review diagnostic and the source remains unchanged:
 
 ```html
@@ -100,7 +112,7 @@ npx flex-layout-codemod ./src --dry-run --report ./reports/flex-layout.json --al
 
 ## Known boundaries
 
-This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation, print, and custom breakpoint aliases remain preserved for review. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
+This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
 
 The codemod does not inspect project styles, Tailwind configuration, Sass, Less, or CSS, and it does not generate a companion stylesheet. Dynamic Angular bindings are not evaluated.
 

--- a/docs/architecture/tailwind-orientation-print-migration.md
+++ b/docs/architecture/tailwind-orientation-print-migration.md
@@ -1,0 +1,121 @@
+# Tailwind orientation and print migration
+
+## Purpose
+
+This milestone adds project-aware Tailwind CSS 4 conversion for Angular Flex-Layout orientation and print aliases. These aliases are configuration-dependent: orientation breakpoints are disabled by default, and print can activate a configured set of ordinary breakpoints through Flex-Layout's runtime print hook. The migrator therefore requires explicit configuration evidence and preserves source when that evidence is absent or inconsistent.
+
+The implementation reproduces the archived Angular Flex-Layout breakpoint registry and print-hook precedence rather than treating suffixes as Tailwind breakpoint names. Standard viewport behavior remains as defined by the existing responsive architecture, and Grid directives participate through the same responsive-family planner.
+
+Custom breakpoints, replaced default breakpoint definitions, dynamic expressions, native CSS output, and assisted conversion remain outside this milestone.
+
+## Configuration contract
+
+The CLI adds two independent, opt-in flags:
+
+- `--orientation-breakpoints` confirms that the source application enables the archived `addOrientationBps: true` definitions.
+- `--print-with-breakpoints <aliases>` supplies the source application's archived `printWithBreakpoints` value as a comma-separated alias list. The literal `none` explicitly confirms an empty list.
+
+Omitting a flag is not interpreted as the upstream default. It means the migrator has no project-level evidence for that feature, so affected aliases remain unchanged with `breakpoint-unverified`. This avoids silently changing projects that override Flex-Layout configuration.
+
+The print list accepts only aliases whose exact definitions are known in the same invocation: the 13 standard aliases and, when `--orientation-breakpoints` is present, the nine archived orientation aliases. Empty entries, duplicates, `print`, unknown aliases, and orientation aliases without orientation opt-in are configuration errors reported before template discovery. CLI help and reports render a normalized list without changing the user's source configuration.
+
+Configuration is immutable migration context passed from the CLI to adapter construction. Target-neutral parsing does not read process arguments, and adapters not using this configuration keep their current behavior.
+
+## Upstream semantics
+
+### Orientation breakpoints
+
+When enabled, the archived registry adds these exact aliases:
+
+| Alias               | Exact screen condition                     | Priority |
+| ------------------- | ------------------------------------------ | -------: |
+| `handset.portrait`  | portrait and at most `599.98px`            |     2000 |
+| `handset.landscape` | landscape and at most `959.98px`           |     2000 |
+| `handset`           | either handset condition above             |     2000 |
+| `tablet.portrait`   | portrait from `600px` through `839.98px`   |     2100 |
+| `tablet.landscape`  | landscape from `960px` through `1279.98px` |     2100 |
+| `tablet`            | either tablet condition above              |     2100 |
+| `web.portrait`      | portrait from `840px` upward               |     2200 |
+| `web.landscape`     | landscape from `1280px` upward             |     2200 |
+| `web`               | either web condition above                 |     2200 |
+
+Composite aliases are disjunctions, not wider numeric ranges. The catalog retains both clauses so intersection and emission never erase the orientation constraint or fill the gap between branches.
+
+### Print behavior
+
+The archived `print` alias uses the exact media query `print` at priority 1000. During printing, the print hook also substitutes every alias named by `printWithBreakpoints` into the active breakpoint stream. Their normal screen media queries do not apply; their configured responsive values become print-time fallbacks. An explicit `.print` value takes precedence over those fallbacks.
+
+For each directive family, the effective print value is selected from its literal base, responsive values named in the configured print list, and explicit `.print` value using archived priority and fallback behavior. Conversion proceeds only when that effective value and every semantic dependency can be proven. A configured alias does not need its screen condition to match during printing.
+
+## Breakpoint domain model
+
+`BreakpointDefinition` expands from one numeric range to an immutable media definition containing a media type and one or more clauses. A screen clause may contain minimum width, maximum width, and orientation. Print is represented as its own media type with no screen bounds.
+
+Standard aliases contain one screen clause. Specific orientation aliases contain one oriented screen clause, composite orientation aliases contain two, and print contains one print clause. Range intersection becomes media intersection: media types must be compatible, widths must overlap, and orientation constraints must agree. Two definitions intersect when any clause pair intersects.
+
+Definitions retain upstream priority for planning only. Emitted class order is never assumed to reproduce Flex-Layout priority when simultaneously active aliases disagree.
+
+## Planning and atomicity
+
+The existing element and responsive-family planners remain the single conversion pipeline. Orientation, print, class/style ownership, layout dependencies, and Grid display ownership are resolved before edits are created.
+
+For screen behavior:
+
+1. Enabled orientation aliases are planned like verified standard aliases.
+2. Each media clause is an activation branch of the same responsive member.
+3. Disjoint values may convert independently and identical overlapping values may share ownership.
+4. Differing values in intersecting standard or orientation definitions preserve the complete semantic family with `responsive-precedence-unverified`.
+
+For print behavior:
+
+1. The planner computes one effective print semantic plan per family from the explicitly configured alias list.
+2. An explicit `.print` member overrides configured responsive fallbacks.
+3. A configured responsive fallback can generate a print-only class even when that member also generates a screen class.
+4. If a selected print value depends on an unresolved base value, bound input, preserved sibling, parent context, or conflicting class/style authority, the coupled family remains unchanged.
+5. Removing a directive is allowed only when its screen and print behavior are both represented by the complete plan.
+
+This family closure prevents partial conversion from dropping the runtime print-hook behavior. Directives with no print participation retain their existing independent-conversion rules.
+
+## Tailwind rendering
+
+The responsive emitter produces one deterministic arbitrary media variant per media clause. Composite orientation aliases therefore emit two classes rather than relying on comma-separated arbitrary-variant parsing. For example, a handset value is rendered once for its portrait branch and once for its landscape branch.
+
+Print output uses a self-contained arbitrary `@media print` variant. Print-time fallbacks and explicit print values converge on the single effective semantic plan, so the renderer never emits competing print candidates for one owned property.
+
+Every generated candidate is checked with the pinned Tailwind CSS 4 compiler. Verification compares the emitted media condition, selector, and exact declaration set. Compiler-empty candidates, altered orientation conditions, theme-dependent output, incomplete property ownership, and selector-changing variants are rejected.
+
+Candidate order is canonical by semantic family, activation definition, clause order, and utility. Re-running the migrator produces no edits.
+
+## Diagnostics
+
+The structured diagnostic contract remains stable:
+
+- `breakpoint-unverified` covers orientation or print inputs without the required explicit configuration and identifies the corresponding CLI flag;
+- `responsive-precedence-unverified` covers differing values in intersecting screen definitions;
+- `dynamic-binding`, `class-conflict`, `invalid-value`, and `context-unverified` retain their existing meanings;
+- invalid CLI breakpoint configuration is a usage error, exits before migration, and does not produce partial edits.
+
+Diagnostics name the preserved semantic family and distinguish screen overlap from unresolved print fallback behavior. They never suggest that enabling a flag is safe unless the user has verified the source application's Flex-Layout configuration.
+
+## Verification
+
+Implementation follows test-driven development and includes:
+
+- catalog tests for all nine orientation aliases, exact clauses, priorities, classifications, and intersections;
+- CLI parsing and validation tests for omitted flags, `none`, normalized lists, invalid aliases, duplicates, and orientation dependencies;
+- responsive emitter compiler differentials for portrait, landscape, composite, and print variants;
+- family-planner tests for standard/orientation overlap, identical overlap, composite branches, configured print fallbacks, explicit print precedence, and atomic preservation;
+- coverage for every responsive-capable directive family, including Grid container and child directives;
+- existing static class, responsive `ngClass`, and `ngStyle` ownership tests across screen and print activation;
+- browser computed-style comparisons at representative width/orientation pairs and through print-media emulation;
+- template source preservation, deterministic output, idempotence, JSON reporting, and strict unresolved exit behavior;
+- compatibility inventory and public fixture totals that distinguish configured conversion from conservative preservation;
+- full repository verification, audit, packed CLI smoke, clean-status checks, and forbidden-control-file scans.
+
+Completeness means every orientation and print alias has executable configured and unconfigured expectations. It does not imply support for arbitrary application breakpoint providers.
+
+## Documentation and release
+
+The compatibility reference changes orientation and print from Planned to Limited and documents the explicit configuration requirement, archived definitions, overlap policy, and print fallback boundary. The README gains concise configuration examples and continues to direct detailed cases to the compatibility reference.
+
+The pull request includes a Changeset because it adds user-visible CLI options and conversion behavior. It does not publish a package or add a runtime dependency.

--- a/docs/architecture/v2-product-roadmap.md
+++ b/docs/architecture/v2-product-roadmap.md
@@ -141,3 +141,5 @@ Repository verification, audit, package-surface checks, clean-status checks, and
 10. Run a stable-release readiness audit and address every documented compatibility gap or explicitly retained limitation.
 
 Milestones may be split into smaller pull requests when reviewability or risk requires it. Architectural cleanup follows demonstrated duplication and ownership needs rather than speculative abstraction.
+
+Milestone 5 is delivered through the Grid slice and the project-aware orientation/print slice. The latter remains deliberately Limited because conversion requires explicit evidence of the source application's Flex-Layout configuration.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -64,8 +64,8 @@ The Tailwind CSS 4 column identifies current target behavior. Native CSS and res
 - `fxFill`: Non-responsive alias of `fxFlexFill`.
 - `fxFlexOffset`: Static values with a statically known parent axis; unitless values remain percentages.
 - `fxFlexOrder`: Static integer values emitted independently of the Tailwind theme.
-- `fxShow`: Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.
-- `fxHide`: Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.
+- `fxShow`: Literal base and configured viewport, orientation, or print states convert when display restoration and the complete visibility family are safe.
+- `fxHide`: Literal base and configured responsive states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.
 - `gdAlignColumns`, `gdAlignRows`, `gdArea`, `gdAreas`, `gdAuto`, `gdColumn`, `gdColumns`, `gdGap`, `gdGridAlign`, `gdInline`, `gdRow`, and `gdRows`: Literal values convert when compiler output, display composition, context, and ownership are exact.
 
 All generated lengths that originate in the template use Tailwind arbitrary values. This prevents a project spacing scale from changing `fxLayoutGap="4"` from Angular Flex-Layout's `4px`, or `fxFlexOffset="4"` from its `4%` meaning.
@@ -101,7 +101,7 @@ When layout and visibility both control `display`, the planner composes them bef
 
 ## Grid directives
 
-Grid container and child directives convert for literal base values and the 13 standard viewport aliases when their complete declaration, display, parent context, and existing ownership are safe. Container directives share one `grid` or `inline-grid` display state; `gdInline` is composed with that state. Bound values, orientation and print aliases, custom breakpoints, unsafe parent context, and compiler-unverified values remain unchanged with diagnostics.
+Grid container and child directives convert for literal base values, the 13 standard viewport aliases, and explicitly configured orientation and print aliases when their complete declaration, display, parent context, and existing ownership are safe. Container directives share one `grid` or `inline-grid` display state; `gdInline` is composed with that state. Bound values, unconfigured or custom breakpoints, unsafe parent context, and compiler-unverified values remain unchanged with diagnostics.
 
 ## Responsive class and style inputs
 
@@ -110,7 +110,7 @@ Grid container and child directives convert for literal base values and the 13 s
 - deprecated `class.<alias>` and `style.<alias>`: Version-dependent replacement and merge behavior is not inferred.
 - responsive `imgSrc`: Recognized and reported; no target conversion is implemented.
 
-The supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`. Each emitted class contains the exact Angular Flex-Layout media range rather than a project-defined Tailwind breakpoint.
+The always-supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`. Each emitted class contains the exact Angular Flex-Layout media range rather than a project-defined Tailwind breakpoint. Explicit configuration additionally enables orientation and print as described below.
 
 ```html
 <!-- input -->
@@ -138,7 +138,7 @@ The following inputs are always preserved:
 
 - property, two-way, and `bind-` forms, even when an expression appears constant;
 - interpolated values;
-- orientation, print, custom, and empty breakpoint suffixes;
+- unconfigured orientation or print aliases, custom aliases, and empty breakpoint suffixes;
 - deprecated `class.<alias>` and `style.<alias>` selectors;
 - project-specific classes, plugin utilities, and candidates whose meaning depends on custom Tailwind theme values;
 - style values that cannot be encoded with equivalent sanitized CSS semantics;
@@ -154,10 +154,18 @@ Literal responsive values using the standard Angular Flex-Layout viewport aliase
 
 Base values and disjoint responsive values may convert together. Overlapping responsive values convert only when they emit the same utility. A conflicting overlap preserves the entire directive family with `responsive-precedence-unverified`; an existing utility that controls the same property in an intersecting range preserves the family with `class-conflict`. See [Exact responsive breakpoint conversion](architecture/responsive-breakpoints.md) for the exact ranges, conflict rules, and diagnostic contract.
 
+### Project-aware orientation and print
+
+Orientation and print conversion require explicit source-configuration evidence. `--orientation-breakpoints` confirms the source application uses the archived `addOrientationBps: true` definitions. It enables `handset`, `handset.portrait`, `handset.landscape`, `tablet`, `tablet.portrait`, `tablet.landscape`, `web`, `web.portrait`, and `web.landscape` with their exact width-and-orientation conditions. Composite aliases emit separate portrait and landscape media variants; conflicting overlaps remain atomic and preserved.
+
+`--print-with-breakpoints <aliases>` confirms the source application's `printWithBreakpoints` value. Supply a comma-separated list such as `md,handset`, or use `none` to assert an empty list. The list accepts standard aliases and orientation aliases enabled in the same invocation. During print, configured responsive values become print fallbacks even though their screen queries do not match; an explicit `.print` value wins. Duplicate, unknown, `print`, empty, or disabled-orientation entries are configuration errors before migration.
+
+Omitting either flag preserves the corresponding aliases with `breakpoint-unverified`. The flags are assertions, not discovery: verify the application's Flex-Layout provider configuration before using them. See [Tailwind orientation and print migration](architecture/tailwind-orientation-print-migration.md) for the exact definitions and planner contract.
+
 The current safety gate preserves these cases for review:
 
 - every Angular property binding, including bindings whose expression appears constant;
-- orientation and print aliases;
+- orientation and print aliases without their corresponding explicit configuration;
 - unknown aliases, because they may be registered as custom project breakpoints;
 - visibility whose shown state needs a display value that cannot be proven from template and layout semantics;
 - visibility on an element whose literal or bound style may control `display`;

--- a/scripts/release-artifact.spec.ts
+++ b/scripts/release-artifact.spec.ts
@@ -220,7 +220,7 @@ async function withRealPackRepository(run: (repository: string) => Promise<void>
       `#!/usr/bin/env node
 const arguments_ = process.argv.slice(2);
 if (arguments_.includes('--help')) {
-  console.log('--dry-run --report <path> --allow-unresolved path must end in .json single-file output must end in .html');
+  console.log('--dry-run --report <path> --allow-unresolved --orientation-breakpoints --print-with-breakpoints <aliases> path must end in .json single-file output must end in .html');
 } else if (arguments_.includes('--version')) {
   console.log('${repositoryManifest.version}');
 } else if (arguments_.includes('--dry-run')) {

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -85,15 +85,21 @@ export async function smokePackageTarball({
       platform === 'win32' ? nodeExecutable : join(temporaryDirectory, 'node_modules', '.bin', 'flex-layout-codemod');
     const executableArguments = platform === 'win32' ? [installedModuleExecutable] : [];
     const help = await execFileImpl(executable, [...executableArguments, '--help'], { cwd: temporaryDirectory });
-    for (const option of ['--dry-run', '--report <path>', '--allow-unresolved']) {
+    for (const option of [
+      '--dry-run',
+      '--report <path>',
+      '--allow-unresolved',
+      '--orientation-breakpoints',
+      '--print-with-breakpoints <aliases>',
+    ]) {
       if (!help.stdout.includes(option)) {
         throw new Error(`Packaged CLI help is missing ${option}`);
       }
     }
-    if (!help.stdout.includes('path must end in .json')) {
+    if (!/path must\s+end in \.json/u.test(help.stdout)) {
       throw new Error('Packaged CLI help is missing the JSON report extension requirement');
     }
-    if (!/single-file output must end\s+in \.html/.test(help.stdout)) {
+    if (!/single-file\s+output must\s+end\s+in \.html/u.test(help.stdout)) {
       throw new Error('Packaged CLI help is missing the HTML single-file output requirement');
     }
 

--- a/scripts/verify-package.spec.ts
+++ b/scripts/verify-package.spec.ts
@@ -11,7 +11,7 @@ describe('smokePackageTarball', () => {
       if (args.includes('--help')) {
         return {
           stdout:
-            '--dry-run --report <path> --allow-unresolved path must end in .json single-file output must end in .html',
+            '--dry-run --report <path> --allow-unresolved --orientation-breakpoints --print-with-breakpoints <aliases> path must\n end in .json single-file\n output must end\n in .html',
           stderr: '',
         };
       }
@@ -41,7 +41,7 @@ describe('smokePackageTarball', () => {
       if (args.includes('--help')) {
         return {
           stdout:
-            '--dry-run --report <path> --allow-unresolved path must end in .json single-file output must end in .html',
+            '--dry-run --report <path> --allow-unresolved --orientation-breakpoints --print-with-breakpoints <aliases> path must end in .json single-file output must end in .html',
           stderr: '',
         };
       }

--- a/src/adapter/adapter.factory.spec.ts
+++ b/src/adapter/adapter.factory.spec.ts
@@ -6,6 +6,15 @@ describe('AdapterFactory', () => {
     expect(AdapterFactory.create('tailwind')).toBeInstanceOf(TailwindAdapter);
   });
 
+  test('creates the Tailwind adapter with breakpoint migration configuration', () => {
+    expect(
+      AdapterFactory.create('tailwind', {
+        orientationBreakpoints: true,
+        printWithBreakpoints: Object.freeze(['md']),
+      }),
+    ).toBeInstanceOf(TailwindAdapter);
+  });
+
   test('rejects unknown targets', () => {
     expect(() => AdapterFactory.create('unknown')).toThrow('Adapter [unknown] not found');
   });

--- a/src/adapter/adapter.factory.ts
+++ b/src/adapter/adapter.factory.ts
@@ -1,11 +1,15 @@
 import { logger } from '../logger';
 import type { ConversionAdapter } from './conversion-adapter';
 import { TailwindAdapter } from './tailwind/tailwind.adapter';
+import type { BreakpointMigrationConfig } from '../config/breakpoint-migration-config';
 
 export class AdapterFactory {
-  static create(target: string): ConversionAdapter {
+  static create(
+    target: string,
+    config: BreakpointMigrationConfig = { orientationBreakpoints: false },
+  ): ConversionAdapter {
     logger.info(`Creating adapter [${target}]`);
-    if (target === 'tailwind') return new TailwindAdapter();
+    if (target === 'tailwind') return new TailwindAdapter(config);
     throw new Error(`Adapter [${target}] not found`);
   }
 }

--- a/src/adapter/tailwind/extended/extended-display-composition.planner.spec.ts
+++ b/src/adapter/tailwind/extended/extended-display-composition.planner.spec.ts
@@ -17,7 +17,7 @@ function definition(alias: string) {
 }
 
 function responsive(alias: string, utility: string): string {
-  return emitter.emit(definition(alias), utility);
+  return emitter.emit(definition(alias), utility)[0] ?? '';
 }
 
 function responsiveExtended(alias: string, utility: string): string {

--- a/src/adapter/tailwind/extended/extended-family.planner.ts
+++ b/src/adapter/tailwind/extended/extended-family.planner.ts
@@ -1,7 +1,7 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
 import {
   BreakpointCatalog,
-  mediaRangesIntersect,
+  mediaDefinitionsIntersect,
   type BreakpointClassification,
 } from '../../../breakpoint/breakpoint-catalog';
 import type { PlannedConversion } from '../../conversion-adapter';
@@ -194,7 +194,7 @@ export class ExtendedFamilyPlanner {
         .some(
           right =>
             !equals(left.value, right.value) &&
-            mediaRangesIntersect(left.activation.definition.range, right.activation.definition.range),
+            mediaDefinitionsIntersect(left.activation.definition.media, right.activation.definition.media),
         ),
     );
   }

--- a/src/adapter/tailwind/extended/extended-family.planner.ts
+++ b/src/adapter/tailwind/extended/extended-family.planner.ts
@@ -61,8 +61,11 @@ function unresolvedBreakpoint(
     status: 'review',
     input,
     code: 'breakpoint-unverified',
-    reason: `Exact media-query output for the ${kind} breakpoint alias ${classification.alias} is not implemented.`,
-    suggestion: 'Keep the responsive directive until exact breakpoint support is available.',
+    reason: `The ${kind} breakpoint alias ${classification.alias} is not enabled by explicit migration configuration.`,
+    suggestion:
+      classification.kind === 'print'
+        ? 'Verify the source printWithBreakpoints value, then rerun with --print-with-breakpoints.'
+        : 'Verify that the source enables orientation breakpoints, then rerun with --orientation-breakpoints.',
   };
 }
 

--- a/src/adapter/tailwind/extended/extended-responsive.emitter.ts
+++ b/src/adapter/tailwind/extended/extended-responsive.emitter.ts
@@ -24,7 +24,7 @@ export class ExtendedResponsiveEmitter {
       if (classification.status !== 'verified' || classification.descriptor.cssProperties.length === 0) {
         throw new Error('Cannot emit an unverified or ungrouped Tailwind class candidate.');
       }
-      emitted.push(this.responsiveEmitter.emitCandidate(state.activation.definition, token));
+      emitted.push(...this.responsiveEmitter.emitCandidate(state.activation.definition, token));
     }
 
     return emitted;
@@ -43,7 +43,7 @@ export class ExtendedResponsiveEmitter {
       if (descriptor === undefined || descriptor.cssProperties.length === 0) {
         throw new Error('Cannot emit an ungrouped Tailwind arbitrary-property candidate.');
       }
-      emitted.push(this.responsiveEmitter.emitCandidate(state.activation.definition, candidate));
+      emitted.push(...this.responsiveEmitter.emitCandidate(state.activation.definition, candidate));
     }
 
     return emitted;

--- a/src/adapter/tailwind/extended/generated-property-composition.planner.spec.ts
+++ b/src/adapter/tailwind/extended/generated-property-composition.planner.spec.ts
@@ -13,7 +13,7 @@ const emitter = new ResponsiveVariantEmitter();
 function responsive(alias: string, utility: string): string {
   const classification = catalog.classify(alias);
   if (classification.kind !== 'verified') throw new Error(`Expected ${alias} to be verified.`);
-  return emitter.emit(classification.definition, utility);
+  return emitter.emit(classification.definition, utility)[0] ?? '';
 }
 
 function converted(

--- a/src/adapter/tailwind/extended/responsive-class-value.parser.ts
+++ b/src/adapter/tailwind/extended/responsive-class-value.parser.ts
@@ -1,5 +1,4 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
-import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
 import type { ResponsiveClassValueResult } from './responsive-class.model';
 import type { TailwindCandidateClassifier } from './tailwind-candidate-classifier';
 
@@ -39,8 +38,6 @@ export function parseResponsiveClassValue(
   if (input.directive !== 'ngClass') {
     return { status: 'unverified', reason: 'Deprecated responsive class aliases are not converted.' };
   }
-  if (input.breakpoint === undefined || new BreakpointCatalog().classify(input.breakpoint).kind !== 'verified') {
-    return { status: 'unverified', reason: 'The responsive class breakpoint is not a verified viewport alias.' };
-  }
+  if (!input.breakpoint) return { status: 'unverified', reason: 'A responsive class alias is required.' };
   return parseLiteralResponsiveClassValue(input.value, classifier);
 }

--- a/src/adapter/tailwind/extended/responsive-style-value.parser.ts
+++ b/src/adapter/tailwind/extended/responsive-style-value.parser.ts
@@ -1,5 +1,4 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
-import { BreakpointCatalog } from '../../../breakpoint/breakpoint-catalog';
 import type { LiteralStyleDeclaration, ResponsiveStyleValueResult } from './responsive-style.model';
 import { TailwindArbitraryPropertyEncoder } from './tailwind-arbitrary-property.encoder';
 import { cssPropertiesOverlap } from './css-property-ownership';
@@ -194,9 +193,7 @@ export function parseResponsiveStyleValue(input: LocatedFlexLayoutInput): Respon
   if (input.directive !== 'ngStyle') {
     return { status: 'unverified', reason: 'Deprecated responsive style aliases are not converted.' };
   }
-  if (input.breakpoint === undefined || new BreakpointCatalog().classify(input.breakpoint).kind !== 'verified') {
-    return { status: 'unverified', reason: 'The responsive style breakpoint is not a verified viewport alias.' };
-  }
+  if (!input.breakpoint) return { status: 'unverified', reason: 'A responsive style alias is required.' };
   if (interpolation.test(input.value)) {
     return { status: 'unverified', reason: 'Responsive style interpolation may depend on runtime state.' };
   }

--- a/src/adapter/tailwind/responsive-family.planner.ts
+++ b/src/adapter/tailwind/responsive-family.planner.ts
@@ -125,6 +125,15 @@ function sameClasses(left: PlannedConversion, right: PlannedConversion): boolean
   );
 }
 
+function printCandidate(candidate: string): string {
+  if (candidate.startsWith('[@media_print]:')) return candidate;
+  if (candidate.startsWith('[@media_')) {
+    const variantEnd = candidate.indexOf(']:');
+    if (variantEnd >= 0) return `[@media_print]${candidate.slice(variantEnd + 1)}`;
+  }
+  return `[@media_print]:${candidate}`;
+}
+
 function numericRange(range: MediaRange): NumericRange {
   return {
     min: range.min ?? Number.NEGATIVE_INFINITY,
@@ -329,7 +338,11 @@ export class ResponsiveFamilyPlanner {
     const plansById = new Map<string, PlannedConversion>();
     for (const [family, plans] of rawPlansByFamily) {
       const shouldDecorate = decorate && family !== 'extended-class' && family !== 'extended-style';
-      for (const plan of plans) plansById.set(plan.input.id, shouldDecorate ? this.decorate(plan) : plan);
+      const decoratedPlans = plans.map(plan => (shouldDecorate ? this.decorate(plan) : plan));
+      const printAwarePlans = decorate
+        ? this.addPrintFallback(groups.get(family) ?? [], decoratedPlans)
+        : decoratedPlans;
+      for (const plan of printAwarePlans) plansById.set(plan.input.id, plan);
     }
     for (const input of ungrouped) {
       const plan = planOne(input, completeContext);
@@ -340,6 +353,49 @@ export class ResponsiveFamilyPlanner {
       if (planned) return planned;
       const plan = planOne(input, completeContext);
       return decorate ? this.decorate(plan) : plan;
+    });
+  }
+
+  private addPrintFallback(
+    inputs: readonly LocatedFlexLayoutInput[],
+    plans: readonly PlannedConversion[],
+  ): readonly PlannedConversion[] {
+    const configuredAliases = this.catalog.printWithBreakpoints;
+    if (configuredAliases === undefined || plans.some(plan => plan.status !== 'converted')) return plans;
+    if (inputs.some(input => input.breakpoint === 'print')) return plans;
+
+    const configured = inputs
+      .map((input, index) => ({
+        input,
+        index,
+        classification: input.breakpoint === undefined ? undefined : this.catalog.classify(input.breakpoint),
+      }))
+      .filter(
+        (
+          item,
+        ): item is typeof item & {
+          readonly classification: Extract<ReturnType<BreakpointCatalog['classify']>, { readonly kind: 'verified' }>;
+        } =>
+          item.input.breakpoint !== undefined &&
+          configuredAliases.includes(item.input.breakpoint) &&
+          item.classification !== undefined &&
+          item.classification.kind === 'verified',
+      )
+      .sort(
+        (left, right) =>
+          right.classification.definition.priority - left.classification.definition.priority ||
+          configuredAliases.indexOf(left.input.breakpoint ?? '') -
+            configuredAliases.indexOf(right.input.breakpoint ?? ''),
+      );
+    const selected = configured[0];
+    if (!selected) return plans;
+
+    return plans.map((plan, index) => {
+      if (index !== selected.index || plan.status !== 'converted') return plan;
+      return {
+        ...plan,
+        classNames: [...new Set([...plan.classNames, ...plan.classNames.map(printCandidate)])],
+      };
     });
   }
 

--- a/src/adapter/tailwind/responsive-family.planner.ts
+++ b/src/adapter/tailwind/responsive-family.planner.ts
@@ -1,5 +1,10 @@
 import type { LocatedFlexLayoutInput } from '../../analyzer/flex-layout-attribute.analyzer';
-import { BreakpointCatalog, mediaRangesIntersect, type MediaRange } from '../../breakpoint/breakpoint-catalog';
+import {
+  BreakpointCatalog,
+  mediaDefinitionsIntersect,
+  mediaRangesIntersect,
+  type MediaRange,
+} from '../../breakpoint/breakpoint-catalog';
 import type { ConversionContext, PlannedConversion } from '../conversion-adapter';
 import { planResponsiveClasses } from './responsive-plan';
 import { ResponsiveVariantEmitter } from './responsive-variant.emitter';
@@ -514,7 +519,7 @@ export class ResponsiveFamilyPlanner {
         const rightClassification = this.catalog.classify(rightInput.breakpoint);
         if (
           rightClassification.kind === 'verified' &&
-          mediaRangesIntersect(leftClassification.definition.range, rightClassification.definition.range) &&
+          mediaDefinitionsIntersect(leftClassification.definition.media, rightClassification.definition.media) &&
           !sameClasses(leftPlan, rightPlan)
         ) {
           return inputs.map(input => ({

--- a/src/adapter/tailwind/responsive-plan.spec.ts
+++ b/src/adapter/tailwind/responsive-plan.spec.ts
@@ -49,4 +49,14 @@ describe('planResponsiveClasses', () => {
   ] as const)('preserves the unverified %s breakpoint alias', (breakpoint, code) => {
     expect(plan({ sourceName: `fxFlexAlign.${breakpoint}`, breakpoint })).toMatchObject({ status: 'review', code });
   });
+
+  test.each([
+    ['handset', '--orientation-breakpoints'],
+    ['print', '--print-with-breakpoints'],
+  ])('identifies the required configuration evidence for %s', (breakpoint, option) => {
+    expect(plan({ sourceName: `fxFlexAlign.${breakpoint}`, breakpoint })).toMatchObject({
+      status: 'review',
+      suggestion: expect.stringContaining(option),
+    });
+  });
 });

--- a/src/adapter/tailwind/responsive-plan.ts
+++ b/src/adapter/tailwind/responsive-plan.ts
@@ -24,7 +24,7 @@ export function planResponsiveClasses(
   if (classification.kind === 'verified') {
     return {
       status: 'converted',
-      classNames: classNames.map(className => emitter.emit(classification.definition, className)),
+      classNames: classNames.flatMap(className => emitter.emit(classification.definition, className)),
     };
   }
 

--- a/src/adapter/tailwind/responsive-plan.ts
+++ b/src/adapter/tailwind/responsive-plan.ts
@@ -42,7 +42,10 @@ export function planResponsiveClasses(
   return {
     status: 'review',
     code: 'breakpoint-unverified',
-    reason: `Exact media-query output for the ${kind} breakpoint alias ${alias} is not implemented.`,
-    suggestion: 'Keep the responsive directive until exact breakpoint support is available.',
+    reason: `The ${kind} breakpoint alias ${alias} is not enabled by explicit migration configuration.`,
+    suggestion:
+      classification.kind === 'print'
+        ? 'Verify the source printWithBreakpoints value, then rerun with --print-with-breakpoints.'
+        : 'Verify that the source enables orientation breakpoints, then rerun with --orientation-breakpoints.',
   };
 }

--- a/src/adapter/tailwind/responsive-variant.emitter.spec.ts
+++ b/src/adapter/tailwind/responsive-variant.emitter.spec.ts
@@ -15,7 +15,7 @@ describe('ResponsiveVariantEmitter', () => {
     ['lt-sm', 'flex-col', '[@media_screen_and_(max-width:_599.98px)]:flex-col'],
     ['sm', 'flex-col', '[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:flex-col'],
   ])('emits the exact %s media variant for %s', (alias, utility, expected) => {
-    expect(new ResponsiveVariantEmitter().emit(definition(alias), utility)).toBe(expected);
+    expect(new ResponsiveVariantEmitter().emit(definition(alias), utility)).toEqual([expected]);
   });
 
   test.each(['sm:flex-col', '[@media_screen_and_(min-width:_600px)]:flex-col'])(
@@ -40,9 +40,9 @@ describe('ResponsiveVariantEmitter', () => {
   });
 
   test('preserves a structurally valid escaped closing bracket inside an arbitrary utility', () => {
-    expect(new ResponsiveVariantEmitter().emit(definition('sm'), '[content:\\]]')).toBe(
+    expect(new ResponsiveVariantEmitter().emit(definition('sm'), '[content:\\]]')).toEqual([
       '[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:[content:\\]]',
-    );
+    ]);
   });
 
   test.each([
@@ -52,7 +52,7 @@ describe('ResponsiveVariantEmitter', () => {
     ['sm', 'hover:-mt-2', '[@media_screen_and_(min-width:_600px)_and_(max-width:_959.98px)]:hover:-mt-2'],
     ['gt-xs', 'dark:flex!', '[@media_screen_and_(min-width:_600px)]:dark:flex!'],
   ])('places the exact %s media variant before ordinary variants in %s', (alias, candidate, expected) => {
-    expect(new ResponsiveVariantEmitter().emitCandidate(definition(alias), candidate)).toBe(expected);
+    expect(new ResponsiveVariantEmitter().emitCandidate(definition(alias), candidate)).toEqual([expected]);
   });
 
   test.each([
@@ -62,5 +62,25 @@ describe('ResponsiveVariantEmitter', () => {
     expect(() => new ResponsiveVariantEmitter().emitCandidate(definition('sm'), candidate)).toThrow(
       'Cannot decorate a candidate containing a generated media variant',
     );
+  });
+
+  test('emits every composite orientation clause in canonical order', () => {
+    const classification = new BreakpointCatalog({ orientationBreakpoints: true }).classify('handset');
+    if (classification.kind !== 'verified') throw new Error('Expected handset to be verified');
+
+    expect(new ResponsiveVariantEmitter().emit(classification.definition, 'flex-col')).toEqual([
+      '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex-col',
+      '[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex-col',
+    ]);
+  });
+
+  test('emits print as an exact media variant', () => {
+    const classification = new BreakpointCatalog({
+      orientationBreakpoints: false,
+      printWithBreakpoints: [],
+    }).classify('print');
+    if (classification.kind !== 'verified') throw new Error('Expected print to be verified');
+
+    expect(new ResponsiveVariantEmitter().emit(classification.definition, 'hidden')).toEqual(['[@media_print]:hidden']);
   });
 });

--- a/src/adapter/tailwind/responsive-variant.emitter.ts
+++ b/src/adapter/tailwind/responsive-variant.emitter.ts
@@ -1,8 +1,8 @@
-import type { BreakpointDefinition, MediaRange } from '../../breakpoint/breakpoint-catalog';
+import type { BreakpointDefinition, MediaClause, MediaDefinition } from '../../breakpoint/breakpoint-catalog';
 import { describeTailwindUtility } from './tailwind-class-conflict';
 
 export class ResponsiveVariantEmitter {
-  emit(definition: BreakpointDefinition, utility: string): string {
+  emit(definition: BreakpointDefinition, utility: string): readonly string[] {
     const descriptor = describeTailwindUtility(utility);
     if (descriptor === undefined) {
       throw new Error('Cannot decorate a malformed Tailwind utility');
@@ -11,10 +11,10 @@ export class ResponsiveVariantEmitter {
       throw new Error('Cannot decorate an already-variant utility');
     }
 
-    return `[${this.mediaQuery(definition.range)}]:${utility}`;
+    return definition.media.clauses.map(clause => `[${this.mediaQuery(definition.media, clause)}]:${utility}`);
   }
 
-  emitCandidate(definition: BreakpointDefinition, candidate: string): string {
+  emitCandidate(definition: BreakpointDefinition, candidate: string): readonly string[] {
     const descriptor = describeTailwindUtility(candidate);
     if (descriptor === undefined) {
       throw new Error('Cannot decorate a malformed Tailwind candidate');
@@ -23,15 +23,19 @@ export class ResponsiveVariantEmitter {
       throw new Error('Cannot decorate a candidate containing a generated media variant');
     }
 
-    return `[${this.mediaQuery(definition.range)}]:${candidate}`;
+    return definition.media.clauses.map(clause => `[${this.mediaQuery(definition.media, clause)}]:${candidate}`);
   }
 
-  private mediaQuery(range: MediaRange): string {
+  private mediaQuery(media: MediaDefinition, clause: MediaClause): string {
+    if (media.type === 'print') return '@media_print';
+
     const conditions = [
-      range.min === undefined ? undefined : `(min-width:_${range.min}px)`,
-      range.max === undefined ? undefined : `(max-width:_${range.max}px)`,
+      clause.orientation === undefined ? undefined : `(orientation:_${clause.orientation})`,
+      clause.min === undefined ? undefined : `(min-width:_${clause.min}px)`,
+      clause.max === undefined ? undefined : `(max-width:_${clause.max}px)`,
     ].filter((condition): condition is string => condition !== undefined);
 
-    return `@media_screen_and_${conditions.join('_and_')}`;
+    const medium = clause.orientation === undefined ? 'screen_and_' : '';
+    return `@media_${medium}${conditions.join('_and_')}`;
   }
 }

--- a/src/adapter/tailwind/tailwind-class-conflict.spec.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.spec.ts
@@ -586,6 +586,14 @@ describe('findTailwindClassConflicts', () => {
     expect(findTailwindClassConflicts([portrait], [landscape])).toEqual(new Set());
   });
 
+  test('keeps print ownership disjoint from screen media ownership', () => {
+    const screen = '[@media_screen_and_(min-width:_600px)]:flex-row';
+    const print = '[@media_print]:flex-col';
+
+    expect(findTailwindClassConflicts([screen], [print])).toEqual(new Set());
+    expect(findTailwindClassConflicts(['[@media_print]:flex-row'], [print])).toEqual(new Set([print]));
+  });
+
   test('returns the generated token when responsive ranges overlap', () => {
     const generated = sm('flex-col');
 

--- a/src/adapter/tailwind/tailwind-class-conflict.spec.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.spec.ts
@@ -579,6 +579,13 @@ describe('findTailwindClassConflicts', () => {
     expect(findTailwindClassConflicts([xs('flex-row')], [sm('flex-col')])).toEqual(new Set());
   });
 
+  test('does not conflict when generated orientation conditions are disjoint', () => {
+    const portrait = '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex-row';
+    const landscape = '[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex-col';
+
+    expect(findTailwindClassConflicts([portrait], [landscape])).toEqual(new Set());
+  });
+
   test('returns the generated token when responsive ranges overlap', () => {
     const generated = sm('flex-col');
 

--- a/src/adapter/tailwind/tailwind-class-conflict.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.ts
@@ -53,8 +53,10 @@ const displayUtilities = new Set([
   'hidden',
 ]);
 
-const generatedMediaVariant =
+const generatedScreenMediaVariant =
   /^\[@media_screen_and_(?:(?:\(min-width:_(\d+(?:\.\d+)?)px\))(?:_and_\(max-width:_(\d+(?:\.\d+)?)px\))?|\(max-width:_(\d+(?:\.\d+)?)px\))\]$/u;
+const generatedOrientationMediaVariant =
+  /^\[@media_\(orientation:_(portrait|landscape)\)(?:_and_\(min-width:_(\d+(?:\.\d+)?)px\))?(?:_and_\(max-width:_(\d+(?:\.\d+)?)px\))?\]$/u;
 
 function splitVariants(
   className: string,
@@ -94,7 +96,19 @@ function splitVariants(
 
 function activation(variants: readonly string[]): TailwindActivation {
   for (const variant of variants) {
-    const match = variant.match(generatedMediaVariant);
+    const orientationMatch = variant.match(generatedOrientationMediaVariant);
+    if (orientationMatch) {
+      return {
+        kind: 'media',
+        range: {
+          orientation: orientationMatch[1] as 'portrait' | 'landscape',
+          min: orientationMatch[2] === undefined ? undefined : Number(orientationMatch[2]),
+          max: orientationMatch[3] === undefined ? undefined : Number(orientationMatch[3]),
+        },
+      };
+    }
+
+    const match = variant.match(generatedScreenMediaVariant);
     if (!match) continue;
     const min = match[1] === undefined ? undefined : Number(match[1]);
     const maxValue = match[2] ?? match[3];
@@ -107,7 +121,7 @@ function activation(variants: readonly string[]): TailwindActivation {
 }
 
 function hasGeneratedMediaVariant(variants: readonly string[]): boolean {
-  return variants.some(variant => variant.startsWith('[@media_screen_and_'));
+  return variants.some(variant => variant.startsWith('[@media_'));
 }
 
 function hasInternalDeclarationImportance(utility: string): boolean {

--- a/src/adapter/tailwind/tailwind-class-conflict.ts
+++ b/src/adapter/tailwind/tailwind-class-conflict.ts
@@ -9,7 +9,9 @@ import {
   tailwindArbitraryTextKind,
 } from './extended/tailwind-arbitrary-value-ownership';
 
-export type TailwindActivation = { readonly kind: 'base' } | { readonly kind: 'media'; readonly range: MediaRange };
+export type TailwindActivation =
+  | { readonly kind: 'base' }
+  | { readonly kind: 'media'; readonly range: MediaRange; readonly mediaType?: 'screen' | 'print' };
 
 export interface TailwindDisplayUtility {
   readonly token: string;
@@ -96,6 +98,8 @@ function splitVariants(
 
 function activation(variants: readonly string[]): TailwindActivation {
   for (const variant of variants) {
+    if (variant === '[@media_print]') return { kind: 'media', range: {}, mediaType: 'print' };
+
     const orientationMatch = variant.match(generatedOrientationMediaVariant);
     if (orientationMatch) {
       return {
@@ -599,7 +603,9 @@ export function describeTailwindDisplay(token: string): TailwindDisplayUtility |
 }
 
 function activationsIntersect(left: TailwindActivation, right: TailwindActivation): boolean {
-  return left.kind === 'base' || right.kind === 'base' || mediaRangesIntersect(left.range, right.range);
+  if (left.kind === 'base' || right.kind === 'base') return true;
+  if ((left.mediaType ?? 'screen') !== (right.mediaType ?? 'screen')) return false;
+  return mediaRangesIntersect(left.range, right.range);
 }
 
 export function findTailwindClassConflicts(

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -222,6 +222,107 @@ describe('TailwindAdapter', () => {
     ]);
   });
 
+  test('emits a configured responsive value as the effective print fallback', () => {
+    const base = input({ id: 'fixture:base', value: 'row' });
+    const md = input({
+      id: 'fixture:md',
+      sourceName: 'fxLayout.md',
+      breakpoint: 'md',
+      value: 'column',
+    });
+
+    const plans = new TailwindAdapter({
+      orientationBreakpoints: false,
+      printWithBreakpoints: ['md'],
+    }).planElement([base, md], { element, inputs: [base, md] });
+
+    expect(plans[0]).toMatchObject({ status: 'converted', classNames: ['flex', 'flex-row', 'box-border'] });
+    expect(plans[1]).toMatchObject({
+      status: 'converted',
+      classNames: expect.arrayContaining([
+        '[@media_print]:flex',
+        '[@media_print]:flex-col',
+        '[@media_print]:box-border',
+      ]),
+    });
+  });
+
+  test('lets an explicit print value override configured responsive fallbacks', () => {
+    const md = input({ id: 'fixture:md', sourceName: 'fxLayout.md', breakpoint: 'md', value: 'column' });
+    const print = input({ id: 'fixture:print', sourceName: 'fxLayout.print', breakpoint: 'print', value: 'row' });
+
+    const plans = new TailwindAdapter({
+      orientationBreakpoints: false,
+      printWithBreakpoints: ['md'],
+    }).planElement([md, print], { element, inputs: [md, print] });
+
+    expect(plans[0]).toMatchObject({ status: 'converted' });
+    expect(plans[0]?.status === 'converted' ? plans[0].classNames : []).not.toContain('[@media_print]:flex-col');
+    expect(plans[1]).toMatchObject({
+      status: 'converted',
+      classNames: ['[@media_print]:flex', '[@media_print]:flex-row', '[@media_print]:box-border'],
+    });
+  });
+
+  test('uses the highest-priority configured responsive value during print', () => {
+    const md = input({ id: 'fixture:md', sourceName: 'fxLayout.md', breakpoint: 'md', value: 'row' });
+    const handset = input({
+      id: 'fixture:handset',
+      sourceName: 'fxLayout.handset',
+      breakpoint: 'handset',
+      value: 'column',
+    });
+
+    const plans = new TailwindAdapter({
+      orientationBreakpoints: true,
+      printWithBreakpoints: ['md', 'handset'],
+    }).planElement([md, handset], { element, inputs: [md, handset] });
+
+    expect(plans[1]).toMatchObject({
+      status: 'converted',
+      classNames: expect.arrayContaining(['[@media_print]:flex-col']),
+    });
+    expect(plans[0]?.status === 'converted' ? plans[0].classNames : []).not.toContain('[@media_print]:flex-row');
+  });
+
+  test('adds print fallbacks for responsive class, style, and Grid families', () => {
+    const responsiveClass = input({
+      id: 'fixture:class',
+      directive: 'ngClass',
+      sourceName: 'ngClass.md',
+      breakpoint: 'md',
+      value: 'flex',
+    });
+    const responsiveStyle = input({
+      id: 'fixture:style',
+      directive: 'ngStyle',
+      sourceName: 'ngStyle.md',
+      breakpoint: 'md',
+      value: 'color:red',
+    });
+    const columns = input({
+      id: 'fixture:columns',
+      directive: 'gdColumns',
+      sourceName: 'gdColumns.md',
+      breakpoint: 'md',
+      value: '1fr',
+    });
+    const adapter = new TailwindAdapter({ orientationBreakpoints: false, printWithBreakpoints: ['md'] });
+
+    expect(adapter.planElement([responsiveClass], { element, inputs: [responsiveClass] })[0]).toMatchObject({
+      status: 'converted',
+      classNames: expect.arrayContaining(['[@media_print]:flex']),
+    });
+    expect(adapter.planElement([responsiveStyle], { element, inputs: [responsiveStyle] })[0]).toMatchObject({
+      status: 'converted',
+      classNames: expect.arrayContaining(['[@media_print]:[color:red]']),
+    });
+    expect(adapter.planElement([columns], { element, inputs: [columns] })[0]).toMatchObject({
+      status: 'converted',
+      classNames: expect.arrayContaining(['[@media_print]:grid', '[@media_print]:[grid-template-columns:1fr]']),
+    });
+  });
+
   test('encodes quoted gdAreas rows without introducing an HTML delimiter collision', () => {
     const gridInput = input({ directive: 'gdAreas', sourceName: 'gdAreas', value: 'header | main' });
 

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -90,6 +90,138 @@ describe('TailwindAdapter', () => {
     });
   });
 
+  test('converts explicitly enabled composite orientation breakpoints', () => {
+    const member = input({ sourceName: 'fxLayout.handset', breakpoint: 'handset', value: 'column' });
+
+    expect(
+      new TailwindAdapter({ orientationBreakpoints: true }).planElement([member], {
+        element,
+        inputs: [member],
+      }),
+    ).toEqual([
+      {
+        status: 'converted',
+        input: member,
+        classNames: [
+          '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex',
+          '[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex',
+          '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex-col',
+          '[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex-col',
+          '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:box-border',
+          '[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:box-border',
+        ],
+      },
+    ]);
+  });
+
+  test('converts different values in disjoint portrait and landscape activations', () => {
+    const portrait = input({
+      id: 'fixture:portrait',
+      sourceName: 'fxLayout.handset.portrait',
+      breakpoint: 'handset.portrait',
+      value: 'column',
+    });
+    const landscape = input({
+      id: 'fixture:landscape',
+      sourceName: 'fxLayout.handset.landscape',
+      breakpoint: 'handset.landscape',
+      value: 'row',
+    });
+
+    const plans = new TailwindAdapter({ orientationBreakpoints: true }).planElement([portrait, landscape], {
+      element,
+      inputs: [portrait, landscape],
+    });
+
+    expect(plans).toEqual([
+      expect.objectContaining({ status: 'converted' }),
+      expect.objectContaining({ status: 'converted' }),
+    ]);
+  });
+
+  test('preserves differing values in intersecting composite and specific orientation aliases', () => {
+    const handset = input({
+      id: 'fixture:handset',
+      sourceName: 'fxLayout.handset',
+      breakpoint: 'handset',
+      value: 'column',
+    });
+    const portrait = input({
+      id: 'fixture:portrait',
+      sourceName: 'fxLayout.handset.portrait',
+      breakpoint: 'handset.portrait',
+      value: 'row',
+    });
+
+    expect(
+      new TailwindAdapter({ orientationBreakpoints: true }).planElement([handset, portrait], {
+        element,
+        inputs: [handset, portrait],
+      }),
+    ).toEqual([
+      expect.objectContaining({ status: 'review', code: 'responsive-precedence-unverified' }),
+      expect.objectContaining({ status: 'review', code: 'responsive-precedence-unverified' }),
+    ]);
+  });
+
+  test('converts orientation visibility, responsive class, and responsive style families', () => {
+    const hidden = input({
+      id: 'fixture:hidden',
+      directive: 'fxShow',
+      sourceName: 'fxShow',
+      value: 'false',
+    });
+    const shown = input({
+      id: 'fixture:shown',
+      directive: 'fxShow',
+      sourceName: 'fxShow.handset.portrait',
+      breakpoint: 'handset.portrait',
+      value: '',
+    });
+    const responsiveClass = input({
+      id: 'fixture:class',
+      directive: 'ngClass',
+      sourceName: 'ngClass.handset.landscape',
+      breakpoint: 'handset.landscape',
+      value: 'flex',
+    });
+    const responsiveStyle = input({
+      id: 'fixture:style',
+      directive: 'ngStyle',
+      sourceName: 'ngStyle.web.portrait',
+      breakpoint: 'web.portrait',
+      value: 'color:red',
+    });
+
+    const adapter = new TailwindAdapter({ orientationBreakpoints: true });
+
+    expect(
+      adapter.planElement([hidden, shown], {
+        element,
+        inputs: [hidden, shown],
+        existingClassNames: ['block'],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        status: 'converted',
+        classNames: ['hidden', '[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:block'],
+      }),
+      expect.objectContaining({ status: 'converted', classNames: [] }),
+    ]);
+    expect(adapter.planElement([responsiveClass], { element, inputs: [responsiveClass] })).toEqual([
+      expect.objectContaining({
+        status: 'converted',
+        classNames: ['[@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex'],
+      }),
+    ]);
+    expect(adapter.planElement([responsiveStyle], { element, inputs: [responsiveStyle] })).toEqual([
+      expect.objectContaining({
+        status: 'converted',
+        classNames: ['[@media_(orientation:_portrait)_and_(min-width:_840px)]:[color:red]'],
+      }),
+    ]);
+  });
+
   test('encodes quoted gdAreas rows without introducing an HTML delimiter collision', () => {
     const gridInput = input({ directive: 'gdAreas', sourceName: 'gdAreas', value: 'header | main' });
 

--- a/src/adapter/tailwind/tailwind.adapter.ts
+++ b/src/adapter/tailwind/tailwind.adapter.ts
@@ -28,6 +28,7 @@ import { TailwindCandidateClassifier } from './extended/tailwind-candidate-class
 import { GeneratedPropertyCompositionPlanner } from './extended/generated-property-composition.planner';
 import { parseGridValue } from '../../grid/grid-value.parser';
 import { TailwindGridRenderer } from './grid/tailwind-grid.renderer';
+import type { BreakpointMigrationConfig } from '../../config/breakpoint-migration-config';
 
 const flexItemDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxFlex', 'fxGrow', 'fxShrink']);
 const visibilityDirectives = new Set<LocatedFlexLayoutInput['directive']>(['fxShow', 'fxHide']);
@@ -192,6 +193,8 @@ function equalStyleValues(left: ResponsiveStyleValue, right: ResponsiveStyleValu
 
 export class TailwindAdapter implements ConversionAdapter {
   readonly name = 'tailwind' as const;
+  constructor(_config: BreakpointMigrationConfig = { orientationBreakpoints: false }) {}
+
   private readonly breakpointCatalog = new BreakpointCatalog();
   private readonly responsiveEmitter = new ResponsiveVariantEmitter();
   private readonly responsiveFamilyPlanner = new ResponsiveFamilyPlanner(

--- a/src/adapter/tailwind/tailwind.adapter.ts
+++ b/src/adapter/tailwind/tailwind.adapter.ts
@@ -193,29 +193,34 @@ function equalStyleValues(left: ResponsiveStyleValue, right: ResponsiveStyleValu
 
 export class TailwindAdapter implements ConversionAdapter {
   readonly name = 'tailwind' as const;
-  constructor(_config: BreakpointMigrationConfig = { orientationBreakpoints: false }) {}
-
-  private readonly breakpointCatalog = new BreakpointCatalog();
+  private readonly breakpointCatalog: BreakpointCatalog;
   private readonly responsiveEmitter = new ResponsiveVariantEmitter();
-  private readonly responsiveFamilyPlanner = new ResponsiveFamilyPlanner(
-    this.breakpointCatalog,
-    this.responsiveEmitter,
-  );
-  private readonly visibilityStatePlanner = new VisibilityStatePlanner(this.breakpointCatalog);
+  private readonly responsiveFamilyPlanner: ResponsiveFamilyPlanner;
+  private readonly visibilityStatePlanner: VisibilityStatePlanner;
   private readonly visibleDisplayResolver = new VisibleDisplayResolver();
-  private readonly displayCompositionPlanner = new DisplayCompositionPlanner(this.breakpointCatalog);
-  private readonly extendedFamilyPlanner = new ExtendedFamilyPlanner(this.breakpointCatalog);
+  private readonly displayCompositionPlanner: DisplayCompositionPlanner;
+  private readonly extendedFamilyPlanner: ExtendedFamilyPlanner;
   private readonly extendedResponsivePlanner = new ExtendedResponsivePlanner();
   private readonly tailwindCandidateClassifier = new TailwindCandidateClassifier();
-  private readonly extendedDisplayCompositionPlanner = new ExtendedDisplayCompositionPlanner(
-    this.breakpointCatalog,
-    this.tailwindCandidateClassifier,
-  );
-  private readonly generatedPropertyCompositionPlanner = new GeneratedPropertyCompositionPlanner(
-    this.breakpointCatalog,
-    this.tailwindCandidateClassifier,
-  );
+  private readonly extendedDisplayCompositionPlanner: ExtendedDisplayCompositionPlanner;
+  private readonly generatedPropertyCompositionPlanner: GeneratedPropertyCompositionPlanner;
   private readonly gridRenderer = new TailwindGridRenderer();
+
+  constructor(config: BreakpointMigrationConfig = { orientationBreakpoints: false }) {
+    this.breakpointCatalog = new BreakpointCatalog(config);
+    this.responsiveFamilyPlanner = new ResponsiveFamilyPlanner(this.breakpointCatalog, this.responsiveEmitter);
+    this.visibilityStatePlanner = new VisibilityStatePlanner(this.breakpointCatalog);
+    this.displayCompositionPlanner = new DisplayCompositionPlanner(this.breakpointCatalog);
+    this.extendedFamilyPlanner = new ExtendedFamilyPlanner(this.breakpointCatalog);
+    this.extendedDisplayCompositionPlanner = new ExtendedDisplayCompositionPlanner(
+      this.breakpointCatalog,
+      this.tailwindCandidateClassifier,
+    );
+    this.generatedPropertyCompositionPlanner = new GeneratedPropertyCompositionPlanner(
+      this.breakpointCatalog,
+      this.tailwindCandidateClassifier,
+    );
+  }
 
   resolveClassConflicts(
     plans: readonly PlannedConversion[],

--- a/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/display-composition.planner.spec.ts
@@ -47,7 +47,7 @@ function layout(classNames: readonly string[], breakpoint?: string, id?: string)
 function variant(breakpoint: string, utility: string): string {
   const classification = new BreakpointCatalog().classify(breakpoint);
   if (classification.kind !== 'verified') throw new Error(`Expected ${breakpoint} to be verified.`);
-  return new ResponsiveVariantEmitter().emit(classification.definition, utility);
+  return new ResponsiveVariantEmitter().emit(classification.definition, utility)[0] ?? '';
 }
 
 function request(

--- a/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.spec.ts
@@ -48,7 +48,12 @@ describe('VisibilityStatePlanner', () => {
           intent: 'shown',
           activation: {
             kind: 'media',
-            definition: { alias: 'sm', range: { min: 600, max: 959.98 }, priority: 900 },
+            definition: {
+              alias: 'sm',
+              range: { min: 600, max: 959.98 },
+              media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] },
+              priority: 900,
+            },
           },
         },
       ],
@@ -68,7 +73,12 @@ describe('VisibilityStatePlanner', () => {
           intent: 'hidden',
           activation: {
             kind: 'media',
-            definition: { alias: 'md', range: { min: 960, max: 1279.98 }, priority: 800 },
+            definition: {
+              alias: 'md',
+              range: { min: 960, max: 1279.98 },
+              media: { type: 'screen', clauses: [{ min: 960, max: 1279.98 }] },
+              priority: 800,
+            },
           },
         },
       ],

--- a/src/adapter/tailwind/visibility/visibility-state.planner.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.ts
@@ -47,8 +47,11 @@ function unresolvedBreakpoint(
     status: 'review',
     input,
     code: 'breakpoint-unverified',
-    reason: `Exact media-query output for the ${kind} breakpoint alias ${classification.alias} is not implemented.`,
-    suggestion: 'Keep the responsive directive until exact breakpoint support is available.',
+    reason: `The ${kind} breakpoint alias ${classification.alias} is not enabled by explicit migration configuration.`,
+    suggestion:
+      classification.kind === 'print'
+        ? 'Verify the source printWithBreakpoints value, then rerun with --print-with-breakpoints.'
+        : 'Verify that the source enables orientation breakpoints, then rerun with --orientation-breakpoints.',
   };
 }
 

--- a/src/adapter/tailwind/visibility/visibility-state.planner.ts
+++ b/src/adapter/tailwind/visibility/visibility-state.planner.ts
@@ -1,7 +1,7 @@
 import type { LocatedFlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';
 import {
   BreakpointCatalog,
-  mediaRangesIntersect,
+  mediaDefinitionsIntersect,
   type BreakpointClassification,
 } from '../../../breakpoint/breakpoint-catalog';
 import type { PlannedConversion } from '../../conversion-adapter';
@@ -143,7 +143,7 @@ export class VisibilityStatePlanner {
         .some(
           right =>
             left.intent !== right.intent &&
-            mediaRangesIntersect(left.activation.definition.range, right.activation.definition.range),
+            mediaDefinitionsIntersect(left.activation.definition.media, right.activation.definition.media),
         ),
     );
   }

--- a/src/adapter/tailwind/visibility/visibility.emitter.ts
+++ b/src/adapter/tailwind/visibility/visibility.emitter.ts
@@ -8,6 +8,6 @@ export class VisibilityEmitter {
     const utility = state.intent === 'hidden' ? 'hidden' : restorationUtility;
     if (utility === undefined) return [];
     if (state.activation.kind === 'base') return [utility];
-    return [this.responsiveEmitter.emit(state.activation.definition, utility)];
+    return this.responsiveEmitter.emit(state.activation.definition, utility);
   }
 }

--- a/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
+++ b/src/adapter/tailwind/visibility/visible-display.resolver.spec.ts
@@ -34,8 +34,18 @@ function mediaState(intent: VisibilityIntent, alias: 'xs' | 'sm'): VisibilitySta
     kind: 'media',
     definition:
       alias === 'xs'
-        ? { alias: 'xs', range: { min: 0, max: 599.98 }, priority: 1000 }
-        : { alias: 'sm', range: { min: 600, max: 959.98 }, priority: 900 },
+        ? {
+            alias: 'xs',
+            range: { min: 0, max: 599.98 },
+            media: { type: 'screen', clauses: [{ min: 0, max: 599.98 }] },
+            priority: 1000,
+          }
+        : {
+            alias: 'sm',
+            range: { min: 600, max: 959.98 },
+            media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] },
+            priority: 900,
+          },
   });
 }
 

--- a/src/breakpoint/breakpoint-catalog.spec.ts
+++ b/src/breakpoint/breakpoint-catalog.spec.ts
@@ -1,4 +1,4 @@
-import { BreakpointCatalog, mediaRangesIntersect } from './breakpoint-catalog';
+import { BreakpointCatalog, mediaDefinitionsIntersect, mediaRangesIntersect } from './breakpoint-catalog';
 
 describe('BreakpointCatalog', () => {
   const cases = [
@@ -20,7 +20,12 @@ describe('BreakpointCatalog', () => {
   test.each(cases)('%s has the exact upstream range', (alias, min, max, priority) => {
     expect(new BreakpointCatalog().classify(alias)).toEqual({
       kind: 'verified',
-      definition: { alias, range: { min, max }, priority },
+      definition: {
+        alias,
+        range: { min, max },
+        media: { type: 'screen', clauses: [{ min, max }] },
+        priority,
+      },
     });
   });
 
@@ -30,6 +35,77 @@ describe('BreakpointCatalog', () => {
     expect(catalog.classify('handset')).toEqual({ kind: 'optional', alias: 'handset' });
     expect(catalog.classify('print')).toEqual({ kind: 'print', alias: 'print' });
     expect(catalog.classify('cinema')).toEqual({ kind: 'custom', alias: 'cinema' });
+  });
+
+  test.each([
+    ['handset.portrait', [{ max: 599.98, orientation: 'portrait' }], 2000],
+    ['handset.landscape', [{ max: 959.98, orientation: 'landscape' }], 2000],
+    [
+      'handset',
+      [
+        { max: 599.98, orientation: 'portrait' },
+        { max: 959.98, orientation: 'landscape' },
+      ],
+      2000,
+    ],
+    ['tablet.portrait', [{ min: 600, max: 839.98, orientation: 'portrait' }], 2100],
+    ['tablet.landscape', [{ min: 960, max: 1279.98, orientation: 'landscape' }], 2100],
+    [
+      'tablet',
+      [
+        { min: 600, max: 839.98, orientation: 'portrait' },
+        { min: 960, max: 1279.98, orientation: 'landscape' },
+      ],
+      2100,
+    ],
+    ['web.portrait', [{ min: 840, orientation: 'portrait' }], 2200],
+    ['web.landscape', [{ min: 1280, orientation: 'landscape' }], 2200],
+    [
+      'web',
+      [
+        { min: 840, orientation: 'portrait' },
+        { min: 1280, orientation: 'landscape' },
+      ],
+      2200,
+    ],
+  ] as const)('%s has the exact opt-in orientation definition', (alias, clauses, priority) => {
+    expect(new BreakpointCatalog({ orientationBreakpoints: true }).classify(alias)).toEqual({
+      kind: 'verified',
+      definition: { alias, range: clauses[0], media: { type: 'screen', clauses }, priority },
+    });
+  });
+
+  test('verifies print only when its source configuration is explicit', () => {
+    expect(new BreakpointCatalog().classify('print')).toEqual({ kind: 'print', alias: 'print' });
+    expect(
+      new BreakpointCatalog({ orientationBreakpoints: false, printWithBreakpoints: [] }).classify('print'),
+    ).toEqual({
+      kind: 'verified',
+      definition: { alias: 'print', range: {}, media: { type: 'print', clauses: [{}] }, priority: 1000 },
+    });
+  });
+});
+
+describe('mediaDefinitionsIntersect', () => {
+  const screen = (...clauses: Parameters<typeof mediaDefinitionsIntersect>[0]['clauses']) => ({
+    type: 'screen' as const,
+    clauses,
+  });
+
+  test('requires compatible orientation and width in at least one clause pair', () => {
+    expect(mediaDefinitionsIntersect(screen({ max: 599.98, orientation: 'portrait' }), screen({ min: 500 }))).toBe(
+      true,
+    );
+    expect(
+      mediaDefinitionsIntersect(
+        screen({ max: 599.98, orientation: 'portrait' }),
+        screen({ max: 959.98, orientation: 'landscape' }),
+      ),
+    ).toBe(false);
+  });
+
+  test('keeps print disjoint from screen', () => {
+    expect(mediaDefinitionsIntersect({ type: 'print', clauses: [{}] }, screen({}))).toBe(false);
   });
 });
 

--- a/src/breakpoint/breakpoint-catalog.ts
+++ b/src/breakpoint/breakpoint-catalog.ts
@@ -1,13 +1,25 @@
-import { ORIENTATION_BREAKPOINTS, type DefaultBreakpoint } from '../analyzer/flex-layout.catalog';
+import { ORIENTATION_BREAKPOINTS } from '../analyzer/flex-layout.catalog';
+import type { BreakpointMigrationConfig } from '../config/breakpoint-migration-config';
 
 export interface MediaRange {
   readonly min?: number;
   readonly max?: number;
 }
 
+export interface MediaClause extends MediaRange {
+  readonly orientation?: 'portrait' | 'landscape';
+}
+
+export interface MediaDefinition {
+  readonly type: 'screen' | 'print';
+  readonly clauses: readonly MediaClause[];
+}
+
 export interface BreakpointDefinition {
-  readonly alias: DefaultBreakpoint;
-  readonly range: MediaRange;
+  readonly alias: string;
+  /** @deprecated Use media clauses; retained while range consumers migrate. */
+  readonly range: MediaClause;
+  readonly media: MediaDefinition;
   readonly priority: number;
 }
 
@@ -21,33 +33,99 @@ function freezeDefinition(definition: BreakpointDefinition): BreakpointDefinitio
   return Object.freeze({
     ...definition,
     range: Object.freeze({ ...definition.range }),
+    media: Object.freeze({
+      ...definition.media,
+      clauses: Object.freeze(definition.media.clauses.map(clause => Object.freeze({ ...clause }))),
+    }),
   });
 }
 
+function screen(alias: string, range: MediaClause, priority: number): BreakpointDefinition {
+  return { alias, range, media: { type: 'screen', clauses: [range] }, priority };
+}
+
+function composite(alias: string, clauses: readonly MediaClause[], priority: number): BreakpointDefinition {
+  return { alias, range: clauses[0] ?? {}, media: { type: 'screen', clauses }, priority };
+}
+
 const breakpointDefinitions: readonly BreakpointDefinition[] = [
-  { alias: 'xs', range: { min: 0, max: 599.98 }, priority: 1000 },
-  { alias: 'sm', range: { min: 600, max: 959.98 }, priority: 900 },
-  { alias: 'md', range: { min: 960, max: 1279.98 }, priority: 800 },
-  { alias: 'lg', range: { min: 1280, max: 1919.98 }, priority: 700 },
-  { alias: 'xl', range: { min: 1920, max: 4999.98 }, priority: 600 },
-  { alias: 'lt-sm', range: { min: undefined, max: 599.98 }, priority: 950 },
-  { alias: 'lt-md', range: { min: undefined, max: 959.98 }, priority: 850 },
-  { alias: 'lt-lg', range: { min: undefined, max: 1279.98 }, priority: 750 },
-  { alias: 'lt-xl', range: { min: undefined, max: 1919.98 }, priority: 650 },
-  { alias: 'gt-xs', range: { min: 600, max: undefined }, priority: -950 },
-  { alias: 'gt-sm', range: { min: 960, max: undefined }, priority: -850 },
-  { alias: 'gt-md', range: { min: 1280, max: undefined }, priority: -750 },
-  { alias: 'gt-lg', range: { min: 1920, max: undefined }, priority: -650 },
+  screen('xs', { min: 0, max: 599.98 }, 1000),
+  screen('sm', { min: 600, max: 959.98 }, 900),
+  screen('md', { min: 960, max: 1279.98 }, 800),
+  screen('lg', { min: 1280, max: 1919.98 }, 700),
+  screen('xl', { min: 1920, max: 4999.98 }, 600),
+  screen('lt-sm', { min: undefined, max: 599.98 }, 950),
+  screen('lt-md', { min: undefined, max: 959.98 }, 850),
+  screen('lt-lg', { min: undefined, max: 1279.98 }, 750),
+  screen('lt-xl', { min: undefined, max: 1919.98 }, 650),
+  screen('gt-xs', { min: 600, max: undefined }, -950),
+  screen('gt-sm', { min: 960, max: undefined }, -850),
+  screen('gt-md', { min: 1280, max: undefined }, -750),
+  screen('gt-lg', { min: 1920, max: undefined }, -650),
 ];
 
+const orientationDefinitions: readonly BreakpointDefinition[] = [
+  screen('handset.portrait', { max: 599.98, orientation: 'portrait' }, 2000),
+  screen('handset.landscape', { max: 959.98, orientation: 'landscape' }, 2000),
+  composite(
+    'handset',
+    [
+      { max: 599.98, orientation: 'portrait' },
+      { max: 959.98, orientation: 'landscape' },
+    ],
+    2000,
+  ),
+  screen('tablet.portrait', { min: 600, max: 839.98, orientation: 'portrait' }, 2100),
+  screen('tablet.landscape', { min: 960, max: 1279.98, orientation: 'landscape' }, 2100),
+  composite(
+    'tablet',
+    [
+      { min: 600, max: 839.98, orientation: 'portrait' },
+      { min: 960, max: 1279.98, orientation: 'landscape' },
+    ],
+    2100,
+  ),
+  screen('web.portrait', { min: 840, orientation: 'portrait' }, 2200),
+  screen('web.landscape', { min: 1280, orientation: 'landscape' }, 2200),
+  composite(
+    'web',
+    [
+      { min: 840, orientation: 'portrait' },
+      { min: 1280, orientation: 'landscape' },
+    ],
+    2200,
+  ),
+];
+
+const printDefinition: BreakpointDefinition = {
+  alias: 'print',
+  range: {},
+  media: { type: 'print', clauses: [{}] },
+  priority: 1000,
+};
+
 const definitions = Object.freeze(breakpointDefinitions.map(freezeDefinition));
+const orientations = Object.freeze(orientationDefinitions.map(freezeDefinition));
+const frozenPrintDefinition = freezeDefinition(printDefinition);
 
 const definitionsByAlias = new Map(definitions.map(definition => [definition.alias, definition]));
 const optionalAliases = new Set<string>(ORIENTATION_BREAKPOINTS);
 
 export class BreakpointCatalog {
+  private readonly configuredDefinitions: ReadonlyMap<string, BreakpointDefinition>;
+
+  constructor(config: BreakpointMigrationConfig = { orientationBreakpoints: false }) {
+    this.configuredDefinitions = new Map([
+      ...definitionsByAlias,
+      ...(config.orientationBreakpoints ? orientations.map(definition => [definition.alias, definition] as const) : []),
+      ...(config.printWithBreakpoints === undefined
+        ? []
+        : ([[frozenPrintDefinition.alias, frozenPrintDefinition]] as const)),
+    ]);
+  }
+
   classify(alias: string): BreakpointClassification {
-    const definition = definitionsByAlias.get(alias as DefaultBreakpoint);
+    const definition = this.configuredDefinitions.get(alias);
 
     if (definition) {
       return { kind: 'verified', definition };
@@ -72,4 +150,17 @@ export function mediaRangesIntersect(left: MediaRange, right: MediaRange): boole
   const rightMax = right.max ?? Number.POSITIVE_INFINITY;
 
   return leftMin <= rightMax && rightMin <= leftMax;
+}
+
+export function mediaDefinitionsIntersect(left: MediaDefinition, right: MediaDefinition): boolean {
+  if (left.type !== right.type) return false;
+  return left.clauses.some(leftClause =>
+    right.clauses.some(
+      rightClause =>
+        (leftClause.orientation === undefined ||
+          rightClause.orientation === undefined ||
+          leftClause.orientation === rightClause.orientation) &&
+        mediaRangesIntersect(leftClause, rightClause),
+    ),
+  );
 }

--- a/src/breakpoint/breakpoint-catalog.ts
+++ b/src/breakpoint/breakpoint-catalog.ts
@@ -112,8 +112,10 @@ const optionalAliases = new Set<string>(ORIENTATION_BREAKPOINTS);
 
 export class BreakpointCatalog {
   private readonly configuredDefinitions: ReadonlyMap<string, BreakpointDefinition>;
+  readonly printWithBreakpoints: readonly string[] | undefined;
 
   constructor(config: BreakpointMigrationConfig = { orientationBreakpoints: false }) {
+    this.printWithBreakpoints = config.printWithBreakpoints;
     this.configuredDefinitions = new Map([
       ...definitionsByAlias,
       ...(config.orientationBreakpoints ? orientations.map(definition => [definition.alias, definition] as const) : []),

--- a/src/breakpoint/breakpoint-catalog.ts
+++ b/src/breakpoint/breakpoint-catalog.ts
@@ -4,11 +4,10 @@ import type { BreakpointMigrationConfig } from '../config/breakpoint-migration-c
 export interface MediaRange {
   readonly min?: number;
   readonly max?: number;
-}
-
-export interface MediaClause extends MediaRange {
   readonly orientation?: 'portrait' | 'landscape';
 }
+
+export type MediaClause = MediaRange;
 
 export interface MediaDefinition {
   readonly type: 'screen' | 'print';
@@ -144,6 +143,9 @@ export class BreakpointCatalog {
 }
 
 export function mediaRangesIntersect(left: MediaRange, right: MediaRange): boolean {
+  if (left.orientation !== undefined && right.orientation !== undefined && left.orientation !== right.orientation) {
+    return false;
+  }
   const leftMin = left.min ?? Number.NEGATIVE_INFINITY;
   const leftMax = left.max ?? Number.POSITIVE_INFINITY;
   const rightMin = right.min ?? Number.NEGATIVE_INFINITY;

--- a/src/cli/run-cli.spec.ts
+++ b/src/cli/run-cli.spec.ts
@@ -287,6 +287,26 @@ describe('runCli', () => {
     await expect(access(input)).rejects.toThrow();
   });
 
+  test('converts configured orientation and print fallback behavior end to end', async () => {
+    const input = join(temporaryDirectory, 'input.html');
+    const output = join(temporaryDirectory, 'output.html');
+    await writeFile(input, '<div fxLayout.handset="column" fxLayout.md="row"></div>', 'utf8');
+
+    const result = await run([
+      input,
+      '--output',
+      output,
+      '--orientation-breakpoints',
+      '--print-with-breakpoints',
+      'md',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const migrated = await readFile(output, 'utf8');
+    expect(migrated).toContain('[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex-col');
+    expect(migrated).toContain('[@media_print]:flex-row');
+  });
+
   test('creates a missing output directory when a changed template is written', async () => {
     const input = join(temporaryDirectory, 'input.html');
     const output = join(temporaryDirectory, 'new', 'nested', 'output.html');

--- a/src/cli/run-cli.spec.ts
+++ b/src/cli/run-cli.spec.ts
@@ -263,9 +263,28 @@ describe('runCli', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('--report <path>');
-    expect(result.stdout).toContain('path must end in .json');
-    expect(result.stdout.replace(/\s+/g, ' ')).toContain('single-file output must end in .html');
+    const normalizedOutput = result.stdout.replace(/\s+/g, ' ');
+    expect(normalizedOutput).toContain('path must end in .json');
+    expect(normalizedOutput).toContain('single-file output must end in .html');
     expect(result.stderr).toBe('');
+  });
+
+  test('documents project-aware breakpoint options in help output', async () => {
+    const result = await run(['--help']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('--orientation-breakpoints');
+    expect(result.stdout).toContain('--print-with-breakpoints <aliases>');
+  });
+
+  test('rejects invalid print breakpoint configuration before reading input', async () => {
+    const input = join(temporaryDirectory, 'missing.html');
+
+    const result = await run([input, '--print-with-breakpoints', 'handset']);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('requires --orientation-breakpoints');
+    await expect(access(input)).rejects.toThrow();
   });
 
   test('creates a missing output directory when a changed template is written', async () => {

--- a/src/cli/run-cli.ts
+++ b/src/cli/run-cli.ts
@@ -8,6 +8,7 @@ import { TerminalPresenter, type TextOutput } from '../report/terminal.presenter
 import { getErrorMessage } from '../util/error.util';
 import { resolveExitCode } from './exit-policy';
 import { validateReportPath } from './report-path.validator';
+import { parsePrintWithBreakpoints } from '../config/breakpoint-migration-config';
 
 interface ProgramOptions {
   readonly output?: string;
@@ -16,6 +17,8 @@ interface ProgramOptions {
   readonly report?: string;
   readonly allowUnresolved: boolean;
   readonly debug: boolean;
+  readonly orientationBreakpoints: boolean;
+  readonly printWithBreakpoints?: string;
 }
 
 export interface CliOutput {
@@ -55,13 +58,25 @@ export async function runCli(argv: readonly string[], output: CliOutput = proces
     .option('--dry-run', 'analyze and plan without writing templates', false)
     .option('--report <path>', 'atomically write a JSON report; path must end in .json')
     .option('--allow-unresolved', 'return success when unresolved inputs remain', false)
+    .option('--orientation-breakpoints', 'confirm the source enables the archived orientation breakpoints', false)
+    .option(
+      '--print-with-breakpoints <aliases>',
+      'confirm the source printWithBreakpoints list; comma-separated aliases or none',
+    )
     .option('-d, --debug', 'enable debug logging', false)
     .action(async (input: string, options: ProgramOptions) => {
       debug = options.debug;
       logger.level = debug ? 'debug' : 'warn';
 
       const destination = options.output ?? input;
-      const adapter = AdapterFactory.create(options.target);
+      const printWithBreakpoints =
+        options.printWithBreakpoints === undefined
+          ? undefined
+          : parsePrintWithBreakpoints(options.printWithBreakpoints, options.orientationBreakpoints);
+      const adapter = AdapterFactory.create(options.target, {
+        orientationBreakpoints: options.orientationBreakpoints,
+        printWithBreakpoints,
+      });
       if (options.report !== undefined) {
         validateReportPath(options.report);
       }

--- a/src/config/breakpoint-migration-config.spec.ts
+++ b/src/config/breakpoint-migration-config.spec.ts
@@ -1,0 +1,28 @@
+import { parsePrintWithBreakpoints } from './breakpoint-migration-config';
+
+describe('parsePrintWithBreakpoints', () => {
+  test('accepts an explicit empty print list', () => {
+    expect(parsePrintWithBreakpoints('none', false)).toEqual([]);
+  });
+
+  test('normalizes a comma-separated standard alias list', () => {
+    expect(parsePrintWithBreakpoints(' md, gt-sm ', false)).toEqual(['md', 'gt-sm']);
+  });
+
+  test('accepts orientation aliases only when orientation breakpoints are enabled', () => {
+    expect(parsePrintWithBreakpoints('handset,web.portrait', true)).toEqual(['handset', 'web.portrait']);
+    expect(() => parsePrintWithBreakpoints('handset', false)).toThrow(
+      'Orientation breakpoint alias handset requires --orientation-breakpoints',
+    );
+  });
+
+  test.each([
+    ['', 'Print breakpoint aliases must not be empty'],
+    ['md,md', 'Print breakpoint list contains duplicate alias md'],
+    ['print', 'Print breakpoint list must not contain print'],
+    ['cinema', 'Unknown breakpoint alias cinema'],
+    ['none,md', 'The literal none cannot be combined with breakpoint aliases'],
+  ])('rejects invalid value %j', (value, message) => {
+    expect(() => parsePrintWithBreakpoints(value, true)).toThrow(message);
+  });
+});

--- a/src/config/breakpoint-migration-config.ts
+++ b/src/config/breakpoint-migration-config.ts
@@ -1,0 +1,37 @@
+import { DEFAULT_BREAKPOINTS, ORIENTATION_BREAKPOINTS } from '../analyzer/flex-layout.catalog';
+
+export interface BreakpointMigrationConfig {
+  readonly orientationBreakpoints: boolean;
+  readonly printWithBreakpoints?: readonly string[];
+}
+
+const standardAliases = new Set<string>(DEFAULT_BREAKPOINTS);
+const orientationAliases = new Set<string>(ORIENTATION_BREAKPOINTS);
+
+export function parsePrintWithBreakpoints(value: string, orientationEnabled: boolean): readonly string[] {
+  if (value === 'none') return Object.freeze([]);
+
+  const aliases = value.split(',').map(alias => alias.trim());
+  if (aliases.some(alias => alias.length === 0)) {
+    throw new Error('Print breakpoint aliases must not be empty');
+  }
+  if (aliases.includes('none')) {
+    throw new Error('The literal none cannot be combined with breakpoint aliases');
+  }
+
+  const seen = new Set<string>();
+  for (const alias of aliases) {
+    if (seen.has(alias)) throw new Error(`Print breakpoint list contains duplicate alias ${alias}`);
+    seen.add(alias);
+
+    if (alias === 'print') throw new Error('Print breakpoint list must not contain print');
+    if (orientationAliases.has(alias) && !orientationEnabled) {
+      throw new Error(`Orientation breakpoint alias ${alias} requires --orientation-breakpoints`);
+    }
+    if (!standardAliases.has(alias) && !orientationAliases.has(alias)) {
+      throw new Error(`Unknown breakpoint alias ${alias}`);
+    }
+  }
+
+  return Object.freeze(aliases);
+}

--- a/test/compatibility/angular-template-engine.test.ts
+++ b/test/compatibility/angular-template-engine.test.ts
@@ -6,6 +6,7 @@ import type { ConversionResult } from '../../src/analyzer/conversion-result';
 import { SourceEditor } from '../../src/edit/source-editor';
 import { ConversionPlanner } from '../../src/planner/conversion-planner';
 import { AngularTemplateParser } from '../../src/template/angular-template.parser';
+import type { BreakpointMigrationConfig } from '../../src/config/breakpoint-migration-config';
 
 const fixtureDirectory = new URL('../fixtures/compatibility/', import.meta.url);
 const standardAliases = [
@@ -24,11 +25,15 @@ const standardAliases = [
   'gt-lg',
 ] as const;
 
-function migrate(source: string, fileName = 'fixture.html') {
+function migrate(
+  source: string,
+  fileName = 'fixture.html',
+  config: BreakpointMigrationConfig = { orientationBreakpoints: false },
+) {
   const parsed = new AngularTemplateParser().parse(source, fileName);
   if (parsed.status !== 'parsed') throw new Error(parsed.diagnostics.map(item => item.message).join('\n'));
   const inputs = new TemplateAnalyzer().analyze(fileName, parsed.elements);
-  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter());
+  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter(config));
   const edited = new SourceEditor().apply(source, plan.edits);
   if (edited.status !== 'applied') throw new Error(edited.diagnostics.map(item => item.message).join('\n'));
   return { output: edited.output, results: plan.results, editCount: plan.edits.length };
@@ -188,6 +193,25 @@ describe('Angular template engine compatibility', () => {
     expect(migrate(input).output).toBe(
       '<div data-label="a &amp; b" class="flex flex-row box-border">\r\n  {{ value | async }}\r\n</div>\r\n',
     );
+  });
+
+  test('converts configured orientation and print behavior byte-for-byte and idempotently', () => {
+    const input =
+      '<div fxLayout.handset="column"></div>\n' +
+      '<section fxLayout="row" fxLayout.md="column"></section>\n' +
+      '<main fxLayout.print="column"></main>\n';
+    const config = { orientationBreakpoints: true, printWithBreakpoints: ['md'] } as const;
+    const expected =
+      '<div class="[@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex [@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex [@media_(orientation:_portrait)_and_(max-width:_599.98px)]:flex-col [@media_(orientation:_landscape)_and_(max-width:_959.98px)]:flex-col [@media_(orientation:_portrait)_and_(max-width:_599.98px)]:box-border [@media_(orientation:_landscape)_and_(max-width:_959.98px)]:box-border"></div>\n' +
+      '<section class="flex flex-row box-border [@media_screen_and_(min-width:_960px)_and_(max-width:_1279.98px)]:flex [@media_screen_and_(min-width:_960px)_and_(max-width:_1279.98px)]:flex-col [@media_screen_and_(min-width:_960px)_and_(max-width:_1279.98px)]:box-border [@media_print]:flex [@media_print]:flex-col [@media_print]:box-border"></section>\n' +
+      '<main class="[@media_print]:flex [@media_print]:flex-col [@media_print]:box-border"></main>\n';
+
+    const first = migrate(input, 'orientation-print.html', config);
+    expect(first.output).toBe(expected);
+    expect(first.results.every(result => result.status === 'converted')).toBe(true);
+    const second = migrate(first.output, 'orientation-print.html', config);
+    expect(second.output).toBe(expected);
+    expect(second.editCount).toBe(0);
   });
 
   test('emits the same canonical responsive family for equivalent attribute orders', () => {

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -270,11 +270,11 @@ describe('compatibility reference contract', () => {
         ['fxFlexOrder', 'Static integer values emitted independently of the Tailwind theme.'],
         [
           'fxShow',
-          'Literal base and standard viewport states convert when display restoration and the complete visibility family are safe.',
+          'Literal base and configured viewport, orientation, or print states convert when display restoration and the complete visibility family are safe.',
         ],
         [
           'fxHide',
-          'Literal base and standard viewport states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
+          'Literal base and configured responsive states convert with `fxShow`; hiding emits exact base or responsive `hidden` utilities.',
         ],
         ...[
           'gdAlignColumns',
@@ -306,6 +306,11 @@ describe('compatibility reference contract', () => {
 
     expect(markdown).toContain('are currently converted together as one atomic visibility family per element');
     expect(markdown).not.toContain('are planned together as one atomic visibility family per element');
+    expect(markdown).toContain('--orientation-breakpoints');
+    expect(markdown).toContain('--print-with-breakpoints');
+    expect(markdown).toContain('handset.portrait');
+    expect(markdown).toContain('web.landscape');
+    expect(markdown).toContain('printWithBreakpoints');
   });
 
   it('rejects duplicate visible safety entries', async () => {

--- a/test/package/docs-contract.test.ts
+++ b/test/package/docs-contract.test.ts
@@ -36,7 +36,9 @@ function expectCurrentBetaBoundaries(readme: string): void {
   expect(readme).toContain('a native CSS target is not available');
   expect(readme).toContain('Literal Grid directives have limited conversion support');
   expect(readme).toContain('responsive `imgSrc` remains unchanged');
-  expect(readme).toContain('Orientation, print, and custom breakpoint aliases remain preserved for review');
+  expect(readme).toContain('Orientation and print conversion require explicit source-configuration evidence');
+  expect(readme).toContain('--orientation-breakpoints');
+  expect(readme).toContain('--print-with-breakpoints');
 }
 
 describe('maintainer documentation', () => {
@@ -183,7 +185,7 @@ describe('maintainer documentation', () => {
   it('rejects a paraphrased false-current-capability claim that the former blacklist misses', async () => {
     const readme = await readRepositoryFile('README.md');
     const falseCurrentCapability = readme.replace(
-      'This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation, print, and custom breakpoint aliases remain preserved for review.',
+      'This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review.',
       'This beta has native CSS and Tailwind CSS targets. Grid directives, responsive `imgSrc`, orientation, print, and custom breakpoint aliases convert directly.',
     );
 

--- a/test/package/package-contract.test.ts
+++ b/test/package/package-contract.test.ts
@@ -34,7 +34,7 @@ async function createPackageFixture({ missingFile, extraFile }: { missingFile?: 
       `#!/usr/bin/env node
 const arguments_ = process.argv.slice(2);
 if (arguments_.includes('--help')) {
-  console.log('--dry-run --report <path> --allow-unresolved path must end in .json single-file output must end in .html');
+  console.log('--dry-run --report <path> --allow-unresolved --orientation-breakpoints --print-with-breakpoints <aliases> path must end in .json single-file output must end in .html');
 } else if (arguments_.includes('--version')) {
   console.log('${fixtureVersion}');
 } else if (arguments_.includes('--dry-run')) {

--- a/test/tailwind/responsive-variant-compilation.test.ts
+++ b/test/tailwind/responsive-variant-compilation.test.ts
@@ -47,7 +47,9 @@ function visibilityState(intent: VisibilityIntent, alias?: string): VisibilitySt
 }
 
 function responsiveUtility(alias: string, utility: string): string {
-  return new ResponsiveVariantEmitter().emit(definition(alias), utility);
+  const emitted = new ResponsiveVariantEmitter().emit(definition(alias), utility)[0];
+  if (!emitted) throw new Error(`Expected ${alias} to emit one responsive utility`);
+  return emitted;
 }
 
 function layoutPlan(alias: string): PlannedConversion {
@@ -101,15 +103,39 @@ describe('Tailwind CSS v4 arbitrary media variants', () => {
   test('compiles representative exact viewport ranges', async () => {
     const emitter = new ResponsiveVariantEmitter();
     const css = await compileCandidates([
-      emitter.emit(definition('gt-xs'), 'flex-col'),
-      emitter.emit(definition('lt-sm'), 'flex-col'),
-      emitter.emit(definition('sm'), 'flex-col'),
+      ...emitter.emit(definition('gt-xs'), 'flex-col'),
+      ...emitter.emit(definition('lt-sm'), 'flex-col'),
+      ...emitter.emit(definition('sm'), 'flex-col'),
     ]);
 
     expect(css).toContain('@media screen and (min-width: 600px)');
     expect(css).toContain('@media screen and (max-width: 599.98px)');
     expect(css).toContain('@media screen and (min-width: 600px) and (max-width: 959.98px)');
     expect(css).toContain('flex-direction: column');
+  });
+
+  test('compiles exact composite orientation and print variants', async () => {
+    const catalog = new BreakpointCatalog({
+      orientationBreakpoints: true,
+      printWithBreakpoints: [],
+    });
+    const handset = catalog.classify('handset');
+    const print = catalog.classify('print');
+    if (handset.kind !== 'verified' || print.kind !== 'verified') {
+      throw new Error('Expected configured orientation and print aliases');
+    }
+
+    const emitter = new ResponsiveVariantEmitter();
+    const css = await compileCandidates([
+      ...emitter.emit(handset.definition, 'flex-col'),
+      ...emitter.emit(print.definition, 'hidden'),
+    ]);
+
+    expect(css).toContain('@media (orientation: portrait) and (max-width: 599.98px)');
+    expect(css).toContain('@media (orientation: landscape) and (max-width: 959.98px)');
+    expect(css).toContain('@media print');
+    expect(css).toContain('flex-direction: column');
+    expect(css).toContain('display: none');
   });
 
   test('compiles emitted responsive class candidates and arbitrary style declarations with exact ownership', async () => {


### PR DESCRIPTION
## Summary

Add opt-in, project-aware Tailwind CSS 4 conversion for Angular Flex-Layout orientation and print aliases. The CLI now accepts explicit evidence for archived orientation definitions and `printWithBreakpoints`, while unconfigured aliases remain preserved.

The breakpoint model supports disjunctive orientation clauses, the responsive planner reproduces print fallback precedence, and compiler-backed ownership checks distinguish screen, orientation, and print activations.

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

Fresh verification: 65 test files and 2,118 tests passed. Package smoke and `npm audit --audit-level=high` also passed with 0 vulnerabilities.

## Migration example

Before:

```html
<div fxLayout.handset="column" fxLayout.md="row"></div>
```

Run after verifying `addOrientationBps: true` and `printWithBreakpoints: ["md"]` in the source application:

```bash
flex-layout-codemod ./src --orientation-breakpoints --print-with-breakpoints md
```

The generated Tailwind candidates retain the exact portrait and landscape media conditions and add the configured `md` value under `@media print`.

## Dependencies and compatibility

No dependency changes. Requires the existing Node.js 24 baseline and emits Tailwind CSS 4.3.3-verified candidates. Orientation and print conversion are deliberately Limited and require explicit source-configuration evidence; custom breakpoint providers remain preserved.