### PR TITLE
feat: migrate responsive images to native picture markup

### DIFF
--- a/.changeset/responsive-picture.md
+++ b/.changeset/responsive-picture.md
@@ -1,0 +1,5 @@
+---
+'@nipe-solutions/flex-layout-codemod': minor
+---
+
+Add opt-in migration of safe literal responsive image sources to native picture markup with atomic template validation and report-based review locations.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ test/fixtures/compatibility/visibility.input.html
 test/fixtures/compatibility/visibility.expected.html
 test/fixtures/compatibility/extended-responsive.input.html
 test/fixtures/compatibility/extended-responsive.expected.html
+test/fixtures/compatibility/responsive-image.input.html
+test/fixtures/compatibility/responsive-image.expected.html

--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ npx flex-layout-codemod ./src --print-with-breakpoints none
 
 With orientation enabled, all nine archived aliases are available: `handset`, `handset.portrait`, `handset.landscape`, `tablet`, `tablet.portrait`, `tablet.landscape`, `web`, `web.portrait`, and `web.landscape`. Print conversion reproduces configured responsive fallback values, while an explicit `.print` value takes precedence.
 
+Responsive image migration is a separate opt-in because introducing `<picture>` changes the image's parent and may affect CSS or test selectors. After reviewing that risk, enable literal standard-breakpoint sources with `--responsive-images`:
+
+```bash
+npx flex-layout-codemod ./src --responsive-images --report ./reports/flex-layout.json
+```
+
+```html
+<!-- input -->
+<img src="hero.png" src.lt-sm="hero-mobile.png" alt="Hero" />
+
+<!-- output -->
+<picture
+  ><source media="screen and (max-width: 599.98px)" srcset="hero-mobile.png" />
+  <img src="hero.png" alt="Hero"
+/></picture>
+```
+
+Only literal values using the 13 standard viewport aliases convert. Dynamic values, orientation, print, custom aliases, ambiguous URLs, structural directives on the image, and images already inside `<picture>` remain unchanged. Use the JSON report's file paths and source offsets to review every converted `imgSrc` occurrence and check selectors that assume the `<img>` has its former parent. Interactive file navigation is deferred to the CLI upgrade.
+
 This fixture is intentionally preserved because the value is a runtime Angular expression. The report records a `dynamic-binding` review diagnostic and the source remains unchanged:
 
 ```html
@@ -112,7 +131,7 @@ npx flex-layout-codemod ./src --dry-run --report ./reports/flex-layout.json --al
 
 ## Known boundaries
 
-This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
+This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` has an opt-in native `<picture>` migration for safe literal standard aliases. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review. See [docs/compatibility.md](docs/compatibility.md) for exact supported forms and diagnostic codes before planning a large migration.
 
 The codemod does not inspect project styles, Tailwind configuration, Sass, Less, or CSS, and it does not generate a companion stylesheet. Dynamic Angular bindings are not evaluated.
 

--- a/docs/architecture/responsive-image-migration.md
+++ b/docs/architecture/responsive-image-migration.md
@@ -1,0 +1,159 @@
+# Responsive image migration
+
+## Purpose
+
+This milestone adds an opt-in native HTML migration for Angular Flex-Layout responsive image sources. It converts literal `src.<alias>` inputs on `<img>` elements into ordered `<picture>` and `<source media>` markup while retaining the original `<img>` as the fallback.
+
+Responsive images are a structural HTML transformation, not a Tailwind or native CSS target. They therefore use a dedicated planning and rendering pipeline rather than extending class-oriented adapter results. Conversion remains safety-first: the migrator rewrites an image only when browser `<picture>` selection can be proven equivalent to the archived Flex-Layout breakpoint behavior.
+
+Dynamic responsive sources, orientation, print, custom breakpoints, project-defined breakpoint replacements, multi-density `srcset`, art-direction metadata, and interactive review UI remain outside this milestone.
+
+## Opt-in contract
+
+The CLI adds `--responsive-images`. Supplying the flag confirms that the user accepts `<img>` elements being wrapped in `<picture>` and has reviewed the possibility of selector changes such as `parent > img`, `img:first-child`, or rules tied to the original parent element.
+
+The flag enables structural planning but does not weaken individual safety checks. Without it, responsive `src.<alias>` inputs remain unchanged with a diagnostic that identifies `--responsive-images`. The migrator does not inspect CSS, Sass, Less, test selectors, or application JavaScript to infer whether wrapping is harmless.
+
+Responsive-image behavior is independent of `--target tailwind`, `--orientation-breakpoints`, and `--print-with-breakpoints`. The current CLI still requires its existing target because responsive-image output shares the same migration invocation and report.
+
+## Supported source contract
+
+An image is eligible when all of these conditions hold:
+
+- the host is an HTML `<img>` element;
+- at least one responsive `src.<alias>` input is present;
+- every responsive member is a literal using one of the 13 archived standard viewport aliases;
+- every responsive value can be encoded as one safe, descriptor-free `srcset` candidate without changing its decoded URL;
+- the fallback is either a literal `src`, a bound `[src]`, or absent;
+- the image is not already a descendant of `<picture>`;
+- the image has no Angular structural-directive attribute;
+- its source ranges describe one complete, unambiguous element that can be replaced atomically; and
+- the complete edited template reparses successfully with the Angular compiler.
+
+The supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg` using the exact definitions and priorities in the shared breakpoint catalog.
+
+All nonresponsive attributes and bindings stay on the fallback `<img>`, including `alt`, `width`, `height`, `loading`, `decoding`, accessibility metadata, event handlers, references, classes, styles, literal `src`, and bound `[src]`. The renderer removes only responsive source attributes whose complete family converts.
+
+## Archived runtime semantics
+
+Angular Flex-Layout registers the standard responsive image inputs as `src.<alias>`. In the browser, the directive writes the value of the highest-priority active alias to the host `src`. When no configured responsive value is active, it restores the base `src` value or the empty string.
+
+On the server with the Flex-Layout server module, responsive selection is represented through generated `content: url(...)` styling while the host `src` is cleared. The native migration intentionally replaces that directive-specific server behavior with ordinary `<picture>` fallback markup. Browsers, crawlers, and SSR output retain the fallback `<img src>` or `[src]`; responsive `<source>` elements carry literal alternatives without requiring Flex-Layout runtime code.
+
+Native `<picture>` evaluates `<source>` elements in document order and uses the first matching media condition. The renderer orders sources by descending archived Flex-Layout priority, then by canonical alias order. Standard aliases have distinct priorities, so overlapping `lt-*`, `gt-*`, and bounded aliases can reproduce runtime precedence without relying on CSS cascade order.
+
+## Architecture
+
+Responsive-image migration has five focused units:
+
+1. The Angular template parser exposes immutable full-element, start-tag, end-tag, structural-template, and ancestry ranges without changing existing attribute analysis.
+2. The attribute analyzer recognizes upstream `src.<alias>` and bound `[src.<alias>]` spellings as the internal `imgSrc` directive. Plain `src` and `[src]` remain ordinary fallback attributes and never become standalone migration inputs.
+3. A target-independent responsive-image planner groups `imgSrc` occurrences by host element and validates configuration, breakpoints, fallback ownership, structural context, URL safety, and priority.
+4. A native picture renderer converts one valid semantic plan into deterministic HTML while retaining the original `<img>` bytes except for responsive-attribute removals.
+5. The conversion planner composes structural edits with ordinary attribute/class edits, rejects overlap, applies them in memory, and reparses the complete result before any file write.
+
+The existing breakpoint catalog remains the only source of standard media definitions and priorities. The image pipeline consumes catalog definitions but does not consume Tailwind arbitrary-variant strings or Tailwind compiler descriptors.
+
+## Template source model
+
+`TemplateElement` expands to include:
+
+- the full element source range;
+- the opening-tag source range;
+- an optional closing-tag source range; and
+- ordered ancestor identifiers or sufficient parent links to resolve ancestry.
+
+Structural `TmplAstTemplate` wrappers created by `*` syntax are retained as explicit source evidence so `*ngIf`, `*ngFor`, and custom structural directives cannot disappear during AST normalization. Native block syntax surrounding an image is allowed when the image itself still has one unambiguous source range; structural attributes attached to the image are not.
+
+Void `<img>` forms, explicit closing tags accepted by Angular, and self-closing spellings are characterized separately. Ranges always refer to original source bytes. The parser does not normalize attribute spelling or serialize the Angular AST.
+
+If the Angular compiler cannot provide an unambiguous replaceable range for the encountered spelling, the image remains unchanged. The migrator never searches for a closing delimiter heuristically after parsing.
+
+## Image semantic plan
+
+One immutable plan represents the whole image family:
+
+- host element identity and replacement range;
+- ordered responsive sources containing alias, exact media definition, priority, decoded URL, and original attribute range;
+- fallback kind: literal, bound, or absent;
+- retained `<img>` source slices;
+- indentation and line-ending evidence; and
+- all diagnostics needed if the family is rejected.
+
+The planner validates the family before producing any source edit. One invalid, dynamic, custom, optional, duplicate, or unsafe responsive member preserves every `src.<alias>` member on that image. A base `[src]` binding is allowed because it remains on the same fallback `<img>` and is not copied or reinterpreted.
+
+## URL and attribute safety
+
+Each responsive value becomes a descriptor-free `srcset` value. The encoder must prove that parsing the generated attribute yields the same single URL string as the original Angular literal.
+
+The renderer uses double-quoted generated attributes and encodes at least `&`, `"`, carriage return, line feed, and other syntax-significant characters according to HTML rules. Values containing interpolation, ambiguous unescaped whitespace, a candidate descriptor, or syntax that would be interpreted as multiple `srcset` candidates remain unchanged. Data URLs and character references convert only when executable parser tests prove one-candidate equivalence; otherwise they are preserved.
+
+Empty responsive values follow the archived directive fallback behavior and do not name an alternative image. Because an empty `<source srcset>` does not reproduce that behavior, a family containing an empty responsive value remains unchanged.
+
+## Rendering and formatting
+
+The renderer emits one `<source media="..." srcset="...">` per responsive member, ordered by priority. Media attributes contain exact standard queries suitable for native HTML, for example `screen and (min-width: 600px) and (max-width: 959.98px)`.
+
+The original `<img>` spelling is retained byte-for-byte after removing the converted responsive attributes and their adjacent attribute whitespace. The renderer does not reorder retained attributes, normalize quotes, rewrite the fallback `src`, or change unrelated bindings.
+
+For a single-line input, deterministic output is compact:
+
+```html
+<picture
+  ><source media="screen and (max-width: 599.98px)" srcset="mobile.png" />
+  <img src="default.png"
+/></picture>
+```
+
+For multiline input, generated children follow the image's existing indentation unit and line-ending style. The closing `</picture>` aligns with the original `<img>` indentation. Formatting is source-derived and idempotent; no external formatter is invoked.
+
+## Edit composition and validation
+
+Responsive-image replacement is one structural `SourceEdit` for the full `<img>` range. Existing class-based conversions on the same image are planned first and incorporated into the retained `<img>` slice before wrapping, rather than emitted as overlapping edits. If this composition cannot be represented without overlapping or reordered source ranges, all conversions coupled to that image remain unchanged with `context-unverified`.
+
+Edits on descendants cannot exist because `<img>` is void. Edits on ancestors or siblings remain independent when ranges are disjoint. The source editor continues to reject all overlapping edit plans as an internal invariant.
+
+After every file plan is applied in memory, the complete result is parsed again with the Angular compiler. A reparse failure discards the file's planned writes and returns stable diagnostics; it never writes a partially valid template. A second migration run finds no responsive source attributes and produces zero edits.
+
+## Diagnostics and reporting
+
+Responsive-image failures use the existing structured result and source-location contract. Reasons distinguish at least:
+
+- feature not enabled;
+- dynamic responsive source;
+- unsupported orientation, print, custom, or empty alias;
+- unsafe or ambiguous `srcset` value;
+- non-`img` host;
+- existing `<picture>` ancestry;
+- Angular structural-directive context;
+- incomplete or conflicting source family;
+- overlapping structural/class edit ownership; and
+- generated-template reparse failure.
+
+The JSON report records each converted and preserved responsive-image occurrence with its file and source location. Documentation instructs users to review files containing converted `imgSrc` results for selector assumptions introduced by `<picture>` wrapping. This milestone does not add an image-specific interactive checklist, file navigator, or post-run review screen; those belong to the adaptive CLI milestone.
+
+## Verification
+
+Implementation follows test-driven development and includes:
+
+- characterization tests derived from the archived directive for fallback, active alias, overlap priority, and missing base source behavior;
+- parser range tests for void, self-closing, explicitly closed, multiline, nested, and control-flow images;
+- all 13 standard aliases with exact native media conditions and priority order;
+- literal, bound, and absent fallback coverage;
+- preservation tests for responsive bindings, interpolation, orientation, print, custom and empty aliases, duplicate ownership, structural directives, and existing `<picture>` ancestry;
+- URL and attribute encoding differentials using the Angular parser and an HTML `srcset` parser or browser;
+- composition tests for existing class/style conversions and nonresponsive image attributes;
+- CRLF, indentation, unrelated-byte preservation, deterministic output, and idempotence fixtures;
+- browser selection tests at representative viewport widths for bounded and overlapping aliases;
+- SSR-oriented markup tests proving the fallback `<img>` remains present without Flex-Layout runtime behavior;
+- JSON location, terminal diagnostic, strict exit, and packaged CLI tests;
+- compatibility inventory and public fixture totals; and
+- full repository verification, audit, package inspection, clean-status checks, and forbidden-control-file scans.
+
+Completeness means every supported and preserved responsive-image form has an executable expectation. It does not claim that project selectors are safe; `--responsive-images` is the explicit acknowledgement boundary.
+
+## Documentation and release
+
+The compatibility inventory changes responsive-image `imgSrc` from Planned to Limited and documents its opt-in, literal, standard-breakpoint, structural, URL, and fallback boundaries. The README includes one migration example, the selector-risk acknowledgement, and report-based review guidance.
+
+The pull request includes a Changeset because it adds user-visible CLI behavior and template transformations. It does not add a runtime dependency or publish a package.

--- a/docs/architecture/v2-product-roadmap.md
+++ b/docs/architecture/v2-product-roadmap.md
@@ -62,7 +62,7 @@ Dynamic expressions, custom breakpoints, project plugins, and ambiguous overlapp
 
 Responsive `imgSrc` behavior is a separate native HTML migration rather than a Tailwind or CSS utility conversion. Initial automatic support is opt-in and limited to literal standard-breakpoint values that can be represented by ordered `<picture>` and `<source media>` elements without changing effective selection precedence.
 
-The renderer preserves image accessibility, loading, dimensions, fallback `src`, bindings unrelated to responsive source selection, and unrelated source bytes. It refuses dynamic responsive expressions, unsafe structural contexts, selector-sensitive wrapping, or ambiguous breakpoint overlap. Generated templates must reparse with the Angular compiler and be idempotent.
+The renderer preserves image accessibility, loading, dimensions, fallback `src`, bindings unrelated to responsive source selection, and unrelated source bytes. It refuses dynamic responsive expressions, unsafe structural contexts, or ambiguous breakpoint overlap. The explicit CLI opt-in acknowledges selector-sensitive wrapping; generated templates must reparse with the Angular compiler and be idempotent.
 
 ### Native CSS
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -46,7 +46,7 @@ The Tailwind CSS 4 column identifies current target behavior. Native CSS and res
 | `ngClass`        | Class/style | Limited        | Planned        | Not applicable   |
 | `style`          | Class/style | Preserved      | Preserved      | Not applicable   |
 | `ngStyle`        | Class/style | Limited        | Planned        | Not applicable   |
-| `imgSrc`         | Image       | Not applicable | Not applicable | Planned          |
+| `imgSrc`         | Image       | Not applicable | Not applicable | Limited          |
 
 <!-- compatibility-inventory:end -->
 
@@ -108,7 +108,15 @@ Grid container and child directives convert for literal base values, the 13 stan
 - literal `ngClass.<alias>`: Converts complete families whose class tokens are proven Tailwind CSS v4 candidates.
 - literal `ngStyle.<alias>`: Converts complete, sanitizer-safe declaration lists with exact CSS ownership.
 - deprecated `class.<alias>` and `style.<alias>`: Version-dependent replacement and merge behavior is not inferred.
-- responsive `imgSrc`: Recognized and reported; no target conversion is implemented.
+- responsive `imgSrc`: Opt-in literal standard aliases convert to picture markup when URL, fallback, and structural context are safe.
+
+## Responsive images
+
+`--responsive-images` converts eligible literal `src.<alias>` inputs into ordered native `<picture>` sources. The flag acknowledges that wrapping an `<img>` can affect parent/child CSS and application test selectors. The original fallback `<img>` retains its literal `src`, bound `[src]`, accessibility, loading, sizing, event, reference, class, style, and other unrelated attributes.
+
+Conversion is limited to the 13 standard viewport aliases and one descriptor-free literal URL per responsive source. Dynamic or interpolated values, empty values, orientation, print, custom aliases, conflicting source ownership, structural directives on the image, and existing `<picture>` ancestry remain unchanged with diagnostics. The complete generated template must reparse before any file is written.
+
+JSON reports retain schema version `1` and identify converted and preserved `imgSrc` occurrences by file and source offset. Review every converted image for selectors that assumed the `<img>` had its former parent. Interactive file navigation and a post-run checklist belong to the later CLI upgrade.
 
 The always-supported aliases are `xs`, `sm`, `md`, `lg`, `xl`, `lt-sm`, `lt-md`, `lt-lg`, `lt-xl`, `gt-xs`, `gt-sm`, `gt-md`, and `gt-lg`. Each emitted class contains the exact Angular Flex-Layout media range rather than a project-defined Tailwind breakpoint. Explicit configuration additionally enables orientation and print as described below.
 

--- a/src/adapter/tailwind/responsive-family.planner.spec.ts
+++ b/src/adapter/tailwind/responsive-family.planner.spec.ts
@@ -5,7 +5,9 @@ import { ResponsiveFamilyPlanner } from './responsive-family.planner';
 const element = {
   id: '0',
   name: 'div',
+  source: { start: 0, end: 5 },
   startTag: { start: 0, end: 5 },
+  structural: false,
   attributes: [],
 } as const;
 

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -5,13 +5,17 @@ import { TailwindAdapter } from './tailwind.adapter';
 const element: TemplateElement = {
   id: '0',
   name: 'div',
+  source: { start: 0, end: 5 },
   startTag: { start: 0, end: 5 },
+  structural: false,
   attributes: [],
 };
 const parent: TemplateElement = {
   id: 'parent',
   name: 'section',
+  source: { start: 0, end: 9 },
   startTag: { start: 0, end: 9 },
+  structural: false,
   attributes: [],
 };
 

--- a/src/analyzer/compatibility-inventory.spec.ts
+++ b/src/analyzer/compatibility-inventory.spec.ts
@@ -14,7 +14,12 @@ describe('compatibility inventory', () => {
         expect.objectContaining({ directive: 'fxLayout', tailwind: 'limited', css: 'planned' }),
         expect.objectContaining({ directive: 'gdColumns', tailwind: 'limited', css: 'planned' }),
         expect.objectContaining({ directive: 'gdInline', family: 'grid', tailwind: 'limited', css: 'planned' }),
-        expect.objectContaining({ directive: 'imgSrc', tailwind: 'not-applicable', image: 'planned' }),
+        expect.objectContaining({
+          directive: 'imgSrc',
+          tailwind: 'not-applicable',
+          image: 'limited',
+          breakpoints: expect.objectContaining({ standard: 'limited', custom: 'preserved' }),
+        }),
         expect.objectContaining({ directive: 'class', tailwind: 'preserved', css: 'preserved' }),
       ]),
     );

--- a/src/analyzer/compatibility-inventory.ts
+++ b/src/analyzer/compatibility-inventory.ts
@@ -38,8 +38,8 @@ const standardLimited: BreakpointCoverage = {
   custom: 'preserved',
 };
 
-const imagePlanned: BreakpointCoverage = {
-  standard: 'planned',
+const imageLimited: BreakpointCoverage = {
+  standard: 'limited',
   orientation: 'not-applicable',
   print: 'not-applicable',
   custom: 'preserved',
@@ -319,9 +319,9 @@ const entries: CompatibilityEntry[] = [
     family: 'image',
     tailwind: 'not-applicable',
     css: 'not-applicable',
-    image: 'planned',
-    breakpoints: imagePlanned,
-    note: 'Recognized and reported; no target conversion is implemented.',
+    image: 'limited',
+    breakpoints: imageLimited,
+    note: 'Opt-in literal standard aliases convert to picture markup when URL, fallback, and structural context are safe.',
   },
 ];
 

--- a/src/analyzer/conversion-result.spec.ts
+++ b/src/analyzer/conversion-result.spec.ts
@@ -31,8 +31,15 @@ const results = [
     reason: 'Unexpected closing tag.',
     source: { start: 10, end: 16 },
   },
+  {
+    status: 'parse-error',
+    fileName: 'generated.html',
+    code: 'generated-template-parse-error',
+    reason: 'Generated template did not reparse.',
+    source: { start: 0, end: 1 },
+  },
 ] satisfies readonly ConversionResult[];
 
 test('models successful, unresolved, and parse-error results exhaustively', () => {
-  expect(results.map(result => result.status)).toEqual(['converted', 'review', 'review', 'parse-error']);
+  expect(results.map(result => result.status)).toEqual(['converted', 'review', 'review', 'parse-error', 'parse-error']);
 });

--- a/src/analyzer/conversion-result.ts
+++ b/src/analyzer/conversion-result.ts
@@ -34,7 +34,7 @@ export interface UnresolvedResult {
 export interface ParseErrorResult {
   readonly status: 'parse-error';
   readonly fileName: string;
-  readonly code: 'template-parse-error';
+  readonly code: 'template-parse-error' | 'generated-template-parse-error';
   readonly reason: string;
   readonly source: SourceRange;
 }

--- a/src/analyzer/flex-layout-attribute.analyzer.spec.ts
+++ b/src/analyzer/flex-layout-attribute.analyzer.spec.ts
@@ -32,11 +32,28 @@ describe('analyzeFlexLayoutAttribute', () => {
   });
 
   test.each([
+    ['src.xs', 'small.png', 'literal'],
+    ['src.gt-lg', 'wide.png', 'literal'],
+    ['[src.md]', 'mediumImage', 'property'],
+    ['[src.handset.landscape]', 'handsetImage', 'property'],
+  ] as const)('recognizes upstream responsive image input %s as imgSrc', (sourceName, value, binding) => {
+    expect(analyzeFlexLayoutAttribute(sourceName, value)).toEqual({
+      sourceName,
+      value,
+      directive: 'imgSrc',
+      breakpoint: sourceName.replace(/^\[?src\./, '').replace(/\]$/, ''),
+      binding,
+    });
+  });
+
+  test.each([
     ['aria-label', 'Menu'],
     ['class', 'card'],
     ['style', 'display: block'],
     ['[class]', 'cardClass'],
     ['[style]', 'cardStyle'],
+    ['src', 'fallback.png'],
+    ['[src]', 'fallbackImage'],
     ['fxLayout]', 'row'],
   ])('ignores unrelated or malformed attribute %s', (sourceName, value) => {
     expect(analyzeFlexLayoutAttribute(sourceName, value)).toBeUndefined();

--- a/src/analyzer/flex-layout-attribute.analyzer.ts
+++ b/src/analyzer/flex-layout-attribute.analyzer.ts
@@ -31,6 +31,17 @@ export function analyzeFlexLayoutAttribute(sourceName: string, value: string): F
 
   const binding: BindingKind = startsWithBracket ? 'property' : 'literal';
   const normalizedName = startsWithBracket ? sourceName.slice(1, -1) : sourceName;
+
+  if (normalizedName.startsWith('src.')) {
+    return {
+      sourceName,
+      value,
+      directive: 'imgSrc',
+      breakpoint: normalizedName.slice('src.'.length),
+      binding,
+    };
+  }
+
   const directive = directivesByLength.find(
     candidate => normalizedName === candidate || normalizedName.startsWith(`${candidate}.`),
   );

--- a/src/cli/run-cli.spec.ts
+++ b/src/cli/run-cli.spec.ts
@@ -275,6 +275,48 @@ describe('runCli', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('--orientation-breakpoints');
     expect(result.stdout).toContain('--print-with-breakpoints <aliases>');
+    expect(result.stdout).toContain('--responsive-images');
+    expect(result.stdout).toContain('picture');
+  });
+
+  test('preserves responsive images by default and identifies the opt-in', async () => {
+    const input = join(temporaryDirectory, 'input.html');
+    const source = '<img src="base.png" src.sm="small.png">';
+    await writeFile(input, source, 'utf8');
+
+    const result = await run([input]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stdout).toContain('[target-unsupported]');
+    expect(await readFile(input, 'utf8')).toBe(source);
+  });
+
+  test('converts responsive images only with explicit acknowledgement and reports their location', async () => {
+    const input = join(temporaryDirectory, 'input.html');
+    const output = join(temporaryDirectory, 'output.html');
+    const report = join(temporaryDirectory, 'report.json');
+    await writeFile(input, '<img src="base.png" src.sm="small.png">', 'utf8');
+
+    const result = await run([input, '--output', output, '--responsive-images', '--report', report]);
+
+    expect(result.exitCode).toBe(0);
+    expect(await readFile(output, 'utf8')).toContain('<picture>');
+    expect(JSON.parse(await readFile(report, 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      files: [{ results: [{ status: 'converted', directive: 'imgSrc', sourceName: 'src.sm', offset: 20 }] }],
+    });
+  });
+
+  test('plans responsive image output without writing during dry-run', async () => {
+    const input = join(temporaryDirectory, 'input.html');
+    const output = join(temporaryDirectory, 'output.html');
+    await writeFile(input, '<img src.sm="small.png">', 'utf8');
+
+    const result = await run([input, '--output', output, '--responsive-images', '--dry-run']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('1 would change');
+    await expect(access(output)).rejects.toThrow();
   });
 
   test('rejects invalid print breakpoint configuration before reading input', async () => {

--- a/src/cli/run-cli.ts
+++ b/src/cli/run-cli.ts
@@ -18,6 +18,7 @@ interface ProgramOptions {
   readonly allowUnresolved: boolean;
   readonly debug: boolean;
   readonly orientationBreakpoints: boolean;
+  readonly responsiveImages: boolean;
   readonly printWithBreakpoints?: string;
 }
 
@@ -60,6 +61,11 @@ export async function runCli(argv: readonly string[], output: CliOutput = proces
     .option('--allow-unresolved', 'return success when unresolved inputs remain', false)
     .option('--orientation-breakpoints', 'confirm the source enables the archived orientation breakpoints', false)
     .option(
+      '--responsive-images',
+      'wrap eligible responsive images in picture elements; acknowledges selector and layout risk',
+      false,
+    )
+    .option(
       '--print-with-breakpoints <aliases>',
       'confirm the source printWithBreakpoints list; comma-separated aliases or none',
     )
@@ -80,7 +86,10 @@ export async function runCli(argv: readonly string[], output: CliOutput = proces
       if (options.report !== undefined) {
         validateReportPath(options.report);
       }
-      const report = await new Migrator(adapter, input, destination).migrate({ dryRun: options.dryRun });
+      const report = await new Migrator(adapter, input, destination).migrate({
+        dryRun: options.dryRun,
+        responsiveImages: options.responsiveImages,
+      });
       const reportOutput = report.summary.parseErrors > 0 ? output.stderr : output.stdout;
 
       new TerminalPresenter().present(report, reportOutput);

--- a/src/image/html-attribute.encoder.spec.ts
+++ b/src/image/html-attribute.encoder.spec.ts
@@ -1,0 +1,12 @@
+import { encodeHtmlAttribute } from './html-attribute.encoder';
+
+describe('encodeHtmlAttribute', () => {
+  test.each([
+    ['hero.png', 'hero.png'],
+    ['a&b"c', 'a&amp;b&quot;c'],
+    ['line\r\nbreak', 'line&#13;&#10;break'],
+    ['<hero>', '&lt;hero&gt;'],
+  ])('encodes %j for a generated double-quoted HTML attribute', (value, expected) => {
+    expect(encodeHtmlAttribute(value)).toBe(expected);
+  });
+});

--- a/src/image/html-attribute.encoder.ts
+++ b/src/image/html-attribute.encoder.ts
@@ -1,0 +1,9 @@
+export function encodeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('\r', '&#13;')
+    .replaceAll('\n', '&#10;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}

--- a/src/image/picture.renderer.spec.ts
+++ b/src/image/picture.renderer.spec.ts
@@ -42,6 +42,19 @@ describe('PictureRenderer', () => {
     );
   });
 
+  test.each([
+    ['spaces', '  ', '    '],
+    ['tabs', '\t', '\t\t'],
+  ])('aligns nested multiline output using %s', (_label, baseIndent, attributeIndent) => {
+    const image = `<img\n${attributeIndent}alt="Hero"\n${attributeIndent}src.lt-sm="mobile.png"\n${baseIndent}>`;
+    const source = `<section>\n${baseIndent}${image}\n</section>`;
+    const rendered = new PictureRenderer().render(source, fixture(source));
+
+    expect(rendered).toContain(`\n${attributeIndent}<source `);
+    expect(rendered).toContain(`\n${attributeIndent}<img\n${attributeIndent}alt="Hero"`);
+    expect(rendered).toMatch(new RegExp(`\\n${baseIndent.replaceAll('\t', '\\t')}</picture>$`, 'u'));
+  });
+
   test('composes image-contained edits into the retained image slice', () => {
     const source = '<img class="old" src.md="medium.png">';
     const start = source.indexOf('old');

--- a/src/image/picture.renderer.spec.ts
+++ b/src/image/picture.renderer.spec.ts
@@ -1,0 +1,52 @@
+import { TemplateAnalyzer } from '../analyzer/template.analyzer';
+import type { SourceEdit } from '../edit/source-edit';
+import { AngularTemplateParser } from '../template/angular-template.parser';
+import { PictureRenderer } from './picture.renderer';
+import type { ResponsiveImagePlan } from './responsive-image.model';
+import { ResponsiveImagePlanner } from './responsive-image.planner';
+
+function fixture(source: string): ResponsiveImagePlan {
+  const parsed = new AngularTemplateParser().parse(source, 'fixture.html');
+  if (parsed.status !== 'parsed') throw new Error('fixture did not parse');
+  const element = parsed.elements.find(candidate => candidate.name === 'img');
+  if (!element) throw new Error('fixture has no img');
+  const inputs = new TemplateAnalyzer().analyze('fixture.html', [element]);
+  const planned = new ResponsiveImagePlanner().plan(inputs, { element, ancestors: [] }, true);
+  if (planned.status !== 'converted') throw new Error('fixture did not plan');
+  return planned.plan;
+}
+
+describe('PictureRenderer', () => {
+  test('renders compact native markup in descending priority while retaining unrelated image bytes', () => {
+    const source =
+      '<img alt="Hero" src.gt-xs="wide.png" src="default.png" src.md="medium&amp;crop.png" loading="lazy">';
+
+    expect(new PictureRenderer().render(source, fixture(source))).toBe(
+      '<picture><source media="screen and (min-width: 960px) and (max-width: 1279.98px)" srcset="medium&amp;crop.png"><source media="screen and (min-width: 600px)" srcset="wide.png"><img alt="Hero" src="default.png" loading="lazy"></picture>',
+    );
+  });
+
+  test.each([
+    ['<img src.lt-sm="mobile.png" />', '<img />'],
+    ['<img [src]="fallback" src.lt-sm="mobile.png">', '<img [src]="fallback">'],
+    ['<img src.lt-sm="mobile.png">', '<img>'],
+  ])('retains fallback spelling for %s', (source, retainedImage) => {
+    expect(new PictureRenderer().render(source, fixture(source))).toContain(retainedImage);
+  });
+
+  test('uses source-derived multiline and CRLF formatting', () => {
+    const source = '<img\r\n  alt="Hero"\r\n  src.lt-sm="mobile.png"\r\n>';
+
+    expect(new PictureRenderer().render(source, fixture(source))).toBe(
+      '<picture>\r\n  <source media="screen and (max-width: 599.98px)" srcset="mobile.png">\r\n  <img\r\n  alt="Hero"\r\n>\r\n</picture>',
+    );
+  });
+
+  test('composes image-contained edits into the retained image slice', () => {
+    const source = '<img class="old" src.md="medium.png">';
+    const start = source.indexOf('old');
+    const innerEdit: SourceEdit = { range: { start, end: start + 3 }, text: 'new', inputId: 'class-edit' };
+
+    expect(new PictureRenderer().render(source, fixture(source), [innerEdit])).toContain('<img class="new">');
+  });
+});

--- a/src/image/picture.renderer.ts
+++ b/src/image/picture.renderer.ts
@@ -1,0 +1,64 @@
+import type { SourceEdit } from '../edit/source-edit';
+import { SourceEditor } from '../edit/source-editor';
+import type { MediaClause } from '../breakpoint/breakpoint-catalog';
+import { encodeHtmlAttribute } from './html-attribute.encoder';
+import type { ResponsiveImagePlan, ResponsiveImageSource } from './responsive-image.model';
+
+function mediaClause(clause: MediaClause): string {
+  const conditions: string[] = [];
+  if (clause.min !== undefined) conditions.push(`(min-width: ${clause.min}px)`);
+  if (clause.max !== undefined) conditions.push(`(max-width: ${clause.max}px)`);
+  if (clause.orientation !== undefined) conditions.push(`(orientation: ${clause.orientation})`);
+  return conditions.join(' and ');
+}
+
+function mediaValue(source: ResponsiveImageSource): string {
+  const { media } = source.definition;
+  const clauses = media.clauses.map(mediaClause).filter(Boolean);
+  if (!clauses.length) return media.type;
+  return `${media.type} and ${clauses.map(clause => (clauses.length > 1 ? `(${clause})` : clause)).join(', ')}`;
+}
+
+function removalStart(source: string, elementStart: number, attributeStart: number): number {
+  let start = attributeStart;
+  while (start > elementStart && /\s/u.test(source[start - 1] ?? '')) start--;
+  return start;
+}
+
+export class PictureRenderer {
+  render(source: string, plan: ResponsiveImagePlan, innerEdits: readonly SourceEdit[] = []): string {
+    const { element } = plan;
+    const imageSource = source.slice(element.source.start, element.source.end);
+    const removalEdits: SourceEdit[] = plan.sources.map(responsiveSource => ({
+      range: {
+        start: removalStart(source, element.startTag.start, responsiveSource.input.source.start) - element.source.start,
+        end: responsiveSource.input.source.end - element.source.start,
+      },
+      text: '',
+      inputId: responsiveSource.input.id,
+    }));
+    const localInnerEdits = innerEdits.map(edit => ({
+      ...edit,
+      range: {
+        start: edit.range.start - element.source.start,
+        end: edit.range.end - element.source.start,
+      },
+    }));
+    const edited = new SourceEditor().apply(imageSource, [...removalEdits, ...localInnerEdits]);
+    if (edited.status === 'invalid') {
+      throw new Error(`Cannot compose responsive image edits: ${edited.diagnostics[0]?.message ?? 'invalid edit'}`);
+    }
+
+    const sourceTags = plan.sources.map(
+      responsiveSource =>
+        `<source media="${encodeHtmlAttribute(mediaValue(responsiveSource))}" srcset="${encodeHtmlAttribute(responsiveSource.url)}">`,
+    );
+    const lineEnding = imageSource.includes('\r\n') ? '\r\n' : '\n';
+    if (!imageSource.includes('\n')) {
+      return `<picture>${sourceTags.join('')}${edited.output}</picture>`;
+    }
+
+    const indentation = imageSource.match(/\r?\n([\t ]+)\S/u)?.[1] ?? '  ';
+    return `<picture>${lineEnding}${sourceTags.map(tag => `${indentation}${tag}`).join(lineEnding)}${lineEnding}${indentation}${edited.output}${lineEnding}</picture>`;
+  }
+}

--- a/src/image/picture.renderer.ts
+++ b/src/image/picture.renderer.ts
@@ -58,7 +58,14 @@ export class PictureRenderer {
       return `<picture>${sourceTags.join('')}${edited.output}</picture>`;
     }
 
-    const indentation = imageSource.match(/\r?\n([\t ]+)\S/u)?.[1] ?? '  ';
-    return `<picture>${lineEnding}${sourceTags.map(tag => `${indentation}${tag}`).join(lineEnding)}${lineEnding}${indentation}${edited.output}${lineEnding}</picture>`;
+    const lineStart = Math.max(source.lastIndexOf('\n', element.source.start - 1) + 1, 0);
+    const linePrefix = source.slice(lineStart, element.source.start);
+    const baseIndentation = /^[\t ]*$/u.test(linePrefix) ? linePrefix : '';
+    const attributeIndentation = imageSource.match(/\r?\n([\t ]+)\S/u)?.[1];
+    const indentation =
+      attributeIndentation?.startsWith(baseIndentation) && attributeIndentation.length > baseIndentation.length
+        ? attributeIndentation
+        : `${baseIndentation}  `;
+    return `<picture>${lineEnding}${sourceTags.map(tag => `${indentation}${tag}`).join(lineEnding)}${lineEnding}${indentation}${edited.output}${lineEnding}${baseIndentation}</picture>`;
   }
 }

--- a/src/image/responsive-image.model.ts
+++ b/src/image/responsive-image.model.ts
@@ -1,0 +1,25 @@
+import type { PlannedConversion } from '../adapter/conversion-adapter';
+import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import type { BreakpointDefinition } from '../breakpoint/breakpoint-catalog';
+import type { TemplateElement } from '../template/template.model';
+
+export interface ResponsiveImageSource {
+  readonly input: LocatedFlexLayoutInput;
+  readonly definition: BreakpointDefinition;
+  readonly url: string;
+}
+
+export interface ResponsiveImagePlan {
+  readonly element: TemplateElement;
+  readonly sources: readonly ResponsiveImageSource[];
+  readonly fallback: 'literal' | 'bound' | 'absent';
+}
+
+export interface ResponsiveImageContext {
+  readonly element: TemplateElement;
+  readonly ancestors: readonly TemplateElement[];
+}
+
+export type ResponsiveImagePlanningResult =
+  | { readonly status: 'converted'; readonly plan: ResponsiveImagePlan }
+  | { readonly status: 'unresolved'; readonly plans: readonly PlannedConversion[] };

--- a/src/image/responsive-image.planner.spec.ts
+++ b/src/image/responsive-image.planner.spec.ts
@@ -1,0 +1,118 @@
+import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import { AngularTemplateParser } from '../template/angular-template.parser';
+import type { TemplateElement } from '../template/template.model';
+import { TemplateAnalyzer } from '../analyzer/template.analyzer';
+import { ResponsiveImagePlanner } from './responsive-image.planner';
+
+function fixture(source: string) {
+  const parsed = new AngularTemplateParser().parse(source, 'fixture.html');
+  if (parsed.status !== 'parsed') throw new Error('fixture did not parse');
+  const element = parsed.elements.find(candidate => candidate.name === 'img');
+  if (!element) throw new Error('fixture has no img');
+  const byId = new Map(parsed.elements.map(candidate => [candidate.id, candidate]));
+  const ancestors: TemplateElement[] = [];
+  let parent = element.parentId ? byId.get(element.parentId) : undefined;
+  while (parent) {
+    ancestors.push(parent);
+    parent = parent.parentId ? byId.get(parent.parentId) : undefined;
+  }
+  return {
+    inputs: new TemplateAnalyzer().analyze('fixture.html', [element]),
+    context: { element, ancestors },
+  };
+}
+
+function plan(source: string, enabled = true) {
+  const { inputs, context } = fixture(source);
+  return new ResponsiveImagePlanner().plan(inputs, context, enabled);
+}
+
+describe('ResponsiveImagePlanner', () => {
+  test.each(['xs', 'sm', 'md', 'lg', 'xl', 'lt-sm', 'lt-md', 'lt-lg', 'lt-xl', 'gt-xs', 'gt-sm', 'gt-md', 'gt-lg'])(
+    'plans standard responsive source %s from the shared catalog',
+    alias => {
+      expect(plan(`<img src.${alias}="${alias}.png">`)).toMatchObject({
+        status: 'converted',
+        plan: { sources: [{ definition: { alias }, url: `${alias}.png` }] },
+      });
+    },
+  );
+
+  test('orders overlapping sources by descending Flex priority', () => {
+    const result = plan('<img src.gt-xs="wide.png" src.md="medium.png" src.lt-lg="narrow.png">');
+
+    expect(result.status === 'converted' ? result.plan.sources.map(source => source.definition.alias) : []).toEqual([
+      'md',
+      'lt-lg',
+      'gt-xs',
+    ]);
+  });
+
+  test.each([
+    ['literal', '<img src="fallback.png" src.md="medium.png">'],
+    ['bound', '<img [src]="fallback" src.md="medium.png">'],
+    ['absent', '<img src.md="medium.png">'],
+  ] as const)('classifies a %s fallback', (fallback, source) => {
+    expect(plan(source)).toMatchObject({ status: 'converted', plan: { fallback } });
+  });
+
+  test('preserves the complete family when the feature is disabled', () => {
+    expect(plan('<img src.sm="small.png" src.md="medium.png">', false)).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { status: 'unsupported', code: 'target-unsupported' },
+        { status: 'unsupported', code: 'target-unsupported' },
+      ],
+    });
+  });
+
+  test.each([
+    ['dynamic responsive source', '<img [src.md]="mediumImage">', 'dynamic-binding'],
+    ['interpolated responsive source', '<img src.md="{{ mediumImage }}">', 'dynamic-binding'],
+    ['empty responsive source', '<img src.md="">', 'invalid-value'],
+    ['descriptor-bearing source', '<img src.md="medium.png 2x">', 'invalid-value'],
+    ['orientation alias', '<img src.handset="handset.png">', 'breakpoint-unverified'],
+    ['print alias', '<img src.print="print.png">', 'breakpoint-unverified'],
+    ['custom alias', '<img src.cinema="cinema.png">', 'custom-breakpoint'],
+    ['empty alias', '<img src.="image.png">', 'custom-breakpoint'],
+    ['structural directive', '<img *ngIf="shown" src.md="medium.png">', 'context-unverified'],
+    ['picture ancestry', '<picture><span><img src.md="medium.png"></span></picture>', 'context-unverified'],
+  ] as const)('preserves a family with %s', (_label, source, code) => {
+    expect(plan(source)).toMatchObject({ status: 'unresolved', plans: [{ code }] });
+  });
+
+  test('rejects a responsive source on a non-image host', () => {
+    const parsed = new AngularTemplateParser().parse('<div src.md="medium.png"></div>', 'fixture.html');
+    if (parsed.status !== 'parsed') throw new Error('fixture did not parse');
+    const element = parsed.elements[0] as TemplateElement;
+    const inputs = new TemplateAnalyzer().analyze('fixture.html', [element]);
+
+    expect(new ResponsiveImagePlanner().plan(inputs, { element, ancestors: [] }, true)).toMatchObject({
+      status: 'unresolved',
+      plans: [{ code: 'context-unverified' }],
+    });
+  });
+
+  test('preserves every member when one member is unsafe', () => {
+    const result = plan('<img src.sm="small.png" src.md="medium.png 2x">');
+
+    expect(result).toMatchObject({
+      status: 'unresolved',
+      plans: [
+        { input: { sourceName: 'src.sm' }, code: 'invalid-value' },
+        { input: { sourceName: 'src.md' }, code: 'invalid-value' },
+      ],
+    });
+  });
+
+  test('preserves duplicate ownership for the same alias', () => {
+    const { context } = fixture('<img src.md="one.png">');
+    const first = new TemplateAnalyzer().analyze('fixture.html', [context.element])[0] as LocatedFlexLayoutInput;
+    const second = { ...first, id: 'fixture.html:duplicate', sourceName: 'src.md' };
+
+    expect(new ResponsiveImagePlanner().plan([first, second], context, true)).toMatchObject({
+      status: 'unresolved',
+      plans: [{ code: 'responsive-precedence-unverified' }, { code: 'responsive-precedence-unverified' }],
+    });
+  });
+});

--- a/src/image/responsive-image.planner.ts
+++ b/src/image/responsive-image.planner.ts
@@ -1,0 +1,184 @@
+import type { PlannedConversion } from '../adapter/conversion-adapter';
+import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import type { DiagnosticCode } from '../analyzer/conversion-result';
+import { ORIENTATION_BREAKPOINTS } from '../analyzer/flex-layout.catalog';
+import { BreakpointCatalog, type BreakpointDefinition } from '../breakpoint/breakpoint-catalog';
+import { compareCodeUnits } from '../util/compare-code-units';
+import type {
+  ResponsiveImageContext,
+  ResponsiveImagePlanningResult,
+  ResponsiveImageSource,
+} from './responsive-image.model';
+import { validateSingleSrcsetUrl } from './srcset-value';
+
+interface Failure {
+  readonly status: 'review' | 'unsupported' | 'invalid';
+  readonly code: DiagnosticCode;
+  readonly reason: string;
+  readonly suggestion: string;
+}
+
+const standardAliases = new Set([
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'lt-sm',
+  'lt-md',
+  'lt-lg',
+  'lt-xl',
+  'gt-xs',
+  'gt-sm',
+  'gt-md',
+  'gt-lg',
+]);
+const optionalAliases = new Set<string>(ORIENTATION_BREAKPOINTS);
+
+function unresolved(inputs: readonly LocatedFlexLayoutInput[], failure: Failure): ResponsiveImagePlanningResult {
+  return {
+    status: 'unresolved',
+    plans: inputs.map(
+      input =>
+        ({
+          ...failure,
+          input,
+        }) satisfies PlannedConversion,
+    ),
+  };
+}
+
+function breakpointFailure(alias: string): Failure {
+  if (alias.length === 0 || (!optionalAliases.has(alias) && alias !== 'print')) {
+    return {
+      status: 'unsupported',
+      code: 'custom-breakpoint',
+      reason: `Responsive image breakpoint "${alias}" is not a standard viewport alias.`,
+      suggestion: 'Migrate the responsive image source manually.',
+    };
+  }
+  return {
+    status: 'unsupported',
+    code: 'breakpoint-unverified',
+    reason: `Responsive image breakpoint "${alias}" is not supported by native image migration.`,
+    suggestion: 'Keep this responsive image family unchanged.',
+  };
+}
+
+export class ResponsiveImagePlanner {
+  private readonly catalog = new BreakpointCatalog();
+
+  plan(
+    inputs: readonly LocatedFlexLayoutInput[],
+    context: ResponsiveImageContext,
+    enabled: boolean,
+  ): ResponsiveImagePlanningResult {
+    if (!enabled) {
+      return unresolved(inputs, {
+        status: 'unsupported',
+        code: 'target-unsupported',
+        reason: 'Responsive image migration is not enabled.',
+        suggestion: 'Rerun with --responsive-images after reviewing picture-wrapper selector risk.',
+      });
+    }
+
+    if (context.element.name.toLowerCase() !== 'img') {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'context-unverified',
+        reason: 'Responsive image inputs are only safe to migrate on an img element.',
+        suggestion: 'Remove or migrate the input manually.',
+      });
+    }
+    if (context.element.structural || context.ancestors.some(ancestor => ancestor.name.toLowerCase() === 'picture')) {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'context-unverified',
+        reason: 'The image has structural syntax or is already inside a picture element.',
+        suggestion: 'Keep this responsive image family unchanged.',
+      });
+    }
+    if (
+      context.element.source.start !== context.element.startTag.start ||
+      context.element.source.end < context.element.startTag.end
+    ) {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'context-unverified',
+        reason: 'The image does not have one unambiguous replacement range.',
+        suggestion: 'Keep this responsive image family unchanged.',
+      });
+    }
+    if (inputs.some(input => input.binding !== 'literal')) {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'dynamic-binding',
+        reason: 'Dynamic responsive image sources cannot become literal source elements.',
+        suggestion: 'Keep the binding or replace it with a literal URL before migrating.',
+      });
+    }
+
+    const aliases = inputs.map(input => input.breakpoint ?? '');
+    const unsupportedAlias = aliases.find(alias => !standardAliases.has(alias));
+    if (unsupportedAlias !== undefined) return unresolved(inputs, breakpointFailure(unsupportedAlias));
+    if (new Set(aliases).size !== aliases.length) {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'responsive-precedence-unverified',
+        reason: 'More than one responsive image input owns the same breakpoint.',
+        suggestion: 'Remove duplicate responsive image inputs before migrating.',
+      });
+    }
+
+    const sources: ResponsiveImageSource[] = [];
+    for (const input of inputs) {
+      const validation = validateSingleSrcsetUrl(input.value);
+      if (validation.status === 'invalid') {
+        return unresolved(inputs, {
+          status: 'invalid',
+          code: 'invalid-value',
+          reason: validation.reason,
+          suggestion: 'Use one literal, descriptor-free URL or migrate this image manually.',
+        });
+      }
+      const classification = this.catalog.classify(input.breakpoint ?? '');
+      if (classification.kind !== 'verified') {
+        return unresolved(inputs, breakpointFailure(input.breakpoint ?? ''));
+      }
+      sources.push({ input, definition: classification.definition as BreakpointDefinition, url: validation.value });
+    }
+
+    const fallbackAttributes = context.element.attributes.filter(attribute => attribute.name === 'src');
+    const literalFallback = fallbackAttributes.filter(
+      attribute => attribute.binding === 'literal' && attribute.rawName.toLowerCase() === 'src',
+    );
+    const boundFallback = fallbackAttributes.filter(
+      attribute =>
+        attribute.binding === 'property' &&
+        attribute.bindingTarget === 'property' &&
+        attribute.rawName.toLowerCase() === '[src]',
+    );
+    if (fallbackAttributes.length !== literalFallback.length + boundFallback.length || fallbackAttributes.length > 1) {
+      return unresolved(inputs, {
+        status: 'review',
+        code: 'context-unverified',
+        reason: 'The fallback image source has conflicting or unsupported ownership.',
+        suggestion: 'Keep one literal src or property [src] fallback before migrating.',
+      });
+    }
+
+    sources.sort(
+      (left, right) =>
+        right.definition.priority - left.definition.priority ||
+        compareCodeUnits(left.definition.alias, right.definition.alias),
+    );
+    return {
+      status: 'converted',
+      plan: {
+        element: context.element,
+        sources,
+        fallback: literalFallback.length ? 'literal' : boundFallback.length ? 'bound' : 'absent',
+      },
+    };
+  }
+}

--- a/src/image/srcset-value.spec.ts
+++ b/src/image/srcset-value.spec.ts
@@ -1,0 +1,22 @@
+import { validateSingleSrcsetUrl } from './srcset-value';
+
+describe('validateSingleSrcsetUrl', () => {
+  test.each(['hero.png', '/assets/hero@2x.png?crop=wide&format=webp', 'https://cdn.example/hero.webp'])(
+    'accepts one descriptor-free URL: %s',
+    value => {
+      expect(validateSingleSrcsetUrl(value)).toEqual({ status: 'valid', value });
+    },
+  );
+
+  test.each([
+    '',
+    'hero 2x',
+    'hero.png 480w',
+    'one.png,two.png',
+    'one.png, two.png',
+    '{{ hero }}',
+    'data:image/png;base64,abc',
+  ])('rejects an empty or ambiguous srcset value: %s', value => {
+    expect(validateSingleSrcsetUrl(value)).toMatchObject({ status: 'invalid', reason: expect.any(String) });
+  });
+});

--- a/src/image/srcset-value.ts
+++ b/src/image/srcset-value.ts
@@ -1,0 +1,18 @@
+export type SrcsetValueValidation =
+  { readonly status: 'valid'; readonly value: string } | { readonly status: 'invalid'; readonly reason: string };
+
+export function validateSingleSrcsetUrl(value: string): SrcsetValueValidation {
+  if (value.length === 0) {
+    return { status: 'invalid', reason: 'A responsive image source cannot be empty.' };
+  }
+  if (value.includes('{{') || value.includes('}}')) {
+    return { status: 'invalid', reason: 'Interpolation is not a literal responsive image URL.' };
+  }
+  if ([...value].some(character => character === ',' || character.charCodeAt(0) <= 32 || character === '\u007f')) {
+    return {
+      status: 'invalid',
+      reason: 'The value is not one descriptor-free srcset URL.',
+    };
+  }
+  return { status: 'valid', value };
+}

--- a/src/migrator/file-migration-result.ts
+++ b/src/migrator/file-migration-result.ts
@@ -2,6 +2,7 @@ import type { ConversionResult } from '../analyzer/conversion-result';
 
 export interface FileMigrationOptions {
   readonly write: boolean;
+  readonly responsiveImages?: boolean;
 }
 
 export interface FileMigrationResult {

--- a/src/migrator/file.migrator.spec.ts
+++ b/src/migrator/file.migrator.spec.ts
@@ -2,6 +2,7 @@ import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { TailwindAdapter } from '../adapter/tailwind/tailwind.adapter';
+import { AngularTemplateParser } from '../template/angular-template.parser';
 import { FileMigrator } from './file.migrator';
 
 describe('FileMigrator', () => {
@@ -32,10 +33,51 @@ describe('FileMigrator', () => {
   test('returns conversion results without writing in dry-run mode', async () => {
     await writeFile(input, '<div fxLayout="row"></div>', 'utf8');
 
-    const result = await new FileMigrator(new TailwindAdapter(), input, output).migrate({ write: false });
+    const result = await new FileMigrator(new TailwindAdapter(), input, output).migrate({
+      write: false,
+      responsiveImages: false,
+    });
 
     expect(result).toMatchObject({ inputPath: input, outputPath: output, changed: true });
     expect(result.results.map(item => item.status)).toEqual(['converted']);
+    await expect(access(output)).rejects.toThrow();
+  });
+
+  test('writes an enabled responsive image and produces zero edits on an in-place second run', async () => {
+    await writeFile(input, '<img src="base.png" src.sm="small.png">', 'utf8');
+    const migrator = new FileMigrator(new TailwindAdapter(), input, input);
+
+    const first = await migrator.migrate({ write: true, responsiveImages: true });
+    expect(first.changed).toBe(true);
+    expect(await readFile(input, 'utf8')).toBe(
+      '<picture><source media="screen and (min-width: 600px) and (max-width: 959.98px)" srcset="small.png"><img src="base.png"></picture>',
+    );
+    expect(await migrator.migrate({ write: true, responsiveImages: true })).toMatchObject({
+      changed: false,
+      results: [],
+    });
+  });
+
+  test('does not write when the complete generated template fails reparsing', async () => {
+    await writeFile(input, '<div fxLayout="row"></div>', 'utf8');
+    let calls = 0;
+    const parser = {
+      parse: (source: string) => {
+        calls++;
+        if (calls === 1) return new AngularTemplateParser().parse(source, input);
+        return {
+          status: 'parse-error' as const,
+          diagnostics: [{ message: 'injected generated failure', source: { start: 0, end: 1 } }],
+        };
+      },
+    };
+
+    const result = await new FileMigrator(new TailwindAdapter(), input, output, undefined, parser).migrate();
+
+    expect(result).toMatchObject({
+      changed: false,
+      results: [{ status: 'parse-error', code: 'generated-template-parse-error' }],
+    });
     await expect(access(output)).rejects.toThrow();
   });
 

--- a/src/migrator/file.migrator.ts
+++ b/src/migrator/file.migrator.ts
@@ -15,13 +15,14 @@ export class FileMigrator extends BaseMigrator<FileMigrationResult> {
     private readonly input: string,
     private readonly output: string,
     private readonly writer: AtomicFileWriter = new AtomicFileWriter(),
+    private readonly parser: AngularTemplateParser = new AngularTemplateParser(),
   ) {
     super();
   }
 
   public async migrate(options: FileMigrationOptions = { write: true }): Promise<FileMigrationResult> {
     const source = await readFile(this.input, 'utf8');
-    const parsed = new AngularTemplateParser().parse(source, this.input);
+    const parsed = this.parser.parse(source, this.input);
     if (parsed.status === 'parse-error') {
       const results: readonly ConversionResult[] = parsed.diagnostics.map(diagnostic => ({
         status: 'parse-error',
@@ -38,7 +39,9 @@ export class FileMigrator extends BaseMigrator<FileMigrationResult> {
       return this.result(false, []);
     }
 
-    const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, this.adapter);
+    const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, this.adapter, {
+      responsiveImages: options.responsiveImages ?? false,
+    });
     const edited = new SourceEditor().apply(source, plan.edits);
     if (edited.status === 'invalid') {
       throw new Error(
@@ -47,6 +50,21 @@ export class FileMigrator extends BaseMigrator<FileMigrationResult> {
     }
 
     const changed = edited.output !== source;
+    if (changed) {
+      const reparsed = this.parser.parse(edited.output, this.output);
+      if (reparsed.status === 'parse-error') {
+        return this.result(
+          false,
+          reparsed.diagnostics.map(diagnostic => ({
+            status: 'parse-error' as const,
+            fileName: this.output,
+            code: 'generated-template-parse-error' as const,
+            reason: diagnostic.message,
+            source: diagnostic.source,
+          })),
+        );
+      }
+    }
     if (changed && options.write) {
       await this.writer.write(this.output, edited.output);
     }

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -10,6 +10,7 @@ import { FolderMigrator } from './folder.migrator';
 
 export interface MigrationOptions {
   readonly dryRun: boolean;
+  readonly responsiveImages?: boolean;
 }
 
 export class Migrator {
@@ -39,11 +40,15 @@ export class Migrator {
         throw new Error('Single-file output path must have a .html extension.');
       }
       files = [
-        await new FileMigrator(this.adapter, this.inputPath, this.outputPath).migrate({ write: !options.dryRun }),
+        await new FileMigrator(this.adapter, this.inputPath, this.outputPath).migrate({
+          write: !options.dryRun,
+          responsiveImages: options.responsiveImages ?? false,
+        }),
       ];
     } else if (inputStat.isDirectory()) {
       files = await new FolderMigrator(this.adapter, this.inputPath, this.outputPath).migrate({
         write: !options.dryRun,
+        responsiveImages: options.responsiveImages ?? false,
       });
     } else {
       throw new Error(`Unsupported input type: ${this.inputPath}`);

--- a/src/planner/conversion-planner.spec.ts
+++ b/src/planner/conversion-planner.spec.ts
@@ -48,6 +48,22 @@ describe('ConversionPlanner', () => {
     ]);
   });
 
+  test.each([
+    ['disabled migration', '<img fxHide src.sm="small.png">', false],
+    ['dynamic source', '<img fxHide [src.sm]="smallImage">', true],
+    ['unsafe source', '<img fxHide src.sm="small.png 2x">', true],
+  ] as const)('keeps unrelated same-image conversions when image migration is %s', (_label, source, enabled) => {
+    const result = migrate(source, { responsiveImages: enabled });
+
+    expect(result.output).toContain('class="hidden"');
+    expect(result.output).toContain(
+      enabled ? source.match(/(?:\[src\.sm\]|src\.sm)="[^"]+"/u)?.[0] : 'src.sm="small.png"',
+    );
+    expect(result.results).toContainEqual(
+      expect.objectContaining({ status: 'converted', input: expect.objectContaining({ directive: 'fxHide' }) }),
+    );
+  });
+
   test('removes a converted input and merges classes into a literal class attribute', () => {
     const result = migrate('<div class="card" fxLayout="row"></div>');
 

--- a/src/planner/conversion-planner.spec.ts
+++ b/src/planner/conversion-planner.spec.ts
@@ -4,17 +4,50 @@ import { SourceEditor } from '../edit/source-editor';
 import { AngularTemplateParser } from '../template/angular-template.parser';
 import { ConversionPlanner } from './conversion-planner';
 
-function migrate(source: string) {
+function migrate(source: string, options: { responsiveImages: boolean } = { responsiveImages: false }) {
   const parsed = new AngularTemplateParser().parse(source, 'fixture.html');
   if (parsed.status !== 'parsed') throw new Error('Expected fixture to parse');
   const inputs = new TemplateAnalyzer().analyze('fixture.html', parsed.elements);
-  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter());
+  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter(), options);
   const edited = new SourceEditor().apply(source, plan.edits);
   if (edited.status !== 'applied') throw new Error('Expected edits to be valid');
   return { ...plan, output: edited.output };
 }
 
 describe('ConversionPlanner', () => {
+  test('composes same-image class edits into one responsive image replacement', () => {
+    const result = migrate('<img class="hero" fxHide src.sm="small.png" src="base.png">', {
+      responsiveImages: true,
+    });
+
+    expect(result.output).toBe(
+      '<picture><source media="screen and (min-width: 600px) and (max-width: 959.98px)" srcset="small.png"><img class="hero hidden" src="base.png"></picture>',
+    );
+    expect(result.edits).toHaveLength(1);
+    expect(result.results.every(item => item.status === 'converted')).toBe(true);
+  });
+
+  test('keeps responsive image and sibling edits disjoint', () => {
+    const result = migrate('<img src.md="medium.png"><div fxLayout="row"></div>', { responsiveImages: true });
+
+    expect(result.output).toBe(
+      '<picture><source media="screen and (min-width: 960px) and (max-width: 1279.98px)" srcset="medium.png"><img></picture><div class="flex flex-row box-border"></div>',
+    );
+    expect(result.edits).toHaveLength(3);
+  });
+
+  test('preserves the image family when a same-image class conversion is unresolved', () => {
+    const source = '<img [class]="classes" fxHide src.sm="small.png">';
+    const result = migrate(source, { responsiveImages: true });
+
+    expect(result.output).toBe(source);
+    expect(result.edits).toEqual([]);
+    expect(result.results).toEqual([
+      expect.objectContaining({ input: expect.objectContaining({ sourceName: 'fxHide' }), status: 'review' }),
+      expect.objectContaining({ input: expect.objectContaining({ sourceName: 'src.sm' }), status: 'review' }),
+    ]);
+  });
+
   test('removes a converted input and merges classes into a literal class attribute', () => {
     const result = migrate('<div class="card" fxLayout="row"></div>');
 

--- a/src/planner/conversion-planner.ts
+++ b/src/planner/conversion-planner.ts
@@ -5,10 +5,17 @@ import type { SourceEdit } from '../edit/source-edit';
 import { templateAttributeKeys } from '../template/template-attribute';
 import type { SourceRange, TemplateElement } from '../template/template.model';
 import { appendLiteralClassNames } from '../edit/html-attribute-value';
+import { ResponsiveImagePlanner } from '../image/responsive-image.planner';
+import type { ResponsiveImagePlan } from '../image/responsive-image.model';
+import { PictureRenderer } from '../image/picture.renderer';
 
 export interface FilePlan {
   readonly edits: readonly SourceEdit[];
   readonly results: readonly ConversionResult[];
+}
+
+export interface ConversionPlanningOptions {
+  readonly responsiveImages: boolean;
 }
 
 interface ElementConversions {
@@ -79,6 +86,7 @@ export class ConversionPlanner {
     elements: readonly TemplateElement[],
     inputs: readonly LocatedFlexLayoutInput[],
     adapter: ConversionAdapter,
+    options: ConversionPlanningOptions = { responsiveImages: false },
   ): FilePlan {
     const elementById = new Map(elements.map(element => [element.id, element]));
     const inputsByElementId = new Map<string, LocatedFlexLayoutInput[]>();
@@ -92,9 +100,12 @@ export class ConversionPlanner {
     const plansByInputId = new Map<string, PlannedConversion>();
     const plansByElementId = new Map<string, readonly PlannedConversion[]>();
     const contextsByElementId = new Map<string, ConversionContext>();
+    const imagePlansByElementId = new Map<string, ResponsiveImagePlan>();
 
     for (const element of elements) {
-      const elementInputs = inputsByElementId.get(element.id) ?? [];
+      const allElementInputs = inputsByElementId.get(element.id) ?? [];
+      if (!allElementInputs.length) continue;
+      const elementInputs = allElementInputs.filter(input => input.directive !== 'imgSrc');
       if (!elementInputs.length) continue;
       const parent = element.parentId ? elementById.get(element.parentId) : undefined;
       const literalClass = literalClassAttribute(element);
@@ -132,6 +143,50 @@ export class ConversionPlanner {
       }
     }
 
+    for (const element of elements) {
+      const imageInputs = (inputsByElementId.get(element.id) ?? []).filter(input => input.directive === 'imgSrc');
+      if (!imageInputs.length) continue;
+      const ancestors: TemplateElement[] = [];
+      let ancestor = element.parentId ? elementById.get(element.parentId) : undefined;
+      while (ancestor) {
+        ancestors.push(ancestor);
+        ancestor = ancestor.parentId ? elementById.get(ancestor.parentId) : undefined;
+      }
+      const imageResult = new ResponsiveImagePlanner().plan(
+        imageInputs,
+        { element, ancestors },
+        options.responsiveImages,
+      );
+      const ordinaryPlans = (inputsByElementId.get(element.id) ?? [])
+        .filter(input => input.directive !== 'imgSrc')
+        .map(input => plansByInputId.get(input.id))
+        .filter((plan): plan is PlannedConversion => plan !== undefined);
+      const unresolvedOrdinary = ordinaryPlans.some(plan => plan.status !== 'converted');
+
+      if (imageResult.status === 'converted' && !unresolvedOrdinary) {
+        imagePlansByElementId.set(element.id, imageResult.plan);
+        for (const input of imageInputs) {
+          plansByInputId.set(input.id, { status: 'converted', input, classNames: [] });
+        }
+        continue;
+      }
+
+      const familyFailure = {
+        status: 'review' as const,
+        code: 'context-unverified' as const,
+        reason: 'Responsive image and same-element conversions must be applied atomically.',
+        suggestion: 'Resolve all conversions on this image before enabling its picture migration.',
+      };
+      for (const plan of ordinaryPlans) {
+        if (plan.status === 'converted') plansByInputId.set(plan.input.id, { ...familyFailure, input: plan.input });
+      }
+      if (imageResult.status === 'converted') {
+        for (const input of imageInputs) plansByInputId.set(input.id, { ...familyFailure, input });
+      } else {
+        for (const plan of imageResult.plans) plansByInputId.set(plan.input.id, plan);
+      }
+    }
+
     for (const input of inputs) {
       const element = elementById.get(input.elementId);
       if (!element) continue;
@@ -140,6 +195,11 @@ export class ConversionPlanner {
 
       if (planned.status !== 'converted') {
         results.push(planned);
+        continue;
+      }
+
+      if (input.directive === 'imgSrc') {
+        results.push({ status: 'converted', input });
         continue;
       }
 
@@ -181,6 +241,19 @@ export class ConversionPlanner {
         `${conversion.element.id}:classes`,
       );
       if (classEdit !== undefined) edits.push(classEdit);
+    }
+
+    for (const [elementId, imagePlan] of imagePlansByElementId) {
+      const containedEdits = edits.filter(
+        edit => edit.range.start >= imagePlan.element.source.start && edit.range.end <= imagePlan.element.source.end,
+      );
+      const externalEdits = edits.filter(edit => !containedEdits.includes(edit));
+      edits.length = 0;
+      edits.push(...externalEdits, {
+        range: imagePlan.element.source,
+        text: new PictureRenderer().render(source, imagePlan, containedEdits),
+        inputId: `${elementId}:responsive-image`,
+      });
     }
 
     return { edits, results };

--- a/src/planner/conversion-planner.ts
+++ b/src/planner/conversion-planner.ts
@@ -163,7 +163,12 @@ export class ConversionPlanner {
         .filter((plan): plan is PlannedConversion => plan !== undefined);
       const unresolvedOrdinary = ordinaryPlans.some(plan => plan.status !== 'converted');
 
-      if (imageResult.status === 'converted' && !unresolvedOrdinary) {
+      if (imageResult.status === 'unresolved') {
+        for (const plan of imageResult.plans) plansByInputId.set(plan.input.id, plan);
+        continue;
+      }
+
+      if (!unresolvedOrdinary) {
         imagePlansByElementId.set(element.id, imageResult.plan);
         for (const input of imageInputs) {
           plansByInputId.set(input.id, { status: 'converted', input, classNames: [] });
@@ -180,11 +185,7 @@ export class ConversionPlanner {
       for (const plan of ordinaryPlans) {
         if (plan.status === 'converted') plansByInputId.set(plan.input.id, { ...familyFailure, input: plan.input });
       }
-      if (imageResult.status === 'converted') {
-        for (const input of imageInputs) plansByInputId.set(input.id, { ...familyFailure, input });
-      } else {
-        for (const plan of imageResult.plans) plansByInputId.set(plan.input.id, plan);
-      }
+      for (const input of imageInputs) plansByInputId.set(input.id, { ...familyFailure, input });
     }
 
     for (const input of inputs) {

--- a/src/report/migration-report.ts
+++ b/src/report/migration-report.ts
@@ -44,6 +44,6 @@ export type ReportResult =
   | {
       readonly status: 'parse-error';
       readonly offset: number;
-      readonly code: 'template-parse-error';
+      readonly code: 'template-parse-error' | 'generated-template-parse-error';
       readonly reason: string;
     };

--- a/src/template/angular-template.parser.spec.ts
+++ b/src/template/angular-template.parser.spec.ts
@@ -12,7 +12,10 @@ describe('AngularTemplateParser', () => {
         {
           id: '0',
           name: 'div',
+          source: { start: 0, end: 43 },
           startTag: { start: 0, end: 37 },
+          endTag: { start: 37, end: 43 },
+          structural: false,
           attributes: [
             {
               name: 'fxLayout',
@@ -38,6 +41,70 @@ describe('AngularTemplateParser', () => {
           ],
         },
       ],
+    });
+  });
+
+  test.each([
+    ['void image', '<img src="a.png">', { start: 0, end: 17 }],
+    ['self-closing image', '<img src="a.png" />', { start: 0, end: 19 }],
+    ['multiline image', '<img\n  src="a.png"\n>', { start: 0, end: 20 }],
+  ])('exposes the exact complete range for a %s', (_label, source, expectedRange) => {
+    const result = new AngularTemplateParser().parse(source, 'image.component.html');
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        {
+          name: 'img',
+          source: expectedRange,
+          startTag: expectedRange,
+          structural: false,
+        },
+      ],
+    });
+  });
+
+  test('exposes a distinct closing-tag range when Angular accepts explicit closing syntax', () => {
+    const source = '<app-image src="a.png"></app-image>';
+
+    const result = new AngularTemplateParser().parse(source, 'image.component.html');
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        {
+          name: 'app-image',
+          source: { start: 0, end: 35 },
+          startTag: { start: 0, end: 23 },
+          endTag: { start: 23, end: 35 },
+          structural: false,
+        },
+      ],
+    });
+  });
+
+  test('retains picture ancestry without treating native control flow as structural', () => {
+    const source = '@if (shown) {<picture><img src="a.png"></picture>}';
+
+    const result = new AngularTemplateParser().parse(source, 'image.component.html');
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [
+        { id: '13', name: 'picture', structural: false },
+        { id: '22', name: 'img', parentId: '13', source: { start: 22, end: 39 }, structural: false },
+      ],
+    });
+  });
+
+  test.each(['ngIf', 'feature'])('marks an image with *%s syntax as structural', directive => {
+    const source = `<img *${directive}="shown" src="a.png">`;
+
+    const result = new AngularTemplateParser().parse(source, 'image.component.html');
+
+    expect(result).toMatchObject({
+      status: 'parsed',
+      elements: [{ name: 'img', source: { start: 0, end: source.length }, structural: true }],
     });
   });
 

--- a/src/template/angular-template.parser.ts
+++ b/src/template/angular-template.parser.ts
@@ -4,6 +4,7 @@ import {
   TmplAstBoundAttribute,
   TmplAstElement,
   TmplAstRecursiveVisitor,
+  TmplAstTemplate,
   TmplAstTextAttribute,
   tmplAstVisitAll,
 } from '@angular/compiler';
@@ -67,6 +68,7 @@ function boundTarget(type: BindingType): NonNullable<TemplateAttribute['bindingT
 class ElementCollector extends TmplAstRecursiveVisitor {
   readonly elements: TemplateElement[] = [];
   private readonly parents: string[] = [];
+  private readonly structuralElements = new Set<number>();
 
   constructor(private readonly source: string) {
     super();
@@ -82,7 +84,12 @@ class ElementCollector extends TmplAstRecursiveVisitor {
     this.elements.push({
       id,
       name: element.name,
+      source: range(element.sourceSpan.start.offset, element.sourceSpan.end.offset),
       startTag: range(element.startSourceSpan.start.offset, element.startSourceSpan.end.offset),
+      ...(element.endSourceSpan && element.endSourceSpan.start.offset !== element.startSourceSpan.start.offset
+        ? { endTag: range(element.endSourceSpan.start.offset, element.endSourceSpan.end.offset) }
+        : {}),
+      structural: this.structuralElements.has(element.sourceSpan.start.offset),
       attributes,
       ...(this.parents.at(-1) ? { parentId: this.parents.at(-1) } : {}),
     });
@@ -90,6 +97,27 @@ class ElementCollector extends TmplAstRecursiveVisitor {
     this.parents.push(id);
     super.visitElement(element);
     this.parents.pop();
+  }
+
+  override visitTemplate(template: TmplAstTemplate): void {
+    const structuralElement =
+      template.tagName === null
+        ? undefined
+        : template.children.find(
+            child =>
+              child instanceof TmplAstElement &&
+              child.name === template.tagName &&
+              child.sourceSpan.start.offset === template.sourceSpan.start.offset &&
+              child.sourceSpan.end.offset === template.sourceSpan.end.offset,
+          );
+
+    if (structuralElement) {
+      this.structuralElements.add(structuralElement.sourceSpan.start.offset);
+    }
+    super.visitTemplate(template);
+    if (structuralElement) {
+      this.structuralElements.delete(structuralElement.sourceSpan.start.offset);
+    }
   }
 }
 

--- a/src/template/template.model.ts
+++ b/src/template/template.model.ts
@@ -18,7 +18,10 @@ export interface TemplateAttribute {
 export interface TemplateElement {
   readonly id: string;
   readonly name: string;
+  readonly source: SourceRange;
   readonly startTag: SourceRange;
+  readonly endTag?: SourceRange;
+  readonly structural: boolean;
   readonly attributes: readonly TemplateAttribute[];
   readonly parentId?: string;
 }

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -93,4 +93,18 @@ describe('packaged CLI execution', () => {
     expect(result.stdout).toContain('[dynamic-binding]');
     expect(await readFile(input, 'utf8')).toBe('<div [fxFlex]="basis"></div>');
   });
+
+  test('documents and executes the packaged responsive image opt-in', async () => {
+    const help = await execute(['--help']);
+    expect(help.stdout).toContain('--responsive-images');
+
+    const input = join(temporaryDirectory, 'input.html');
+    const output = join(temporaryDirectory, 'output.html');
+    await writeFile(input, '<img src="base.png" src.sm="small.png">', 'utf8');
+
+    const result = await execute([input, '--output', output, '--responsive-images']);
+
+    expect(result).toMatchObject({ status: 0, stderr: '' });
+    expect(await readFile(output, 'utf8')).toContain('<picture>');
+  });
 });

--- a/test/compatibility/angular-template-engine.test.ts
+++ b/test/compatibility/angular-template-engine.test.ts
@@ -152,7 +152,7 @@ describe('Angular template engine compatibility', () => {
     const expected = await fixture('responsive-image', 'expected');
 
     const disabled = migrate(input, 'responsive-image.html');
-    expect(disabled.output).toBe(input);
+    expect(disabled.output).toBe(input.replace('<img class="hero" fxHide', '<img class="hero hidden"'));
     expect(disabled.results.filter(result => result.status === 'unsupported')).toHaveLength(24);
 
     const first = migrate(input, 'responsive-image.html', { orientationBreakpoints: false }, true);

--- a/test/compatibility/angular-template-engine.test.ts
+++ b/test/compatibility/angular-template-engine.test.ts
@@ -29,11 +29,14 @@ function migrate(
   source: string,
   fileName = 'fixture.html',
   config: BreakpointMigrationConfig = { orientationBreakpoints: false },
+  responsiveImages = false,
 ) {
   const parsed = new AngularTemplateParser().parse(source, fileName);
   if (parsed.status !== 'parsed') throw new Error(parsed.diagnostics.map(item => item.message).join('\n'));
   const inputs = new TemplateAnalyzer().analyze(fileName, parsed.elements);
-  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter(config));
+  const plan = new ConversionPlanner().plan(source, parsed.elements, inputs, new TailwindAdapter(config), {
+    responsiveImages,
+  });
   const edited = new SourceEditor().apply(source, plan.edits);
   if (edited.status !== 'applied') throw new Error(edited.diagnostics.map(item => item.message).join('\n'));
   return { output: edited.output, results: plan.results, editCount: plan.edits.length };
@@ -143,6 +146,36 @@ describe('Angular template engine compatibility', () => {
       'context-unverified',
     ],
   };
+
+  test('matches the responsive image fixture with stable totals and idempotence', async () => {
+    const input = await fixture('responsive-image', 'input');
+    const expected = await fixture('responsive-image', 'expected');
+
+    const disabled = migrate(input, 'responsive-image.html');
+    expect(disabled.output).toBe(input);
+    expect(disabled.results.filter(result => result.status === 'unsupported')).toHaveLength(24);
+
+    const first = migrate(input, 'responsive-image.html', { orientationBreakpoints: false }, true);
+    expect(first.output).toBe(expected);
+    expect(resultCounts(first.results)).toEqual({
+      converted: 17,
+      review: 4,
+      unsupported: 3,
+      invalid: 1,
+      parseError: 0,
+    });
+
+    const second = migrate(first.output, 'responsive-image.html', { orientationBreakpoints: false }, true);
+    expect(second.output).toBe(expected);
+    expect(second.editCount).toBe(0);
+    expect(resultCounts(second.results)).toEqual({
+      converted: 0,
+      review: 4,
+      unsupported: 3,
+      invalid: 1,
+      parseError: 0,
+    });
+  });
 
   test('matches the Grid fixture byte-for-byte with stable public totals and idempotence', async () => {
     const input = await fixture('grid', 'input');

--- a/test/fixtures/compatibility/responsive-image.expected.html
+++ b/test/fixtures/compatibility/responsive-image.expected.html
@@ -1,0 +1,12 @@
+<picture><source media="screen and (min-width: 0px) and (max-width: 599.98px)" srcset="xs.png"><source media="screen and (max-width: 599.98px)" srcset="lt-sm.png"><source media="screen and (min-width: 600px) and (max-width: 959.98px)" srcset="sm.png"><source media="screen and (max-width: 959.98px)" srcset="lt-md.png"><source media="screen and (min-width: 960px) and (max-width: 1279.98px)" srcset="md.png"><source media="screen and (max-width: 1279.98px)" srcset="lt-lg.png"><source media="screen and (min-width: 1280px) and (max-width: 1919.98px)" srcset="lg.png"><source media="screen and (max-width: 1919.98px)" srcset="lt-xl.png"><source media="screen and (min-width: 1920px) and (max-width: 4999.98px)" srcset="xl.png"><source media="screen and (min-width: 1920px)" srcset="gt-lg.png"><source media="screen and (min-width: 1280px)" srcset="gt-md.png"><source media="screen and (min-width: 960px)" srcset="gt-sm.png"><source media="screen and (min-width: 600px)" srcset="gt-xs.png"><img alt="all" src="base.png" loading="lazy"></picture>
+<picture><source media="screen and (min-width: 960px) and (max-width: 1279.98px)" srcset="bound-fallback.png"><img [src]="fallback"></picture>
+<picture><source media="screen and (max-width: 599.98px)" srcset="absent-fallback.png"><img></picture>
+<picture><source media="screen and (min-width: 600px) and (max-width: 959.98px)" srcset="hidden-small.png"><img class="hero hidden" src="hidden-base.png"></picture>
+<img [src.md]="dynamicImage" src="base.png">
+<img src.handset="handset.png">
+<img src.print="print.png">
+<img src.cinema="cinema.png">
+<img src.md="medium.png 2x">
+<img *ngIf="shown" src.md="structural.png">
+<picture><img src.md="existing.png"></picture>
+<picture><span><img src.md="nested.png"></span></picture>

--- a/test/fixtures/compatibility/responsive-image.input.html
+++ b/test/fixtures/compatibility/responsive-image.input.html
@@ -1,0 +1,12 @@
+<img alt="all" src="base.png" src.gt-xs="gt-xs.png" src.gt-sm="gt-sm.png" src.gt-md="gt-md.png" src.gt-lg="gt-lg.png" src.lt-xl="lt-xl.png" src.lt-lg="lt-lg.png" src.lt-md="lt-md.png" src.lt-sm="lt-sm.png" src.xl="xl.png" src.lg="lg.png" src.md="md.png" src.sm="sm.png" src.xs="xs.png" loading="lazy">
+<img [src]="fallback" src.md="bound-fallback.png">
+<img src.lt-sm="absent-fallback.png">
+<img class="hero" fxHide src.sm="hidden-small.png" src="hidden-base.png">
+<img [src.md]="dynamicImage" src="base.png">
+<img src.handset="handset.png">
+<img src.print="print.png">
+<img src.cinema="cinema.png">
+<img src.md="medium.png 2x">
+<img *ngIf="shown" src.md="structural.png">
+<picture><img src.md="existing.png"></picture>
+<picture><span><img src.md="nested.png"></span></picture>

--- a/test/image/responsive-image-selection.test.ts
+++ b/test/image/responsive-image-selection.test.ts
@@ -1,0 +1,39 @@
+import { BreakpointCatalog, type MediaDefinition } from '../../src/breakpoint/breakpoint-catalog';
+
+function matches(media: MediaDefinition, width: number): boolean {
+  return (
+    media.type === 'screen' &&
+    media.clauses.some(
+      clause => (clause.min === undefined || width >= clause.min) && (clause.max === undefined || width <= clause.max),
+    )
+  );
+}
+
+function selected(aliases: readonly string[], width: number): string | undefined {
+  const catalog = new BreakpointCatalog();
+  return aliases
+    .map(alias => catalog.classify(alias))
+    .filter(result => result.kind === 'verified')
+    .map(result => result.definition)
+    .sort((left, right) => right.priority - left.priority)
+    .find(definition => matches(definition.media, width))?.alias;
+}
+
+describe('native responsive image selection order', () => {
+  test.each([
+    [320, 'xs'],
+    [600, undefined],
+    [1000, 'md'],
+    [1280, undefined],
+  ] as const)('selects bounded xs/md equivalently at %dpx', (width, expected) => {
+    expect(selected(['xs', 'md'], width)).toBe(expected);
+  });
+
+  test.each([
+    [320, 'xs'],
+    [700, 'lt-md'],
+    [1000, 'gt-xs'],
+  ] as const)('reproduces overlap priority at %dpx', (width, expected) => {
+    expect(selected(['gt-xs', 'lt-md', 'xs'], width)).toBe(expected);
+  });
+});

--- a/test/image/responsive-image-selection.test.ts
+++ b/test/image/responsive-image-selection.test.ts
@@ -1,39 +1,62 @@
-import { BreakpointCatalog, type MediaDefinition } from '../../src/breakpoint/breakpoint-catalog';
+import { TemplateAnalyzer } from '../../src/analyzer/template.analyzer';
+import { PictureRenderer } from '../../src/image/picture.renderer';
+import { ResponsiveImagePlanner } from '../../src/image/responsive-image.planner';
+import { AngularTemplateParser } from '../../src/template/angular-template.parser';
 
-function matches(media: MediaDefinition, width: number): boolean {
-  return (
-    media.type === 'screen' &&
-    media.clauses.some(
-      clause => (clause.min === undefined || width >= clause.min) && (clause.max === undefined || width <= clause.max),
-    )
-  );
+interface RenderedSource {
+  readonly media: string;
+  readonly url: string;
 }
 
-function selected(aliases: readonly string[], width: number): string | undefined {
-  const catalog = new BreakpointCatalog();
-  return aliases
-    .map(alias => catalog.classify(alias))
-    .filter(result => result.kind === 'verified')
-    .map(result => result.definition)
-    .sort((left, right) => right.priority - left.priority)
-    .find(definition => matches(definition.media, width))?.alias;
+function renderedSources(source: string): readonly RenderedSource[] {
+  const parser = new AngularTemplateParser();
+  const parsed = parser.parse(source, 'selection.html');
+  if (parsed.status !== 'parsed') throw new Error('selection input did not parse');
+  const image = parsed.elements.find(element => element.name === 'img');
+  if (!image) throw new Error('selection input has no image');
+  const inputs = new TemplateAnalyzer().analyze('selection.html', [image]);
+  const planned = new ResponsiveImagePlanner().plan(inputs, { element: image, ancestors: [] }, true);
+  if (planned.status !== 'converted') throw new Error('selection input did not plan');
+
+  const output = new PictureRenderer().render(source, planned.plan);
+  const rendered = parser.parse(output, 'rendered-selection.html');
+  if (rendered.status !== 'parsed') throw new Error('rendered selection did not parse');
+  return rendered.elements
+    .filter(element => element.name === 'source')
+    .map(element => ({
+      media: element.attributes.find(attribute => attribute.name === 'media')?.value ?? '',
+      url: element.attributes.find(attribute => attribute.name === 'srcset')?.value ?? '',
+    }));
+}
+
+function matches(media: string, width: number): boolean {
+  if (!media.startsWith('screen')) return false;
+  const minimum = media.match(/\(min-width: ([\d.]+)px\)/u)?.[1];
+  const maximum = media.match(/\(max-width: ([\d.]+)px\)/u)?.[1];
+  return (minimum === undefined || width >= Number(minimum)) && (maximum === undefined || width <= Number(maximum));
+}
+
+function selected(sources: readonly RenderedSource[], width: number): string | undefined {
+  return sources.find(source => matches(source.media, width))?.url;
 }
 
 describe('native responsive image selection order', () => {
   test.each([
-    [320, 'xs'],
+    [320, 'xs.png'],
     [600, undefined],
-    [1000, 'md'],
+    [1000, 'md.png'],
     [1280, undefined],
-  ] as const)('selects bounded xs/md equivalently at %dpx', (width, expected) => {
-    expect(selected(['xs', 'md'], width)).toBe(expected);
+  ] as const)('selects rendered bounded xs/md sources equivalently at %dpx', (width, expected) => {
+    expect(selected(renderedSources('<img src.md="md.png" src.xs="xs.png">'), width)).toBe(expected);
   });
 
   test.each([
-    [320, 'xs'],
-    [700, 'lt-md'],
-    [1000, 'gt-xs'],
-  ] as const)('reproduces overlap priority at %dpx', (width, expected) => {
-    expect(selected(['gt-xs', 'lt-md', 'xs'], width)).toBe(expected);
+    [320, 'xs.png'],
+    [700, 'lt-md.png'],
+    [1000, 'gt-xs.png'],
+  ] as const)('reproduces rendered overlap priority at %dpx', (width, expected) => {
+    expect(selected(renderedSources('<img src.gt-xs="gt-xs.png" src.lt-md="lt-md.png" src.xs="xs.png">'), width)).toBe(
+      expected,
+    );
   });
 });

--- a/test/package/compatibility-docs-contract.test.ts
+++ b/test/package/compatibility-docs-contract.test.ts
@@ -300,7 +300,10 @@ describe('compatibility reference contract', () => {
         ['ngStyle', 'Converts complete, sanitizer-safe declaration lists with exact CSS ownership.'],
         ['class', 'Version-dependent replacement and merge behavior is not inferred.'],
         ['style', 'Version-dependent replacement and merge behavior is not inferred.'],
-        ['imgSrc', 'Recognized and reported; no target conversion is implemented.'],
+        [
+          'imgSrc',
+          'Opt-in literal standard aliases convert to picture markup when URL, fallback, and structural context are safe.',
+        ],
       ]),
     );
 
@@ -308,6 +311,8 @@ describe('compatibility reference contract', () => {
     expect(markdown).not.toContain('are planned together as one atomic visibility family per element');
     expect(markdown).toContain('--orientation-breakpoints');
     expect(markdown).toContain('--print-with-breakpoints');
+    expect(markdown).toContain('--responsive-images');
+    expect(markdown).toContain('schema version `1`');
     expect(markdown).toContain('handset.portrait');
     expect(markdown).toContain('web.landscape');
     expect(markdown).toContain('printWithBreakpoints');

--- a/test/package/docs-contract.test.ts
+++ b/test/package/docs-contract.test.ts
@@ -35,7 +35,9 @@ function expectCurrentBetaBoundaries(readme: string): void {
   expect(readme).toContain('writes changed templates in place when neither `--dry-run` nor `--output` is supplied');
   expect(readme).toContain('a native CSS target is not available');
   expect(readme).toContain('Literal Grid directives have limited conversion support');
-  expect(readme).toContain('responsive `imgSrc` remains unchanged');
+  expect(readme).toContain('responsive `imgSrc` has an opt-in native `<picture>` migration');
+  expect(readme).toContain('--responsive-images');
+  expect(readme).toContain('former parent');
   expect(readme).toContain('Orientation and print conversion require explicit source-configuration evidence');
   expect(readme).toContain('--orientation-breakpoints');
   expect(readme).toContain('--print-with-breakpoints');
@@ -185,7 +187,7 @@ describe('maintainer documentation', () => {
   it('rejects a paraphrased false-current-capability claim that the former blacklist misses', async () => {
     const readme = await readRepositoryFile('README.md');
     const falseCurrentCapability = readme.replace(
-      'This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` remains unchanged. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review.',
+      'This beta has a Tailwind CSS v4 target only; a native CSS target is not available. Literal Grid directives have limited conversion support; responsive `imgSrc` has an opt-in native `<picture>` migration for safe literal standard aliases. Orientation and print conversion require explicit source-configuration evidence; custom breakpoint aliases remain preserved for review.',
       'This beta has native CSS and Tailwind CSS targets. Grid directives, responsive `imgSrc`, orientation, print, and custom breakpoint aliases convert directly.',
     );
 


### PR DESCRIPTION
## Summary

Add an explicit `--responsive-images` mode that migrates safe literal Angular Flex-Layout `src.<alias>` inputs to native `<picture>` markup.

- recognize all 13 standard responsive image aliases using the shared breakpoint catalog
- preserve dynamic, custom, orientation, print, unsafe, structural, and already-nested image families with diagnostics
- compose same-image class conversions into one structural edit
- reparse the complete generated Angular template before any write
- retain JSON schema v1 locations for post-codemod review
- document the `<picture>` wrapper's CSS and test-selector risk

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

`npm run verify` completed with 70 test files and 2,204 tests passing. Statement coverage is 93.7% and branch coverage is 90.14%.

## Migration example

```html
<!-- before -->
<img src="hero.png" src.lt-sm="hero-mobile.png" alt="Hero" />

<!-- after: run with --responsive-images -->
<picture><source media="screen and (max-width: 599.98px)" srcset="hero-mobile.png"><img src="hero.png" alt="Hero" /></picture>
```

## Dependencies and compatibility

No dependency changes.

Responsive image conversion is opt-in because adding `<picture>` changes the image's parent and may affect CSS or test selectors. Only literal values on the 13 archived standard viewport aliases convert automatically; all other forms remain in place for review.
