### PR TITLE
refactor: extract target-neutral flex semantics

### DIFF
--- a/docs/architecture/flex-semantic-core.md
+++ b/docs/architecture/flex-semantic-core.md
@@ -1,0 +1,142 @@
+# Target-Neutral Flex Semantic Core
+
+## Purpose
+
+This slice extracts the statically provable Flex-Layout behavior already supported by the Tailwind target into a target-neutral semantic core. It is the first implementation step toward native CSS output. The extraction must preserve every current Tailwind class, diagnostic, source edit, report result, and compatibility boundary.
+
+The slice is architectural cleanup, not a new migration capability. It removes value interpretation from the Tailwind adapter so a later native CSS renderer can consume the same verified semantics without duplicating Angular Flex-Layout rules.
+
+## Scope
+
+The semantic core covers the currently supported static behavior of:
+
+- `fxLayout`;
+- `fxLayoutAlign`;
+- `fxLayoutGap`;
+- `fxFlex` together with `fxGrow` and `fxShrink`;
+- `fxFlexAlign`;
+- `fxFlexFill` and `fxFill`;
+- `fxFlexOffset`; and
+- `fxFlexOrder`.
+
+Base values and the 13 standard viewport aliases use the same semantic parsing. Existing orientation and print configuration continues to use the shared breakpoint catalog and the current responsive-family orchestration.
+
+Grid, visibility, responsive class/style, responsive images, project CSS inspection, native stylesheet output, and multi-file transactions are outside this slice. They retain their existing implementations and contracts.
+
+## Design constraints
+
+The extraction follows these constraints:
+
+1. Semantic modules cannot import from `adapter/tailwind`, emit Tailwind class names, or contain Tailwind arbitrary-value syntax.
+2. Tailwind renderers cannot reinterpret raw directive strings. They consume successful semantic values and only decide how those values are encoded as classes.
+3. Context-sensitive behavior remains explicit. Parent layout direction and wrapping are semantic inputs to child sizing, offset, gap, and alignment planning.
+4. The shared breakpoint catalog remains the only authority for media definitions and priority. Semantic values may carry a verified `BreakpointDefinition`, but never a Tailwind media variant string.
+5. Existing public diagnostics retain their status, code, reason, and suggestion. Moving a validation rule must not rename or collapse its diagnostic.
+6. Existing conflict and ownership analysis continues to evaluate the Tailwind classes produced by the renderer. This slice does not generalize target-specific ownership.
+
+## Components
+
+### Shared value parsing
+
+Target-neutral CSS value parsing moves out of the Tailwind adapter. It parses and normalizes only syntax whose meaning is independent of the output target, including nonnegative factors and CSS lengths with directive-specific fallback units.
+
+The parser returns branded semantic values or a typed invalid result. Tailwind encoding helpers such as underscore escaping and arbitrary-class construction remain under `adapter/tailwind`.
+
+### Flex semantic planners
+
+Focused planners under `src/flex/` produce immutable domain values:
+
+- layout direction, wrapping, inline display, and border-box behavior;
+- main-axis, cross-axis, and content alignment plus stretch sizing;
+- gap length and the conditions that make margin-gap behavior unrepresentable;
+- grow, shrink, basis, effective basis, and axis-dependent min/max sizing;
+- self alignment;
+- fill dimensions and zero-margin behavior;
+- axis-dependent offset margin; and
+- integer order behavior.
+
+The planners receive decoded literal values and the minimum verified context they need. They return either a semantic value or the same structured unresolved/invalid information currently produced by Tailwind strategies.
+
+No single universal declaration bag is introduced in this slice. Typed family values preserve intent and avoid turning the semantic layer into a weak string map. A later native CSS renderer can translate those values to declarations while Tailwind renderers translate them to utilities.
+
+### Tailwind renderers
+
+The existing directive strategy modules become thin target renderers. Each calls a semantic planner, forwards any diagnostic unchanged, and maps a successful domain value to the exact current Tailwind class sequence.
+
+Renderer helpers may emit built-in utilities or arbitrary properties, but they do not parse directive grammar or decide Flex-Layout semantics. Responsive variant emission remains a later Tailwind adapter step over the rendered classes.
+
+### Compatibility bridge
+
+During extraction, existing exported strategy functions remain available so the adapter and focused tests can migrate incrementally. Internal compatibility wrappers are removed once all scoped directives consume the semantic core. No deprecated public API is created because these modules are package-internal.
+
+## Data flow
+
+For each scoped input, the resulting flow is:
+
+```text
+decoded Angular literal + verified element/parent context
+                         |
+                         v
+               Flex semantic planner
+                  /             \
+       semantic family value   existing diagnostic
+                  |
+                  v
+             Tailwind renderer
+                  |
+                  v
+      responsive variant + ownership checks
+                  |
+                  v
+             source edit plan
+```
+
+The Tailwind adapter remains responsible for grouping responsive families, closing element and parent dependencies, resolving class conflicts, and returning `PlannedConversion` objects. The semantic core does not depend on template ranges, reports, terminal output, or file writes.
+
+## Migration sequence
+
+Extraction proceeds family by family behind characterization tests:
+
+1. establish target-neutral result, CSS length, and layout models;
+2. move layout, alignment, and gap semantics;
+3. move flex-item sizing and parent-axis semantics;
+4. move align, fill, offset, and order semantics;
+5. reduce Tailwind directive modules to render-only mappings; and
+6. enforce dependency-direction and target-string boundaries with architecture tests.
+
+At each step, existing Tailwind unit and compatibility fixtures must remain byte-for-byte identical. Superseded parsers and duplicate models are deleted as soon as their consumers move.
+
+## Diagnostics and safety
+
+Semantic planners preserve the current conservative decisions:
+
+- malformed literal values remain `invalid-value`;
+- missing or dynamic parent context remains `context-unverified`;
+- negative, computed-possibly-negative, grid-mode, or wrapped gap behavior retains its current diagnostic;
+- unsupported Flex-Layout behavior remains `semantic-unsupported`; and
+- bound inputs remain handled by the existing adapter before semantic literal planning.
+
+The shared result type carries complete diagnostic text rather than requiring renderers to recreate it. A renderer must pass failures through unchanged.
+
+If extraction reveals that a current Tailwind output depends on target-specific interpretation rather than verified Flex semantics, that case remains in the Tailwind layer and is documented as an explicit exception. The extraction does not broaden conversion to make the abstraction appear complete.
+
+## Testing
+
+Verification includes:
+
+- unit tests for each semantic family without importing Tailwind modules;
+- renderer tests showing each semantic value maps to the exact existing class order;
+- base and all-standard-alias characterization through the real adapter;
+- parent row/column, reverse, wrap, and missing-context cases;
+- exact diagnostic status, code, reason, and suggestion parity;
+- architecture tests rejecting `adapter/tailwind` imports and Tailwind class/variant syntax inside `src/flex`;
+- byte-for-byte compatibility fixtures and idempotence; and
+- the complete repository verification command, including coverage, build, and package checks.
+
+Because this slice intentionally has no user-visible behavior change, it does not add a Changeset or alter the compatibility inventory.
+
+## Completion criteria
+
+The slice is complete when every scoped directive delegates value interpretation to `src/flex`, Tailwind-specific code only renders successful semantic values, superseded semantic parsing is removed from the adapter, architectural dependency tests pass, and all existing public outputs remain unchanged.
+
+Native CSS rendering starts only after this parity-preserving extraction is merged.

--- a/src/adapter/tailwind/directives/flex-align.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-align.strategy.spec.ts
@@ -1,4 +1,4 @@
-import { planFlexAlign } from './flex-align.strategy';
+import { planFlexAlign, renderFlexAlign } from './flex-align.strategy';
 
 describe('planFlexAlign', () => {
   test.each([
@@ -15,5 +15,12 @@ describe('planFlexAlign', () => {
 
   test.each(['left', 'space-between', 'start end'])('rejects %j', value => {
     expect(planFlexAlign(value)).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});
+
+test('renders a planned self alignment without interpreting directive text', () => {
+  expect(renderFlexAlign({ alignment: 'baseline' })).toEqual({
+    status: 'converted',
+    classNames: ['self-baseline'],
   });
 });

--- a/src/adapter/tailwind/directives/flex-align.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-align.strategy.ts
@@ -1,9 +1,24 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import {
+  planFlexAlignSemantics,
+  type FlexAlignSemantics,
+  type FlexSelfAlignment,
+} from '../../../flex/flex-align.semantic';
 
-const values = new Set(['auto', 'start', 'end', 'center', 'baseline', 'stretch']);
+const selfAlignment: Readonly<Record<FlexSelfAlignment, string>> = {
+  auto: 'self-auto',
+  start: 'self-start',
+  end: 'self-end',
+  center: 'self-center',
+  baseline: 'self-baseline',
+  stretch: 'self-stretch',
+};
+
+export function renderFlexAlign(value: FlexAlignSemantics): TailwindStrategyResult {
+  return { status: 'converted', classNames: [selfAlignment[value.alignment]] };
+}
 
 export function planFlexAlign(value: string): TailwindStrategyResult {
-  const normalized = value.trim() || 'stretch';
-  if (!values.has(normalized)) return { status: 'invalid', code: 'invalid-value' };
-  return { status: 'converted', classNames: [`self-${normalized}`] };
+  const planned = planFlexAlignSemantics(value);
+  return planned.status === 'planned' ? renderFlexAlign(planned.value) : planned;
 }

--- a/src/adapter/tailwind/directives/flex-fill.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-fill.strategy.spec.ts
@@ -1,7 +1,14 @@
-import { planFlexFill } from './flex-fill.strategy';
+import { planFlexFill, renderFlexFill } from './flex-fill.strategy';
 
 test('emits every style shared by fxFill and fxFlexFill', () => {
   expect(planFlexFill()).toEqual({
+    status: 'converted',
+    classNames: ['m-0', 'w-full', 'h-full', 'min-w-full', 'min-h-full'],
+  });
+});
+
+test('renders the target encoding for planned fill dimensions', () => {
+  expect(renderFlexFill({ margin: '0', width: '100%', height: '100%', minWidth: '100%', minHeight: '100%' })).toEqual({
     status: 'converted',
     classNames: ['m-0', 'w-full', 'h-full', 'min-w-full', 'min-h-full'],
   });

--- a/src/adapter/tailwind/directives/flex-fill.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-fill.strategy.ts
@@ -1,8 +1,14 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import { planFlexFillSemantics, type FlexFillSemantics } from '../../../flex/flex-fill.semantic';
 
-export function planFlexFill(): TailwindStrategyResult {
+export function renderFlexFill(_value: FlexFillSemantics): TailwindStrategyResult {
   return {
     status: 'converted',
     classNames: ['m-0', 'w-full', 'h-full', 'min-w-full', 'min-h-full'],
   };
+}
+
+export function planFlexFill(): TailwindStrategyResult {
+  const planned = planFlexFillSemantics();
+  return planned.status === 'planned' ? renderFlexFill(planned.value) : planned;
 }

--- a/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
@@ -1,4 +1,5 @@
-import { planFlexItem } from './flex-item.strategy';
+import type { CssLength } from '../../../flex/css-length';
+import { planFlexItem, renderFlexItem } from './flex-item.strategy';
 
 describe('planFlexItem', () => {
   test.each([
@@ -44,5 +45,40 @@ describe('planFlexItem', () => {
     [{ basis: '25', layout: undefined }, 'context-unverified'],
   ] as const)('preserves or rejects invalid flex input %o', (input, code) => {
     expect(planFlexItem(input)).toMatchObject({ code });
+  });
+});
+
+describe('renderFlexItem', () => {
+  test('renders shorthand sizing and semantic axis constraints in the existing order', () => {
+    expect(
+      renderFlexItem({
+        grow: '1',
+        shrink: '1',
+        basis: '10rem',
+        axis: 'height',
+        min: '10rem' as CssLength,
+        max: '10rem' as CssLength,
+        splitProperties: false,
+      }),
+    ).toEqual(['[flex:1_1_10rem]', '[min-height:10rem]', '[max-height:10rem]', 'box-border']);
+  });
+
+  test('renders calc sizing as separate arbitrary properties without interpreting it', () => {
+    expect(
+      renderFlexItem({
+        grow: '3',
+        shrink: '2',
+        basis: 'calc(100% - 2rem)',
+        axis: 'width',
+        min: 'calc(100% - 2rem)' as CssLength,
+        splitProperties: true,
+      }),
+    ).toEqual([
+      '[flex-grow:3]',
+      '[flex-shrink:2]',
+      '[flex-basis:calc(100%_-_2rem)]',
+      '[min-width:calc(100%_-_2rem)]',
+      'box-border',
+    ]);
   });
 });

--- a/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
@@ -54,24 +54,22 @@ describe('renderFlexItem', () => {
       renderFlexItem({
         grow: '1',
         shrink: '1',
-        basis: '10rem',
+        basis: { kind: 'literal', value: '10rem' as CssLength },
         axis: 'height',
         min: '10rem' as CssLength,
         max: '10rem' as CssLength,
-        splitProperties: false,
       }),
     ).toEqual(['[flex:1_1_10rem]', '[min-height:10rem]', '[max-height:10rem]', 'box-border']);
   });
 
-  test('renders calc sizing as separate arbitrary properties without interpreting it', () => {
+  test('renders a computed basis as separate arbitrary properties', () => {
     expect(
       renderFlexItem({
         grow: '3',
         shrink: '2',
-        basis: 'calc(100% - 2rem)',
+        basis: { kind: 'computed', value: 'calc(100% - 2rem)' as CssLength },
         axis: 'width',
         min: 'calc(100% - 2rem)' as CssLength,
-        splitProperties: true,
       }),
     ).toEqual([
       '[flex-grow:3]',

--- a/src/adapter/tailwind/directives/flex-item.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.ts
@@ -1,91 +1,23 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
-import { parseLayout } from '../../../flex/layout.semantic';
-import { parseCssLength } from '../tailwind-value.parser';
+import { planFlexItemSemantics, type FlexItemInput, type FlexItemSemantics } from '../../../flex/flex-item.semantic';
 
-export interface FlexItemInput {
-  readonly basis: string;
-  readonly grow?: string;
-  readonly shrink?: string;
-  readonly layout: string | undefined;
-}
+export type { FlexItemInput } from '../../../flex/flex-item.semantic';
 
-const FACTOR = /^\d+(?:\.\d+)?$/;
-function property(name: string, value: string): string {
-  return `[${name}:${value.replaceAll(/\s+/g, '_')}]`;
+const property = (name: string, value: string) => `[${name}:${value.replaceAll(/\s+/g, '_')}]`;
+
+export function renderFlexItem(value: FlexItemSemantics): readonly string[] {
+  const flexClasses = value.splitProperties
+    ? [property('flex-grow', value.grow), property('flex-shrink', value.shrink), property('flex-basis', value.basis)]
+    : [property('flex', `${value.grow} ${value.shrink} ${value.basis}`)];
+  return [
+    ...flexClasses,
+    ...(value.min ? [property(`min-${value.axis}`, value.min)] : []),
+    ...(value.max ? [property(`max-${value.axis}`, value.max)] : []),
+    'box-border',
+  ];
 }
 
 export function planFlexItem(input: FlexItemInput): TailwindStrategyResult {
-  if (input.layout === undefined) {
-    return {
-      status: 'review',
-      code: 'context-unverified',
-      reason: 'Flex sizing depends on a dynamic parent direction or wrapping mode.',
-      suggestion: 'Make the parent layout static or migrate this flex item manually.',
-    };
-  }
-  const layout = parseLayout(input.layout);
-  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
-
-  let grow = input.grow?.trim() || '1';
-  let shrink = input.shrink?.trim() || '1';
-  let basis = input.basis.trim();
-  const shorthand = basis.startsWith('calc(') ? undefined : basis.match(/^(\S+)\s+(\S+)\s+(.+)$/);
-  if (shorthand) {
-    grow = shorthand[1] ?? grow;
-    shrink = shorthand[2] ?? shrink;
-    basis = shorthand[3] ?? basis;
-  } else if (basis.split(/\s+/).length > 1 && !basis.startsWith('calc(')) {
-    return { status: 'invalid', code: 'invalid-value' };
-  }
-  if (!FACTOR.test(grow) || !FACTOR.test(shrink)) return { status: 'invalid', code: 'invalid-value' };
-
-  const direction = layout.value.direction.startsWith('column') ? 'height' : 'width';
-  let isValue = false;
-  let usingCalc = false;
-
-  if (!basis) {
-    basis = direction === 'width' ? '0%' : '0.000000001px';
-  } else if (basis === 'initial' || basis === 'nogrow') {
-    grow = '0';
-    basis = 'auto';
-  } else if (basis === 'grow') {
-    basis = '100%';
-  } else if (basis === 'noshrink') {
-    shrink = '0';
-    basis = 'auto';
-  } else if (basis === 'none') {
-    grow = '0';
-    shrink = '0';
-    basis = 'auto';
-  } else if (basis !== 'auto') {
-    const parsed = parseCssLength(basis, { fallbackUnit: '%' });
-    if (!parsed.ok) return { status: 'invalid', code: 'invalid-value' };
-    basis = parsed.value;
-    usingCalc = basis.startsWith('calc(');
-    isValue = usingCalc || !basis.endsWith('%');
-    if (basis === '0px') basis = '0%';
-  }
-
-  const fixed = grow === '0' && shrink === '0';
-  const min =
-    !['0%', '0px', '0.000000001px', 'auto'].includes(basis) && (fixed || (isValue && grow !== '0')) ? basis : undefined;
-  const max =
-    !['0%', '0px', '0.000000001px', 'auto'].includes(basis) && (fixed || (!usingCalc && shrink !== '0'))
-      ? basis
-      : undefined;
-
-  const effectiveBasis =
-    min || max ? (layout.value.wrap === 'wrap' ? (max ?? min ?? basis) : isValue ? basis : '100%') : basis;
-  const flexClasses = usingCalc
-    ? [property('flex-grow', grow), property('flex-shrink', shrink), property('flex-basis', effectiveBasis)]
-    : [property('flex', `${grow} ${shrink} ${effectiveBasis}`)];
-  return {
-    status: 'converted',
-    classNames: [
-      ...flexClasses,
-      ...(min ? [property(`min-${direction}`, min)] : []),
-      ...(max ? [property(`max-${direction}`, max)] : []),
-      'box-border',
-    ],
-  };
+  const planned = planFlexItemSemantics(input);
+  return planned.status === 'planned' ? { status: 'converted', classNames: renderFlexItem(planned.value) } : planned;
 }

--- a/src/adapter/tailwind/directives/flex-item.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.ts
@@ -1,6 +1,6 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import { parseLayout } from '../../../flex/layout.semantic';
 import { parseCssLength } from '../tailwind-value.parser';
-import { parseLayout } from './layout.strategy';
 
 export interface FlexItemInput {
   readonly basis: string;

--- a/src/adapter/tailwind/directives/flex-item.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.ts
@@ -1,8 +1,6 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
 import { planFlexItemSemantics, type FlexItemInput, type FlexItemSemantics } from '../../../flex/flex-item.semantic';
 
-export type { FlexItemInput } from '../../../flex/flex-item.semantic';
-
 const property = (name: string, value: string) => `[${name}:${value.replaceAll(/\s+/g, '_')}]`;
 
 export function renderFlexItem(value: FlexItemSemantics): readonly string[] {

--- a/src/adapter/tailwind/directives/flex-item.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.ts
@@ -4,9 +4,14 @@ import { planFlexItemSemantics, type FlexItemInput, type FlexItemSemantics } fro
 const property = (name: string, value: string) => `[${name}:${value.replaceAll(/\s+/g, '_')}]`;
 
 export function renderFlexItem(value: FlexItemSemantics): readonly string[] {
-  const flexClasses = value.splitProperties
-    ? [property('flex-grow', value.grow), property('flex-shrink', value.shrink), property('flex-basis', value.basis)]
-    : [property('flex', `${value.grow} ${value.shrink} ${value.basis}`)];
+  const flexClasses =
+    value.basis.kind === 'computed'
+      ? [
+          property('flex-grow', value.grow),
+          property('flex-shrink', value.shrink),
+          property('flex-basis', value.basis.value),
+        ]
+      : [property('flex', `${value.grow} ${value.shrink} ${value.basis.value}`)];
   return [
     ...flexClasses,
     ...(value.min ? [property(`min-${value.axis}`, value.min)] : []),

--- a/src/adapter/tailwind/directives/flex-offset.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-offset.strategy.spec.ts
@@ -1,4 +1,5 @@
-import { planFlexOffset } from './flex-offset.strategy';
+import type { CssLength } from '../../../flex/css-length';
+import { planFlexOffset, renderFlexOffset } from './flex-offset.strategy';
 
 describe('planFlexOffset', () => {
   test.each([
@@ -17,5 +18,12 @@ describe('planFlexOffset', () => {
 
   test.each(['wide', '1;display:none'])('rejects %j', value => {
     expect(planFlexOffset(value, 'row')).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});
+
+test('renders a planned block-start offset with arbitrary-value escaping', () => {
+  expect(renderFlexOffset({ axis: 'block-start', length: 'calc(1rem + 2px)' as CssLength })).toEqual({
+    status: 'converted',
+    classNames: ['mt-[calc(1rem_+_2px)]'],
   });
 });

--- a/src/adapter/tailwind/directives/flex-offset.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-offset.strategy.ts
@@ -1,6 +1,6 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import { parseLayout } from '../../../flex/layout.semantic';
 import { arbitraryValue, parseCssLength } from '../tailwind-value.parser';
-import { parseLayout } from './layout.strategy';
 
 export function planFlexOffset(value: string, layoutValue: string | undefined): TailwindStrategyResult {
   const offset = parseCssLength(value.trim() || '0', { fallbackUnit: '%' });

--- a/src/adapter/tailwind/directives/flex-offset.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-offset.strategy.ts
@@ -1,20 +1,17 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
-import { parseLayout } from '../../../flex/layout.semantic';
-import { arbitraryValue, parseCssLength } from '../tailwind-value.parser';
+import { planFlexOffsetSemantics, type FlexOffsetSemantics } from '../../../flex/flex-offset.semantic';
+import { arbitraryValue } from '../tailwind-value.parser';
+
+const marginPrefix: Readonly<Record<FlexOffsetSemantics['axis'], string>> = {
+  'inline-start': 'ms',
+  'block-start': 'mt',
+};
+
+export function renderFlexOffset(value: FlexOffsetSemantics): TailwindStrategyResult {
+  return { status: 'converted', classNames: [`${marginPrefix[value.axis]}-${arbitraryValue(value.length)}`] };
+}
 
 export function planFlexOffset(value: string, layoutValue: string | undefined): TailwindStrategyResult {
-  const offset = parseCssLength(value.trim() || '0', { fallbackUnit: '%' });
-  if (!offset.ok) return { status: 'invalid', code: 'invalid-value' };
-  if (layoutValue === undefined) {
-    return {
-      status: 'review',
-      code: 'context-unverified',
-      reason: 'The offset margin axis depends on a dynamic parent layout.',
-      suggestion: 'Make the parent layout static or migrate the offset manually.',
-    };
-  }
-  const layout = parseLayout(layoutValue);
-  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
-  const prefix = layout.value.direction.startsWith('column') ? 'mt' : 'ms';
-  return { status: 'converted', classNames: [`${prefix}-${arbitraryValue(offset.value)}`] };
+  const planned = planFlexOffsetSemantics(value, layoutValue);
+  return planned.status === 'planned' ? renderFlexOffset(planned.value) : planned;
 }

--- a/src/adapter/tailwind/directives/flex-order.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-order.strategy.spec.ts
@@ -1,4 +1,4 @@
-import { planFlexOrder } from './flex-order.strategy';
+import { planFlexOrder, renderFlexOrder } from './flex-order.strategy';
 
 describe('planFlexOrder', () => {
   test.each([
@@ -12,4 +12,8 @@ describe('planFlexOrder', () => {
   ] as const)('emits deterministic order for %j', (value, classNames) => {
     expect(planFlexOrder(value)).toEqual({ status: 'converted', classNames });
   });
+});
+
+test('renders a planned nonzero order without parsing source text', () => {
+  expect(renderFlexOrder({ order: -3 })).toEqual({ status: 'converted', classNames: ['[order:-3]'] });
 });

--- a/src/adapter/tailwind/directives/flex-order.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-order.strategy.ts
@@ -1,9 +1,11 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import { planFlexOrderSemantics, type FlexOrderSemantics } from '../../../flex/flex-order.semantic';
+
+export function renderFlexOrder(value: FlexOrderSemantics): TailwindStrategyResult {
+  return { status: 'converted', classNames: value.order === undefined ? [] : [`[order:${value.order}]`] };
+}
 
 export function planFlexOrder(value: string): TailwindStrategyResult {
-  const order = Number.parseInt(value.trim(), 10);
-  return {
-    status: 'converted',
-    classNames: order ? [`[order:${order}]`] : [],
-  };
+  const planned = planFlexOrderSemantics(value);
+  return planned.status === 'planned' ? renderFlexOrder(planned.value) : planned;
 }

--- a/src/adapter/tailwind/directives/layout-align.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/layout-align.strategy.spec.ts
@@ -1,4 +1,4 @@
-import { planLayoutAlign } from './layout-align.strategy';
+import { planLayoutAlign, renderLayoutAlignment } from './layout-align.strategy';
 
 describe('planLayoutAlign', () => {
   test.each([
@@ -21,5 +21,35 @@ describe('planLayoutAlign', () => {
     ['center', 'diagonal'],
   ])('rejects invalid alignment %j or layout context %j', (value, layout) => {
     expect(planLayoutAlign(value, layout)).toEqual({ ok: false });
+  });
+});
+
+describe('renderLayoutAlignment', () => {
+  test('renders semantic alignment without reinterpreting its source values', () => {
+    expect(
+      renderLayoutAlignment({
+        main: 'space-between',
+        items: 'stretch',
+        content: 'space-around',
+        stretchMaximum: 'width',
+        layout: {
+          direction: 'column',
+          wrap: 'nowrap',
+          explicitWrap: false,
+          display: 'flex',
+          boxSizing: 'border-box',
+        },
+      }),
+    ).toEqual({
+      classNames: [
+        'justify-between',
+        'items-stretch',
+        'content-around',
+        'flex',
+        'flex-col',
+        'box-border',
+        'max-w-full',
+      ],
+    });
   });
 });

--- a/src/adapter/tailwind/directives/layout-align.strategy.ts
+++ b/src/adapter/tailwind/directives/layout-align.strategy.ts
@@ -1,5 +1,6 @@
 import type { ParsedValue } from '../tailwind-semantic.model';
-import { layoutClassNames, parseLayout, type TailwindClassPlan } from './layout.strategy';
+import { parseLayout } from '../../../flex/layout.semantic';
+import { renderLayout, type TailwindClassPlan } from './layout.strategy';
 
 const mainAxis = {
   start: 'start',
@@ -42,7 +43,7 @@ export function planLayoutAlign(value: string, layoutValue: string): ParsedValue
         `justify-${main}`,
         `items-${cross[0]}`,
         `content-${cross[1]}`,
-        ...layoutClassNames(layout.value),
+        ...renderLayout(layout.value),
         ...sizing,
       ],
     },

--- a/src/adapter/tailwind/directives/layout-align.strategy.ts
+++ b/src/adapter/tailwind/directives/layout-align.strategy.ts
@@ -1,51 +1,54 @@
 import type { ParsedValue } from '../tailwind-semantic.model';
-import { parseLayout } from '../../../flex/layout.semantic';
+import {
+  planLayoutAlignment,
+  type LayoutAlignmentSemantics,
+  type LayoutContentAlignment,
+  type LayoutItemsAlignment,
+  type LayoutMainAlignment,
+} from '../../../flex/layout-align.semantic';
 import { renderLayout, type TailwindClassPlan } from './layout.strategy';
 
-const mainAxis = {
+const mainAxis: Readonly<Record<LayoutMainAlignment, string>> = {
   start: 'start',
-  'flex-start': 'start',
   center: 'center',
   end: 'end',
-  'flex-end': 'end',
   'space-around': 'around',
   'space-between': 'between',
   'space-evenly': 'evenly',
-} as const;
+};
 
-const crossAxis = {
-  start: ['start', 'start'],
-  'flex-start': ['start', 'start'],
-  center: ['center', 'center'],
-  end: ['end', 'end'],
-  'flex-end': ['end', 'end'],
-  'space-between': ['stretch', 'between'],
-  'space-around': ['stretch', 'around'],
-  baseline: ['baseline', 'stretch'],
-  stretch: ['stretch', 'stretch'],
-} as const;
+const itemsAxis: Readonly<Record<LayoutItemsAlignment, string>> = {
+  start: 'start',
+  center: 'center',
+  end: 'end',
+  baseline: 'baseline',
+  stretch: 'stretch',
+};
+
+const contentAxis: Readonly<Record<LayoutContentAlignment, string>> = {
+  start: 'start',
+  center: 'center',
+  end: 'end',
+  stretch: 'stretch',
+  'space-around': 'around',
+  'space-between': 'between',
+};
+
+export function renderLayoutAlignment(alignment: LayoutAlignmentSemantics): TailwindClassPlan {
+  const sizing =
+    alignment.stretchMaximum === 'height' ? ['max-h-full'] : alignment.stretchMaximum === 'width' ? ['max-w-full'] : [];
+  return {
+    classNames: [
+      `justify-${mainAxis[alignment.main]}`,
+      `items-${itemsAxis[alignment.items]}`,
+      `content-${contentAxis[alignment.content]}`,
+      ...renderLayout(alignment.layout),
+      ...sizing,
+    ],
+  };
+}
 
 export function planLayoutAlign(value: string, layoutValue: string): ParsedValue<TailwindClassPlan> {
-  const values = value.split(/\s+/).filter(Boolean);
-  if (values.length > 2) return { ok: false };
-  const main = mainAxis[(values[0] ?? 'start') as keyof typeof mainAxis];
-  const crossKey = (values[1] ?? 'stretch') as keyof typeof crossAxis;
-  const cross = crossAxis[crossKey];
-  const layout = parseLayout(layoutValue);
-  if (!main || !cross || !layout.ok) return { ok: false };
-
-  const sizing =
-    crossKey !== 'stretch' ? [] : layout.value.direction.startsWith('row') ? ['max-h-full'] : ['max-w-full'];
-  return {
-    ok: true,
-    value: {
-      classNames: [
-        `justify-${main}`,
-        `items-${cross[0]}`,
-        `content-${cross[1]}`,
-        ...renderLayout(layout.value),
-        ...sizing,
-      ],
-    },
-  };
+  const planned = planLayoutAlignment(value, layoutValue);
+  return planned.status === 'planned' ? { ok: true, value: renderLayoutAlignment(planned.value) } : { ok: false };
 }

--- a/src/adapter/tailwind/directives/layout-align.strategy.ts
+++ b/src/adapter/tailwind/directives/layout-align.strategy.ts
@@ -1,4 +1,4 @@
-import type { ParsedValue } from '../tailwind-semantic.model';
+import type { ParsedValue } from '../../../flex/css-length';
 import {
   planLayoutAlignment,
   type LayoutAlignmentSemantics,

--- a/src/adapter/tailwind/directives/layout-gap.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/layout-gap.strategy.spec.ts
@@ -1,4 +1,5 @@
-import { planLayoutGap } from './layout-gap.strategy';
+import type { CssLength } from '../../../flex/css-length';
+import { planLayoutGap, renderLayoutGap } from './layout-gap.strategy';
 
 describe('planLayoutGap', () => {
   test.each([
@@ -46,5 +47,14 @@ describe('planLayoutGap', () => {
 
   test('preserves a valid gap when layout context is dynamic', () => {
     expect(planLayoutGap('4', undefined)).toMatchObject({ status: 'review', code: 'context-unverified' });
+  });
+});
+
+describe('renderLayoutGap', () => {
+  test('encodes a planned CSS length as a Tailwind arbitrary gap utility', () => {
+    expect(renderLayoutGap({ length: 'calc(1rem + 2px)' as CssLength })).toEqual({
+      status: 'converted',
+      classNames: ['gap-[calc(1rem_+_2px)]'],
+    });
   });
 });

--- a/src/adapter/tailwind/directives/layout-gap.strategy.ts
+++ b/src/adapter/tailwind/directives/layout-gap.strategy.ts
@@ -1,6 +1,6 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
+import { parseLayout } from '../../../flex/layout.semantic';
 import { arbitraryValue, parseCssLength } from '../tailwind-value.parser';
-import { parseLayout } from './layout.strategy';
 
 export function planLayoutGap(value: string, layoutValue: string | undefined): TailwindStrategyResult {
   const normalized = value.trim();

--- a/src/adapter/tailwind/directives/layout-gap.strategy.ts
+++ b/src/adapter/tailwind/directives/layout-gap.strategy.ts
@@ -1,57 +1,12 @@
 import type { TailwindStrategyResult } from '../tailwind-semantic.model';
-import { parseLayout } from '../../../flex/layout.semantic';
-import { arbitraryValue, parseCssLength } from '../tailwind-value.parser';
+import { planLayoutGapSemantics, type LayoutGapSemantics } from '../../../flex/layout-gap.semantic';
+import { arbitraryValue } from '../tailwind-value.parser';
+
+export function renderLayoutGap(gap: LayoutGapSemantics): TailwindStrategyResult {
+  return { status: 'converted', classNames: [`gap-${arbitraryValue(gap.length)}`] };
+}
 
 export function planLayoutGap(value: string, layoutValue: string | undefined): TailwindStrategyResult {
-  const normalized = value.trim();
-  if (!normalized) return { status: 'invalid', code: 'invalid-value' };
-
-  if (normalized.endsWith(' grid')) {
-    return {
-      status: 'review',
-      code: 'semantic-unsupported',
-      reason: 'The Flex-Layout grid gap mode changes child padding and compensating host margins.',
-      suggestion: 'Replace the grid gap manually after reviewing the child padding behavior.',
-    };
-  }
-
-  const gap = parseCssLength(normalized, { fallbackUnit: 'px' });
-  if (!gap.ok) return { status: 'invalid', code: 'invalid-value' };
-  if (gap.value.startsWith('-')) {
-    return {
-      status: 'review',
-      code: 'semantic-unsupported',
-      reason: 'Flex-Layout accepts a negative margin gap, but CSS gap does not accept negative values.',
-      suggestion: 'Preserve the margin-based spacing or migrate the child margins manually.',
-    };
-  }
-  if (gap.value.includes('(')) {
-    return {
-      status: 'review',
-      code: 'context-unverified',
-      reason: 'The computed gap may resolve to a negative value that CSS gap cannot represent.',
-      suggestion: 'Prove the value is nonnegative or migrate the margin-based spacing manually.',
-    };
-  }
-  if (layoutValue === undefined) {
-    return {
-      status: 'review',
-      code: 'context-unverified',
-      reason: 'The active flex direction and wrapping behavior depend on a dynamic layout.',
-      suggestion: 'Make the layout static or migrate the gap and responsive layout together.',
-    };
-  }
-
-  const layout = parseLayout(layoutValue);
-  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
-  if (layout.value.wrap !== 'nowrap') {
-    return {
-      status: 'review',
-      code: 'semantic-unsupported',
-      reason: 'Flex-Layout margins and CSS gap differ when flex items wrap across lines.',
-      suggestion: 'Verify the wrapped layout and migrate its spacing manually.',
-    };
-  }
-
-  return { status: 'converted', classNames: [`gap-${arbitraryValue(gap.value)}`] };
+  const planned = planLayoutGapSemantics(value, layoutValue);
+  return planned.status === 'planned' ? renderLayoutGap(planned.value) : planned;
 }

--- a/src/adapter/tailwind/directives/layout.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/layout.strategy.spec.ts
@@ -1,4 +1,5 @@
-import { planLayout } from './layout.strategy';
+import { parseLayout } from '../../../flex/layout.semantic';
+import { planLayout, renderLayout } from './layout.strategy';
 
 describe('planLayout', () => {
   test.each([
@@ -18,4 +19,18 @@ describe('planLayout', () => {
       expect(planLayout(value)).toEqual({ ok: false });
     },
   );
+});
+
+describe('renderLayout', () => {
+  test.each([
+    ['row', ['flex', 'flex-row', 'box-border']],
+    ['row-reverse nowrap', ['flex', 'flex-row-reverse', 'flex-nowrap', 'box-border']],
+    ['column wrap inline', ['inline-flex', 'flex-col', 'flex-wrap', 'box-border']],
+    ['column-reverse wrap-reverse', ['flex', 'flex-col-reverse', 'flex-wrap-reverse', 'box-border']],
+  ] as const)('maps %j in exact class order', (source, expected) => {
+    const parsed = parseLayout(source);
+    if (!parsed.ok) throw new Error(`Expected ${source} to parse`);
+
+    expect(renderLayout(parsed.value)).toEqual(expected);
+  });
 });

--- a/src/adapter/tailwind/directives/layout.strategy.ts
+++ b/src/adapter/tailwind/directives/layout.strategy.ts
@@ -1,5 +1,5 @@
 import { parseLayout, type LayoutSemantics } from '../../../flex/layout.semantic';
-import type { ParsedValue } from '../tailwind-semantic.model';
+import type { ParsedValue } from '../../../flex/css-length';
 
 export interface TailwindClassPlan {
   readonly classNames: readonly string[];

--- a/src/adapter/tailwind/directives/layout.strategy.ts
+++ b/src/adapter/tailwind/directives/layout.strategy.ts
@@ -1,45 +1,12 @@
+import { parseLayout, type LayoutSemantics } from '../../../flex/layout.semantic';
 import type { ParsedValue } from '../tailwind-semantic.model';
-
-export type LayoutDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
-export type LayoutWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
-
-export interface LayoutValue {
-  readonly direction: LayoutDirection;
-  readonly wrap: LayoutWrap;
-  readonly explicitWrap: boolean;
-  readonly inline: boolean;
-}
 
 export interface TailwindClassPlan {
   readonly classNames: readonly string[];
 }
 
-const directions = new Set<LayoutDirection>(['row', 'row-reverse', 'column', 'column-reverse']);
-const wraps = new Set<LayoutWrap>(['nowrap', 'wrap', 'wrap-reverse']);
-
-export function parseLayout(value: string): ParsedValue<LayoutValue> {
-  const tokens = value.split(/\s+/).filter(Boolean);
-  const direction = (tokens.shift() ?? 'row') as LayoutDirection;
-  if (!directions.has(direction)) return { ok: false };
-
-  const wrapTokens = tokens.filter(token => wraps.has(token as LayoutWrap));
-  if (wrapTokens.length > 1) return { ok: false };
-  let wrap: LayoutWrap = 'nowrap';
-  let inline = false;
-  for (const token of tokens) {
-    if (wraps.has(token as LayoutWrap)) {
-      wrap = token as LayoutWrap;
-    } else if (token === 'inline' && !inline) {
-      inline = true;
-    } else {
-      return { ok: false };
-    }
-  }
-
-  return { ok: true, value: { direction, wrap, explicitWrap: wrapTokens.length === 1, inline } };
-}
-
-export function layoutClassNames(layout: LayoutValue): readonly string[] {
+export function renderLayout(layout: LayoutSemantics): readonly string[] {
+  const display = { flex: 'flex', 'inline-flex': 'inline-flex' }[layout.display];
   const direction = {
     row: 'flex-row',
     'row-reverse': 'flex-row-reverse',
@@ -47,10 +14,11 @@ export function layoutClassNames(layout: LayoutValue): readonly string[] {
     'column-reverse': 'flex-col-reverse',
   }[layout.direction];
   const wrap = layout.explicitWrap ? [`flex-${layout.wrap}`] : [];
-  return [layout.inline ? 'inline-flex' : 'flex', direction, ...wrap, 'box-border'];
+  const boxSizing = { 'border-box': 'box-border' }[layout.boxSizing];
+  return [display, direction, ...wrap, boxSizing];
 }
 
 export function planLayout(value: string): ParsedValue<TailwindClassPlan> {
   const parsed = parseLayout(value);
-  return parsed.ok ? { ok: true, value: { classNames: layoutClassNames(parsed.value) } } : parsed;
+  return parsed.ok ? { ok: true, value: { classNames: renderLayout(parsed.value) } } : parsed;
 }

--- a/src/adapter/tailwind/tailwind-semantic.model.ts
+++ b/src/adapter/tailwind/tailwind-semantic.model.ts
@@ -1,6 +1,3 @@
-export type { CssLength, ParsedValue } from '../../flex/css-length';
-export type { SemanticDiagnostic, SemanticResult } from '../../flex/flex-semantic.model';
-
 export type TailwindStrategyResult =
   | { readonly status: 'converted'; readonly classNames: readonly string[] }
   | {

--- a/src/adapter/tailwind/tailwind-semantic.model.ts
+++ b/src/adapter/tailwind/tailwind-semantic.model.ts
@@ -1,6 +1,5 @@
-export type ParsedValue<T> = { readonly ok: true; readonly value: T } | { readonly ok: false };
-
-export type CssLength = string & { readonly __cssLength: unique symbol };
+export type { CssLength, ParsedValue } from '../../flex/css-length';
+export type { SemanticDiagnostic, SemanticResult } from '../../flex/flex-semantic.model';
 
 export type TailwindStrategyResult =
   | { readonly status: 'converted'; readonly classNames: readonly string[] }

--- a/src/adapter/tailwind/tailwind-value.parser.spec.ts
+++ b/src/adapter/tailwind/tailwind-value.parser.spec.ts
@@ -1,28 +1,4 @@
-import { parseCssLength } from '../../flex/css-length';
 import { arbitraryValue } from './tailwind-value.parser';
-
-describe('parseCssLength', () => {
-  test.each([
-    ['4', 'px', '4px'],
-    ['12.5', '%', '12.5%'],
-    ['-2', 'px', '-2px'],
-    ['0', 'px', '0px'],
-    ['10px', 'px', '10px'],
-    ['1.5rem', 'px', '1.5rem'],
-    ['25%', 'px', '25%'],
-    ['calc(100% - 2rem)', 'px', 'calc(100% - 2rem)'],
-    ['var(--layout-gap)', 'px', 'var(--layout-gap)'],
-  ] as const)('normalizes %s with a %s fallback unit', (source, fallbackUnit, expected) => {
-    expect(parseCssLength(source, { fallbackUnit })).toEqual({ ok: true, value: expected });
-  });
-
-  test.each(['', 'four', '10 px', '1;display:none', 'url(example.test)', 'calc(100%);color:red'])(
-    'rejects unsafe or unsupported value %j',
-    source => {
-      expect(parseCssLength(source, { fallbackUnit: 'px' })).toEqual({ ok: false });
-    },
-  );
-});
 
 describe('arbitraryValue', () => {
   test.each([

--- a/src/adapter/tailwind/tailwind-value.parser.spec.ts
+++ b/src/adapter/tailwind/tailwind-value.parser.spec.ts
@@ -1,4 +1,5 @@
-import { arbitraryValue, parseCssLength } from './tailwind-value.parser';
+import { parseCssLength } from '../../flex/css-length';
+import { arbitraryValue } from './tailwind-value.parser';
 
 describe('parseCssLength', () => {
   test.each([

--- a/src/adapter/tailwind/tailwind-value.parser.ts
+++ b/src/adapter/tailwind/tailwind-value.parser.ts
@@ -1,24 +1,5 @@
-import type { CssLength, ParsedValue } from './tailwind-semantic.model';
-
-const NUMBER = String.raw`-?(?:\d+(?:\.\d+)?|\.\d+)`;
-const LENGTH = new RegExp(`^${NUMBER}(?:%|px|r?em|v(?:w|h|min|max)|ch|ex|cm|mm|in|pt|pc)$`);
-const UNITLESS = new RegExp(`^${NUMBER}$`);
-const CSS_FUNCTION = /^(?:calc|clamp|min|max|var)\([a-zA-Z0-9_%+*/.,()\-\s]+\)$/;
-
-export interface CssLengthOptions {
-  readonly fallbackUnit: 'px' | '%';
-}
-
-export function parseCssLength(source: string, options: CssLengthOptions): ParsedValue<CssLength> {
-  const value = source.trim();
-  if (UNITLESS.test(value)) {
-    return { ok: true, value: `${value}${options.fallbackUnit}` as CssLength };
-  }
-  if (LENGTH.test(value) || CSS_FUNCTION.test(value)) {
-    return { ok: true, value: value as CssLength };
-  }
-  return { ok: false };
-}
+export { parseCssLength } from '../../flex/css-length';
+export type { CssLength, CssLengthOptions, ParsedValue } from '../../flex/css-length';
 
 export function arbitraryValue(value: string): string {
   return `[${value.replaceAll(/\s+/g, '_')}]`;

--- a/src/adapter/tailwind/tailwind-value.parser.ts
+++ b/src/adapter/tailwind/tailwind-value.parser.ts
@@ -1,6 +1,3 @@
-export { parseCssLength } from '../../flex/css-length';
-export type { CssLength, CssLengthOptions, ParsedValue } from '../../flex/css-length';
-
 export function arbitraryValue(value: string): string {
   return `[${value.replaceAll(/\s+/g, '_')}]`;
 }

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -581,6 +581,24 @@ describe('TailwindAdapter', () => {
     });
   });
 
+  test('preserves split calc sizing and column constraints through adapter rendering', () => {
+    expect(
+      new TailwindAdapter().plan(input({ directive: 'fxFlex', value: '3 2 calc(100% - 2rem)' }), {
+        element,
+        activeParentLayout: 'column',
+      }),
+    ).toMatchObject({
+      status: 'converted',
+      classNames: [
+        '[flex-grow:3]',
+        '[flex-shrink:2]',
+        '[flex-basis:calc(100%_-_2rem)]',
+        '[min-height:calc(100%_-_2rem)]',
+        'box-border',
+      ],
+    });
+  });
+
   test('preserves every responsive family member when one generated token conflicts', () => {
     const adapter = new TailwindAdapter();
     const inputs = [

--- a/src/adapter/tailwind/tailwind.adapter.spec.ts
+++ b/src/adapter/tailwind/tailwind.adapter.spec.ts
@@ -44,6 +44,16 @@ describe('TailwindAdapter', () => {
     });
   });
 
+  test('preserves explicit inline layout semantics through adapter rendering', () => {
+    const layout = input({ value: 'column wrap inline' });
+
+    expect(new TailwindAdapter().plan(layout, { element })).toEqual({
+      status: 'converted',
+      input: layout,
+      classNames: ['inline-flex', 'flex-col', 'flex-wrap', 'box-border'],
+    });
+  });
+
   test('converts a literal Grid directive through exact arbitrary properties', () => {
     const gridInput = input({
       directive: 'gdColumns',

--- a/src/flex/css-length.spec.ts
+++ b/src/flex/css-length.spec.ts
@@ -1,18 +1,29 @@
 import { parseCssLength } from './css-length';
 
 describe('parseCssLength', () => {
-  test('adds the directive fallback unit to a unitless number', () => {
-    expect(parseCssLength('4', { fallbackUnit: 'px' })).toEqual({ ok: true, value: '4px' });
+  test.each([
+    ['4', 'px', '4px'],
+    ['12.5', '%', '12.5%'],
+    ['-2', 'px', '-2px'],
+    ['0', 'px', '0px'],
+    ['10px', 'px', '10px'],
+    ['1.5rem', 'px', '1.5rem'],
+    ['25%', 'px', '25%'],
+    ['calc(100% - 2rem)', '%', 'calc(100% - 2rem)'],
+    ['var(--layout-gap)', 'px', 'var(--layout-gap)'],
+  ] as const)('normalizes %s with a %s fallback unit', (source, fallbackUnit, expected) => {
+    expect(parseCssLength(source, { fallbackUnit })).toEqual({ ok: true, value: expected });
   });
 
-  test('preserves an allowed CSS calculation', () => {
-    expect(parseCssLength('calc(100% - 2rem)', { fallbackUnit: '%' })).toEqual({
-      ok: true,
-      value: 'calc(100% - 2rem)',
-    });
-  });
-
-  test('rejects unsupported CSS functions', () => {
-    expect(parseCssLength('expression(alert(1))', { fallbackUnit: 'px' })).toEqual({ ok: false });
+  test.each([
+    '',
+    'four',
+    '10 px',
+    '1;display:none',
+    'url(example.test)',
+    'calc(100%);color:red',
+    'expression(alert(1))',
+  ])('rejects unsafe or unsupported value %j', source => {
+    expect(parseCssLength(source, { fallbackUnit: 'px' })).toEqual({ ok: false });
   });
 });

--- a/src/flex/css-length.spec.ts
+++ b/src/flex/css-length.spec.ts
@@ -1,0 +1,18 @@
+import { parseCssLength } from './css-length';
+
+describe('parseCssLength', () => {
+  test('adds the directive fallback unit to a unitless number', () => {
+    expect(parseCssLength('4', { fallbackUnit: 'px' })).toEqual({ ok: true, value: '4px' });
+  });
+
+  test('preserves an allowed CSS calculation', () => {
+    expect(parseCssLength('calc(100% - 2rem)', { fallbackUnit: '%' })).toEqual({
+      ok: true,
+      value: 'calc(100% - 2rem)',
+    });
+  });
+
+  test('rejects unsupported CSS functions', () => {
+    expect(parseCssLength('expression(alert(1))', { fallbackUnit: 'px' })).toEqual({ ok: false });
+  });
+});

--- a/src/flex/css-length.ts
+++ b/src/flex/css-length.ts
@@ -1,0 +1,23 @@
+export type ParsedValue<T> = { readonly ok: true; readonly value: T } | { readonly ok: false };
+
+export type CssLength = string & { readonly __cssLength: unique symbol };
+
+export interface CssLengthOptions {
+  readonly fallbackUnit: 'px' | '%';
+}
+
+const NUMBER = String.raw`-?(?:\d+(?:\.\d+)?|\.\d+)`;
+const LENGTH = new RegExp(`^${NUMBER}(?:%|px|r?em|v(?:w|h|min|max)|ch|ex|cm|mm|in|pt|pc)$`);
+const UNITLESS = new RegExp(`^${NUMBER}$`);
+const CSS_FUNCTION = /^(?:calc|clamp|min|max|var)\([a-zA-Z0-9_%+*/.,()\-\s]+\)$/;
+
+export function parseCssLength(source: string, options: CssLengthOptions): ParsedValue<CssLength> {
+  const value = source.trim();
+  if (UNITLESS.test(value)) {
+    return { ok: true, value: `${value}${options.fallbackUnit}` as CssLength };
+  }
+  if (LENGTH.test(value) || CSS_FUNCTION.test(value)) {
+    return { ok: true, value: value as CssLength };
+  }
+  return { ok: false };
+}

--- a/src/flex/flex-align.semantic.spec.ts
+++ b/src/flex/flex-align.semantic.spec.ts
@@ -1,0 +1,19 @@
+import { planFlexAlignSemantics } from './flex-align.semantic';
+
+describe('planFlexAlignSemantics', () => {
+  test.each([
+    ['', 'stretch'],
+    ['auto', 'auto'],
+    ['start', 'start'],
+    ['end', 'end'],
+    ['center', 'center'],
+    ['baseline', 'baseline'],
+    ['stretch', 'stretch'],
+  ] as const)('plans %j as self alignment %j', (source, alignment) => {
+    expect(planFlexAlignSemantics(source)).toEqual({ status: 'planned', value: { alignment } });
+  });
+
+  test.each(['sideways', 'start end', 'flex-start'] as const)('rejects unsupported self alignment %j', source => {
+    expect(planFlexAlignSemantics(source)).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});

--- a/src/flex/flex-align.semantic.ts
+++ b/src/flex/flex-align.semantic.ts
@@ -1,0 +1,16 @@
+import type { SemanticResult } from './flex-semantic.model';
+
+export type FlexSelfAlignment = 'auto' | 'start' | 'end' | 'center' | 'baseline' | 'stretch';
+
+export interface FlexAlignSemantics {
+  readonly alignment: FlexSelfAlignment;
+}
+
+const alignments = new Set<FlexSelfAlignment>(['auto', 'start', 'end', 'center', 'baseline', 'stretch']);
+
+export function planFlexAlignSemantics(value: string): SemanticResult<FlexAlignSemantics> {
+  const alignment = (value.trim() || 'stretch') as FlexSelfAlignment;
+  return alignments.has(alignment)
+    ? { status: 'planned', value: { alignment } }
+    : { status: 'invalid', code: 'invalid-value' };
+}

--- a/src/flex/flex-fill.semantic.spec.ts
+++ b/src/flex/flex-fill.semantic.spec.ts
@@ -1,0 +1,8 @@
+import { planFlexFillSemantics } from './flex-fill.semantic';
+
+test('plans the shared zero-margin full-size fill dimensions', () => {
+  expect(planFlexFillSemantics()).toEqual({
+    status: 'planned',
+    value: { margin: '0', width: '100%', height: '100%', minWidth: '100%', minHeight: '100%' },
+  });
+});

--- a/src/flex/flex-fill.semantic.ts
+++ b/src/flex/flex-fill.semantic.ts
@@ -1,0 +1,21 @@
+import type { SemanticResult } from './flex-semantic.model';
+
+export interface FlexFillSemantics {
+  readonly margin: '0';
+  readonly width: '100%';
+  readonly height: '100%';
+  readonly minWidth: '100%';
+  readonly minHeight: '100%';
+}
+
+const fill: FlexFillSemantics = {
+  margin: '0',
+  width: '100%',
+  height: '100%',
+  minWidth: '100%',
+  minHeight: '100%',
+};
+
+export function planFlexFillSemantics(): SemanticResult<FlexFillSemantics> {
+  return { status: 'planned', value: fill };
+}

--- a/src/flex/flex-item.semantic.spec.ts
+++ b/src/flex/flex-item.semantic.spec.ts
@@ -1,0 +1,142 @@
+import { planFlexItemSemantics } from './flex-item.semantic';
+
+describe('planFlexItemSemantics', () => {
+  test.each([
+    [
+      { basis: '', layout: 'row' },
+      { grow: '1', shrink: '1', basis: '0%', axis: 'width', splitProperties: false },
+    ],
+    [
+      { basis: '0px', layout: 'row-reverse' },
+      { grow: '1', shrink: '1', basis: '0%', axis: 'width', splitProperties: false },
+    ],
+    [
+      { basis: '', layout: 'column' },
+      { grow: '1', shrink: '1', basis: '0.000000001px', axis: 'height', splitProperties: false },
+    ],
+    [
+      { basis: '25', layout: 'row' },
+      { grow: '1', shrink: '1', basis: '100%', axis: 'width', max: '25%', splitProperties: false },
+    ],
+    [
+      { basis: '25%', layout: 'row wrap' },
+      { grow: '1', shrink: '1', basis: '25%', axis: 'width', max: '25%', splitProperties: false },
+    ],
+    [
+      { basis: '25%', layout: 'row wrap-reverse' },
+      { grow: '1', shrink: '1', basis: '100%', axis: 'width', max: '25%', splitProperties: false },
+    ],
+    [
+      { basis: '10rem', layout: 'column' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: '10rem',
+        axis: 'height',
+        min: '10rem',
+        max: '10rem',
+        splitProperties: false,
+      },
+    ],
+    [
+      { basis: '12px', layout: 'column-reverse' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: '12px',
+        axis: 'height',
+        min: '12px',
+        max: '12px',
+        splitProperties: false,
+      },
+    ],
+  ] as const)('derives effective sizing for %o', (input, expected) => {
+    expect(planFlexItemSemantics(input)).toEqual({ status: 'planned', value: expected });
+  });
+
+  test.each([
+    ['initial', { grow: '0', shrink: '1', basis: 'auto' }],
+    ['nogrow', { grow: '0', shrink: '1', basis: 'auto' }],
+    ['grow', { grow: '1', shrink: '1', basis: '100%', max: '100%' }],
+    ['noshrink', { grow: '1', shrink: '0', basis: 'auto' }],
+    ['none', { grow: '0', shrink: '0', basis: 'auto' }],
+  ] as const)('expands the %j sizing keyword', (basis, expected) => {
+    expect(planFlexItemSemantics({ basis, layout: 'row' })).toEqual({
+      status: 'planned',
+      value: { ...expected, axis: 'width', splitProperties: false },
+    });
+  });
+
+  test('lets explicit factors control percentage constraints', () => {
+    expect(planFlexItemSemantics({ basis: '25', grow: '2', shrink: '0', layout: 'row' })).toEqual({
+      status: 'planned',
+      value: { grow: '2', shrink: '0', basis: '25%', axis: 'width', splitProperties: false },
+    });
+  });
+
+  test('extracts all three shorthand components before applying sizing rules', () => {
+    expect(planFlexItemSemantics({ basis: '0 0 10rem', grow: '4', shrink: '5', layout: 'row' })).toEqual({
+      status: 'planned',
+      value: {
+        grow: '0',
+        shrink: '0',
+        basis: '10rem',
+        axis: 'width',
+        min: '10rem',
+        max: '10rem',
+        splitProperties: false,
+      },
+    });
+  });
+
+  test('marks calc sizing for split-property rendering and omits its unsafe maximum', () => {
+    expect(planFlexItemSemantics({ basis: '3 2 calc(100% - 2rem)', layout: 'row' })).toEqual({
+      status: 'planned',
+      value: {
+        grow: '3',
+        shrink: '2',
+        basis: 'calc(100% - 2rem)',
+        axis: 'width',
+        min: 'calc(100% - 2rem)',
+        splitProperties: true,
+      },
+    });
+  });
+
+  test('uses both constraints for a fixed calc basis and wrapping chooses the maximum fallback', () => {
+    expect(planFlexItemSemantics({ basis: '0 0 calc(50% - 1rem)', layout: 'column wrap' })).toEqual({
+      status: 'planned',
+      value: {
+        grow: '0',
+        shrink: '0',
+        basis: 'calc(50% - 1rem)',
+        axis: 'height',
+        min: 'calc(50% - 1rem)',
+        max: 'calc(50% - 1rem)',
+        splitProperties: true,
+      },
+    });
+  });
+
+  test.each([
+    { basis: 'wide', layout: 'row' },
+    { basis: '10 px', layout: 'row' },
+    { basis: '1 2', layout: 'row' },
+    { basis: '25', grow: 'fast', layout: 'row' },
+    { basis: '25', grow: '-1', layout: 'row' },
+    { basis: '25', shrink: '.5', layout: 'row' },
+    { basis: '1 fast 25px', layout: 'row' },
+    { basis: '25', layout: 'diagonal' },
+  ] as const)('rejects invalid sizing input %o', input => {
+    expect(planFlexItemSemantics(input)).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+
+  test('preserves sizing for review when parent layout context is missing', () => {
+    expect(planFlexItemSemantics({ basis: '25', layout: undefined })).toEqual({
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'Flex sizing depends on a dynamic parent direction or wrapping mode.',
+      suggestion: 'Make the parent layout static or migrate this flex item manually.',
+    });
+  });
+});

--- a/src/flex/flex-item.semantic.spec.ts
+++ b/src/flex/flex-item.semantic.spec.ts
@@ -4,38 +4,37 @@ describe('planFlexItemSemantics', () => {
   test.each([
     [
       { basis: '', layout: 'row' },
-      { grow: '1', shrink: '1', basis: '0%', axis: 'width', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width' },
     ],
     [
       { basis: '0px', layout: 'row-reverse' },
-      { grow: '1', shrink: '1', basis: '0%', axis: 'width', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width' },
     ],
     [
       { basis: '', layout: 'column' },
-      { grow: '1', shrink: '1', basis: '0.000000001px', axis: 'height', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0.000000001px' }, axis: 'height' },
     ],
     [
       { basis: '25', layout: 'row' },
-      { grow: '1', shrink: '1', basis: '100%', axis: 'width', max: '25%', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '100%' }, axis: 'width', max: '25%' },
     ],
     [
       { basis: '25%', layout: 'row wrap' },
-      { grow: '1', shrink: '1', basis: '25%', axis: 'width', max: '25%', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '25%' }, axis: 'width', max: '25%' },
     ],
     [
       { basis: '25%', layout: 'row wrap-reverse' },
-      { grow: '1', shrink: '1', basis: '100%', axis: 'width', max: '25%', splitProperties: false },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '100%' }, axis: 'width', max: '25%' },
     ],
     [
       { basis: '10rem', layout: 'column' },
       {
         grow: '1',
         shrink: '1',
-        basis: '10rem',
+        basis: { kind: 'literal', value: '10rem' },
         axis: 'height',
         min: '10rem',
         max: '10rem',
-        splitProperties: false,
       },
     ],
     [
@@ -43,11 +42,10 @@ describe('planFlexItemSemantics', () => {
       {
         grow: '1',
         shrink: '1',
-        basis: '12px',
+        basis: { kind: 'literal', value: '12px' },
         axis: 'height',
         min: '12px',
         max: '12px',
-        splitProperties: false,
       },
     ],
   ] as const)('derives effective sizing for %o', (input, expected) => {
@@ -55,22 +53,22 @@ describe('planFlexItemSemantics', () => {
   });
 
   test.each([
-    ['initial', { grow: '0', shrink: '1', basis: 'auto' }],
-    ['nogrow', { grow: '0', shrink: '1', basis: 'auto' }],
-    ['grow', { grow: '1', shrink: '1', basis: '100%', max: '100%' }],
-    ['noshrink', { grow: '1', shrink: '0', basis: 'auto' }],
-    ['none', { grow: '0', shrink: '0', basis: 'auto' }],
+    ['initial', { grow: '0', shrink: '1', basis: { kind: 'keyword', value: 'auto' } }],
+    ['nogrow', { grow: '0', shrink: '1', basis: { kind: 'keyword', value: 'auto' } }],
+    ['grow', { grow: '1', shrink: '1', basis: { kind: 'literal', value: '100%' }, max: '100%' }],
+    ['noshrink', { grow: '1', shrink: '0', basis: { kind: 'keyword', value: 'auto' } }],
+    ['none', { grow: '0', shrink: '0', basis: { kind: 'keyword', value: 'auto' } }],
   ] as const)('expands the %j sizing keyword', (basis, expected) => {
     expect(planFlexItemSemantics({ basis, layout: 'row' })).toEqual({
       status: 'planned',
-      value: { ...expected, axis: 'width', splitProperties: false },
+      value: { ...expected, axis: 'width' },
     });
   });
 
   test('lets explicit factors control percentage constraints', () => {
     expect(planFlexItemSemantics({ basis: '25', grow: '2', shrink: '0', layout: 'row' })).toEqual({
       status: 'planned',
-      value: { grow: '2', shrink: '0', basis: '25%', axis: 'width', splitProperties: false },
+      value: { grow: '2', shrink: '0', basis: { kind: 'literal', value: '25%' }, axis: 'width' },
     });
   });
 
@@ -80,25 +78,23 @@ describe('planFlexItemSemantics', () => {
       value: {
         grow: '0',
         shrink: '0',
-        basis: '10rem',
+        basis: { kind: 'literal', value: '10rem' },
         axis: 'width',
         min: '10rem',
         max: '10rem',
-        splitProperties: false,
       },
     });
   });
 
-  test('marks calc sizing for split-property rendering and omits its unsafe maximum', () => {
+  test('represents a calculated basis without a target-rendering hint and omits its unsafe maximum', () => {
     expect(planFlexItemSemantics({ basis: '3 2 calc(100% - 2rem)', layout: 'row' })).toEqual({
       status: 'planned',
       value: {
         grow: '3',
         shrink: '2',
-        basis: 'calc(100% - 2rem)',
+        basis: { kind: 'computed', value: 'calc(100% - 2rem)' },
         axis: 'width',
         min: 'calc(100% - 2rem)',
-        splitProperties: true,
       },
     });
   });
@@ -109,11 +105,10 @@ describe('planFlexItemSemantics', () => {
       value: {
         grow: '0',
         shrink: '0',
-        basis: 'calc(50% - 1rem)',
+        basis: { kind: 'computed', value: 'calc(50% - 1rem)' },
         axis: 'height',
         min: 'calc(50% - 1rem)',
         max: 'calc(50% - 1rem)',
-        splitProperties: true,
       },
     });
   });

--- a/src/flex/flex-item.semantic.ts
+++ b/src/flex/flex-item.semantic.ts
@@ -1,0 +1,94 @@
+import { parseCssLength, type CssLength } from './css-length';
+import type { SemanticResult } from './flex-semantic.model';
+import { parseLayout, type LayoutSemantics } from './layout.semantic';
+
+export interface FlexItemInput {
+  readonly basis: string;
+  readonly grow?: string;
+  readonly shrink?: string;
+  readonly layout?: string;
+}
+
+export interface FlexItemSemantics {
+  readonly grow: string;
+  readonly shrink: string;
+  readonly basis: string;
+  readonly axis: 'width' | 'height';
+  readonly min?: CssLength;
+  readonly max?: CssLength;
+  readonly splitProperties: boolean;
+}
+
+const FACTOR = /^\d+(?:\.\d+)?$/;
+const unconstrainedBases = new Set(['0%', '0px', '0.000000001px', 'auto']);
+
+function sizingAxis(layout: LayoutSemantics): FlexItemSemantics['axis'] {
+  return layout.direction.startsWith('column') ? 'height' : 'width';
+}
+
+export function planFlexItemSemantics(input: FlexItemInput): SemanticResult<FlexItemSemantics> {
+  if (input.layout === undefined) {
+    return {
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'Flex sizing depends on a dynamic parent direction or wrapping mode.',
+      suggestion: 'Make the parent layout static or migrate this flex item manually.',
+    };
+  }
+
+  const layout = parseLayout(input.layout);
+  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
+
+  let grow = input.grow?.trim() || '1';
+  let shrink = input.shrink?.trim() || '1';
+  let basis = input.basis.trim();
+  const shorthand = basis.startsWith('calc(') ? undefined : basis.match(/^(\S+)\s+(\S+)\s+(.+)$/);
+  if (shorthand) {
+    grow = shorthand[1] ?? grow;
+    shrink = shorthand[2] ?? shrink;
+    basis = shorthand[3] ?? basis;
+  } else if (basis.split(/\s+/).length > 1 && !basis.startsWith('calc(')) {
+    return { status: 'invalid', code: 'invalid-value' };
+  }
+  if (!FACTOR.test(grow) || !FACTOR.test(shrink)) return { status: 'invalid', code: 'invalid-value' };
+
+  const axis = sizingAxis(layout.value);
+  let isValue = false;
+  let usingCalc = false;
+
+  if (!basis) {
+    basis = axis === 'width' ? '0%' : '0.000000001px';
+  } else if (basis === 'initial' || basis === 'nogrow') {
+    grow = '0';
+    basis = 'auto';
+  } else if (basis === 'grow') {
+    basis = '100%';
+  } else if (basis === 'noshrink') {
+    shrink = '0';
+    basis = 'auto';
+  } else if (basis === 'none') {
+    grow = '0';
+    shrink = '0';
+    basis = 'auto';
+  } else if (basis !== 'auto') {
+    const parsed = parseCssLength(basis, { fallbackUnit: '%' });
+    if (!parsed.ok) return { status: 'invalid', code: 'invalid-value' };
+    basis = parsed.value;
+    usingCalc = basis.startsWith('calc(');
+    isValue = usingCalc || !basis.endsWith('%');
+    if (basis === '0px') basis = '0%';
+  }
+
+  const fixed = grow === '0' && shrink === '0';
+  const constrainedBasis = basis as CssLength;
+  const min = !unconstrainedBases.has(basis) && (fixed || (isValue && grow !== '0')) ? constrainedBasis : undefined;
+  const max =
+    !unconstrainedBases.has(basis) && (fixed || (!usingCalc && shrink !== '0')) ? constrainedBasis : undefined;
+  const effectiveBasis =
+    min || max ? (layout.value.wrap === 'wrap' ? (max ?? min ?? basis) : isValue ? basis : '100%') : basis;
+
+  return {
+    status: 'planned',
+    value: { grow, shrink, basis: effectiveBasis, axis, min, max, splitProperties: usingCalc },
+  };
+}

--- a/src/flex/flex-item.semantic.ts
+++ b/src/flex/flex-item.semantic.ts
@@ -9,14 +9,17 @@ export interface FlexItemInput {
   readonly layout?: string;
 }
 
+export type FlexBasisSemantics =
+  | { readonly kind: 'keyword'; readonly value: 'auto' }
+  | { readonly kind: 'literal' | 'computed'; readonly value: CssLength };
+
 export interface FlexItemSemantics {
   readonly grow: string;
   readonly shrink: string;
-  readonly basis: string;
+  readonly basis: FlexBasisSemantics;
   readonly axis: 'width' | 'height';
   readonly min?: CssLength;
   readonly max?: CssLength;
-  readonly splitProperties: boolean;
 }
 
 const FACTOR = /^\d+(?:\.\d+)?$/;
@@ -86,9 +89,13 @@ export function planFlexItemSemantics(input: FlexItemInput): SemanticResult<Flex
     !unconstrainedBases.has(basis) && (fixed || (!usingCalc && shrink !== '0')) ? constrainedBasis : undefined;
   const effectiveBasis =
     min || max ? (layout.value.wrap === 'wrap' ? (max ?? min ?? basis) : isValue ? basis : '100%') : basis;
+  const semanticBasis: FlexBasisSemantics =
+    effectiveBasis === 'auto'
+      ? { kind: 'keyword', value: effectiveBasis }
+      : { kind: effectiveBasis.startsWith('calc(') ? 'computed' : 'literal', value: effectiveBasis as CssLength };
 
   return {
     status: 'planned',
-    value: { grow, shrink, basis: effectiveBasis, axis, min, max, splitProperties: usingCalc },
+    value: { grow, shrink, basis: semanticBasis, axis, min, max },
   };
 }

--- a/src/flex/flex-offset.semantic.spec.ts
+++ b/src/flex/flex-offset.semantic.spec.ts
@@ -1,0 +1,30 @@
+import { planFlexOffsetSemantics } from './flex-offset.semantic';
+
+describe('planFlexOffsetSemantics', () => {
+  test.each([
+    ['', 'row', { axis: 'inline-start', length: '0%' }],
+    ['4', 'row-reverse', { axis: 'inline-start', length: '4%' }],
+    ['10px', 'row', { axis: 'inline-start', length: '10px' }],
+    ['4', 'column', { axis: 'block-start', length: '4%' }],
+    ['2rem', 'column-reverse', { axis: 'block-start', length: '2rem' }],
+  ] as const)('plans %j in %j without applying Tailwind syntax', (source, layout, value) => {
+    expect(planFlexOffsetSemantics(source, layout)).toEqual({ status: 'planned', value });
+  });
+
+  test('preserves the dynamic parent layout diagnostic', () => {
+    expect(planFlexOffsetSemantics('4', undefined)).toEqual({
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'The offset margin axis depends on a dynamic parent layout.',
+      suggestion: 'Make the parent layout static or migrate the offset manually.',
+    });
+  });
+
+  test.each([
+    ['wide', 'row'],
+    ['1;display:none', 'row'],
+    ['4', 'diagonal'],
+  ] as const)('rejects invalid offset %j or layout %j', (source, layout) => {
+    expect(planFlexOffsetSemantics(source, layout)).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});

--- a/src/flex/flex-offset.semantic.ts
+++ b/src/flex/flex-offset.semantic.ts
@@ -1,0 +1,31 @@
+import { parseCssLength, type CssLength } from './css-length';
+import type { SemanticResult } from './flex-semantic.model';
+import { parseLayout } from './layout.semantic';
+
+export interface FlexOffsetSemantics {
+  readonly axis: 'inline-start' | 'block-start';
+  readonly length: CssLength;
+}
+
+export function planFlexOffsetSemantics(
+  value: string,
+  layoutValue: string | undefined,
+): SemanticResult<FlexOffsetSemantics> {
+  const offset = parseCssLength(value.trim() || '0', { fallbackUnit: '%' });
+  if (!offset.ok) return { status: 'invalid', code: 'invalid-value' };
+  if (layoutValue === undefined) {
+    return {
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'The offset margin axis depends on a dynamic parent layout.',
+      suggestion: 'Make the parent layout static or migrate the offset manually.',
+    };
+  }
+
+  const layout = parseLayout(layoutValue);
+  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
+  return {
+    status: 'planned',
+    value: { axis: layout.value.direction.startsWith('column') ? 'block-start' : 'inline-start', length: offset.value },
+  };
+}

--- a/src/flex/flex-order.semantic.spec.ts
+++ b/src/flex/flex-order.semantic.spec.ts
@@ -1,0 +1,15 @@
+import { planFlexOrderSemantics } from './flex-order.semantic';
+
+describe('planFlexOrderSemantics', () => {
+  test.each([
+    ['', undefined],
+    ['0', undefined],
+    ['2', 2],
+    ['-3', -3],
+    ['2.9', 2],
+    ['2nd', 2],
+    ['first', undefined],
+  ] as const)('plans source order %j as %j', (source, order) => {
+    expect(planFlexOrderSemantics(source)).toEqual({ status: 'planned', value: { order } });
+  });
+});

--- a/src/flex/flex-order.semantic.ts
+++ b/src/flex/flex-order.semantic.ts
@@ -1,0 +1,10 @@
+import type { SemanticResult } from './flex-semantic.model';
+
+export interface FlexOrderSemantics {
+  readonly order: number | undefined;
+}
+
+export function planFlexOrderSemantics(value: string): SemanticResult<FlexOrderSemantics> {
+  const order = Number.parseInt(value.trim(), 10) || undefined;
+  return { status: 'planned', value: { order } };
+}

--- a/src/flex/flex-semantic.model.ts
+++ b/src/flex/flex-semantic.model.ts
@@ -1,0 +1,10 @@
+export type SemanticDiagnostic =
+  | { readonly status: 'invalid'; readonly code: 'invalid-value' }
+  | {
+      readonly status: 'review';
+      readonly code: 'context-unverified' | 'semantic-unsupported';
+      readonly reason: string;
+      readonly suggestion: string;
+    };
+
+export type SemanticResult<T> = { readonly status: 'planned'; readonly value: T } | SemanticDiagnostic;

--- a/src/flex/layout-align.semantic.spec.ts
+++ b/src/flex/layout-align.semantic.spec.ts
@@ -1,0 +1,83 @@
+import { planLayoutAlignment } from './layout-align.semantic';
+
+describe('planLayoutAlignment', () => {
+  test.each([
+    [
+      '',
+      'row',
+      {
+        main: 'start',
+        items: 'stretch',
+        content: 'stretch',
+        stretchMaximum: 'height',
+        layout: {
+          direction: 'row',
+          wrap: 'nowrap',
+          explicitWrap: false,
+          display: 'flex',
+          boxSizing: 'border-box',
+        },
+      },
+    ],
+    [
+      'flex-end flex-start',
+      'row-reverse inline',
+      {
+        main: 'end',
+        items: 'start',
+        content: 'start',
+        layout: {
+          direction: 'row-reverse',
+          wrap: 'nowrap',
+          explicitWrap: false,
+          display: 'inline-flex',
+          boxSizing: 'border-box',
+        },
+      },
+    ],
+    [
+      'space-between baseline',
+      'column',
+      {
+        main: 'space-between',
+        items: 'baseline',
+        content: 'stretch',
+        layout: {
+          direction: 'column',
+          wrap: 'nowrap',
+          explicitWrap: false,
+          display: 'flex',
+          boxSizing: 'border-box',
+        },
+      },
+    ],
+    [
+      'space-around stretch',
+      'column-reverse',
+      {
+        main: 'space-around',
+        items: 'stretch',
+        content: 'stretch',
+        stretchMaximum: 'width',
+        layout: {
+          direction: 'column-reverse',
+          wrap: 'nowrap',
+          explicitWrap: false,
+          display: 'flex',
+          boxSizing: 'border-box',
+        },
+      },
+    ],
+  ] as const)('derives target-neutral alignment semantics for %j in %j', (value, layout, expected) => {
+    expect(planLayoutAlignment(value, layout)).toEqual({ status: 'planned', value: expected });
+  });
+
+  test.each([
+    ['left center', 'row'],
+    ['center auto', 'row'],
+    ['center center extra', 'row'],
+    ['center', 'diagonal'],
+  ])('rejects invalid alignment %j or layout context %j', (value, layout) => {
+    expect(planLayoutAlignment(value, layout)).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});

--- a/src/flex/layout-align.semantic.ts
+++ b/src/flex/layout-align.semantic.ts
@@ -1,0 +1,60 @@
+import type { SemanticResult } from './flex-semantic.model';
+import { parseLayout, type LayoutSemantics } from './layout.semantic';
+
+export type LayoutMainAlignment = 'start' | 'center' | 'end' | 'space-around' | 'space-between' | 'space-evenly';
+export type LayoutItemsAlignment = 'start' | 'center' | 'end' | 'baseline' | 'stretch';
+export type LayoutContentAlignment = 'start' | 'center' | 'end' | 'stretch' | 'space-around' | 'space-between';
+
+export interface LayoutAlignmentSemantics {
+  readonly main: LayoutMainAlignment;
+  readonly items: LayoutItemsAlignment;
+  readonly content: LayoutContentAlignment;
+  readonly stretchMaximum?: 'width' | 'height';
+  readonly layout: LayoutSemantics;
+}
+
+const mainAxis: Readonly<Record<string, LayoutMainAlignment>> = {
+  start: 'start',
+  'flex-start': 'start',
+  center: 'center',
+  end: 'end',
+  'flex-end': 'end',
+  'space-around': 'space-around',
+  'space-between': 'space-between',
+  'space-evenly': 'space-evenly',
+};
+
+const crossAxis: Readonly<Record<string, readonly [LayoutItemsAlignment, LayoutContentAlignment]>> = {
+  start: ['start', 'start'],
+  'flex-start': ['start', 'start'],
+  center: ['center', 'center'],
+  end: ['end', 'end'],
+  'flex-end': ['end', 'end'],
+  'space-between': ['stretch', 'space-between'],
+  'space-around': ['stretch', 'space-around'],
+  baseline: ['baseline', 'stretch'],
+  stretch: ['stretch', 'stretch'],
+};
+
+export function planLayoutAlignment(value: string, layoutValue: string): SemanticResult<LayoutAlignmentSemantics> {
+  const values = value.split(/\s+/).filter(Boolean);
+  if (values.length > 2) return { status: 'invalid', code: 'invalid-value' };
+
+  const main = mainAxis[values[0] ?? 'start'];
+  const crossKey = values[1] ?? 'stretch';
+  const cross = crossAxis[crossKey];
+  const layout = parseLayout(layoutValue);
+  if (!main || !cross || !layout.ok) return { status: 'invalid', code: 'invalid-value' };
+
+  const stretchMaximum =
+    crossKey === 'stretch'
+      ? layout.value.direction === 'row' || layout.value.direction === 'row-reverse'
+        ? 'height'
+        : 'width'
+      : undefined;
+
+  return {
+    status: 'planned',
+    value: { main, items: cross[0], content: cross[1], stretchMaximum, layout: layout.value },
+  };
+}

--- a/src/flex/layout-gap.semantic.spec.ts
+++ b/src/flex/layout-gap.semantic.spec.ts
@@ -1,0 +1,63 @@
+import { planLayoutGapSemantics } from './layout-gap.semantic';
+
+describe('planLayoutGapSemantics', () => {
+  test.each([
+    ['4', 'row', '4px'],
+    ['1.5rem', 'column', '1.5rem'],
+    ['0', '', '0px'],
+  ] as const)('normalizes static gap %j independently of its non-wrapping layout', (value, layout, length) => {
+    expect(planLayoutGapSemantics(value, layout)).toEqual({ status: 'planned', value: { length } });
+  });
+
+  test('preserves the negative gap diagnostic exactly', () => {
+    expect(planLayoutGapSemantics('-4', 'row')).toEqual({
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'Flex-Layout accepts a negative margin gap, but CSS gap does not accept negative values.',
+      suggestion: 'Preserve the margin-based spacing or migrate the child margins manually.',
+    });
+  });
+
+  test.each(['calc(1px - 2px)', 'var(--gap)', 'min(4px, 2vw)', 'clamp(0px, 1vw, 8px)'] as const)(
+    'preserves the computed-gap diagnostic for %j',
+    value => {
+      expect(planLayoutGapSemantics(value, 'row')).toEqual({
+        status: 'review',
+        code: 'context-unverified',
+        reason: 'The computed gap may resolve to a negative value that CSS gap cannot represent.',
+        suggestion: 'Prove the value is nonnegative or migrate the margin-based spacing manually.',
+      });
+    },
+  );
+
+  test('preserves the upstream grid gap diagnostic', () => {
+    expect(planLayoutGapSemantics('10px grid', 'row')).toEqual({
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'The Flex-Layout grid gap mode changes child padding and compensating host margins.',
+      suggestion: 'Replace the grid gap manually after reviewing the child padding behavior.',
+    });
+  });
+
+  test.each(['row wrap', 'column wrap-reverse'] as const)('preserves the wrapped-layout diagnostic for %j', layout => {
+    expect(planLayoutGapSemantics('4', layout)).toEqual({
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'Flex-Layout margins and CSS gap differ when flex items wrap across lines.',
+      suggestion: 'Verify the wrapped layout and migrate its spacing manually.',
+    });
+  });
+
+  test('preserves the missing-layout diagnostic', () => {
+    expect(planLayoutGapSemantics('4', undefined)).toEqual({
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'The active flex direction and wrapping behavior depend on a dynamic layout.',
+      suggestion: 'Make the layout static or migrate the gap and responsive layout together.',
+    });
+  });
+
+  test.each(['', 'wide', '1;display:none', '10 px'] as const)('rejects invalid gaps %j', value => {
+    expect(planLayoutGapSemantics(value, 'row')).toEqual({ status: 'invalid', code: 'invalid-value' });
+  });
+});

--- a/src/flex/layout-gap.semantic.ts
+++ b/src/flex/layout-gap.semantic.ts
@@ -1,0 +1,64 @@
+import { parseCssLength, type CssLength } from './css-length';
+import type { SemanticResult } from './flex-semantic.model';
+import { parseLayout } from './layout.semantic';
+
+export interface LayoutGapSemantics {
+  readonly length: CssLength;
+}
+
+export function planLayoutGapSemantics(
+  value: string,
+  layoutValue: string | undefined,
+): SemanticResult<LayoutGapSemantics> {
+  const normalized = value.trim();
+  if (!normalized) return { status: 'invalid', code: 'invalid-value' };
+
+  if (normalized.endsWith(' grid')) {
+    return {
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'The Flex-Layout grid gap mode changes child padding and compensating host margins.',
+      suggestion: 'Replace the grid gap manually after reviewing the child padding behavior.',
+    };
+  }
+
+  const length = parseCssLength(normalized, { fallbackUnit: 'px' });
+  if (!length.ok) return { status: 'invalid', code: 'invalid-value' };
+  if (length.value.startsWith('-')) {
+    return {
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'Flex-Layout accepts a negative margin gap, but CSS gap does not accept negative values.',
+      suggestion: 'Preserve the margin-based spacing or migrate the child margins manually.',
+    };
+  }
+  if (length.value.includes('(')) {
+    return {
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'The computed gap may resolve to a negative value that CSS gap cannot represent.',
+      suggestion: 'Prove the value is nonnegative or migrate the margin-based spacing manually.',
+    };
+  }
+  if (layoutValue === undefined) {
+    return {
+      status: 'review',
+      code: 'context-unverified',
+      reason: 'The active flex direction and wrapping behavior depend on a dynamic layout.',
+      suggestion: 'Make the layout static or migrate the gap and responsive layout together.',
+    };
+  }
+
+  const layout = parseLayout(layoutValue);
+  if (!layout.ok) return { status: 'invalid', code: 'invalid-value' };
+  if (layout.value.wrap !== 'nowrap') {
+    return {
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'Flex-Layout margins and CSS gap differ when flex items wrap across lines.',
+      suggestion: 'Verify the wrapped layout and migrate its spacing manually.',
+    };
+  }
+
+  return { status: 'planned', value: { length: length.value } };
+}

--- a/src/flex/layout.semantic.spec.ts
+++ b/src/flex/layout.semantic.spec.ts
@@ -1,0 +1,39 @@
+import { parseLayout } from './layout.semantic';
+
+describe('parseLayout', () => {
+  test.each([
+    ['', { direction: 'row', wrap: 'nowrap', explicitWrap: false, display: 'flex', boxSizing: 'border-box' }],
+    ['row', { direction: 'row', wrap: 'nowrap', explicitWrap: false, display: 'flex', boxSizing: 'border-box' }],
+    [
+      'row-reverse nowrap',
+      { direction: 'row-reverse', wrap: 'nowrap', explicitWrap: true, display: 'flex', boxSizing: 'border-box' },
+    ],
+    [
+      'column wrap',
+      { direction: 'column', wrap: 'wrap', explicitWrap: true, display: 'flex', boxSizing: 'border-box' },
+    ],
+    [
+      'column-reverse wrap-reverse inline',
+      {
+        direction: 'column-reverse',
+        wrap: 'wrap-reverse',
+        explicitWrap: true,
+        display: 'inline-flex',
+        boxSizing: 'border-box',
+      },
+    ],
+    [
+      'column wrap inline',
+      { direction: 'column', wrap: 'wrap', explicitWrap: true, display: 'inline-flex', boxSizing: 'border-box' },
+    ],
+  ] as const)('derives target-neutral semantics for %j', (value, expected) => {
+    expect(parseLayout(value)).toEqual({ ok: true, value: expected });
+  });
+
+  test.each(['diagonal', 'row row', 'row wrap nowrap', 'inline', 'row inline inline', 'row unknown'])(
+    'rejects duplicate or unknown layout tokens in %j',
+    value => {
+      expect(parseLayout(value)).toEqual({ ok: false });
+    },
+  );
+});

--- a/src/flex/layout.semantic.ts
+++ b/src/flex/layout.semantic.ts
@@ -1,0 +1,41 @@
+import type { ParsedValue } from './css-length';
+
+export type LayoutDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+export type LayoutWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
+
+export interface LayoutSemantics {
+  readonly direction: LayoutDirection;
+  readonly wrap: LayoutWrap;
+  readonly explicitWrap: boolean;
+  readonly display: 'flex' | 'inline-flex';
+  readonly boxSizing: 'border-box';
+}
+
+const directions = new Set<LayoutDirection>(['row', 'row-reverse', 'column', 'column-reverse']);
+const wraps = new Set<LayoutWrap>(['nowrap', 'wrap', 'wrap-reverse']);
+
+export function parseLayout(value: string): ParsedValue<LayoutSemantics> {
+  const tokens = value.split(/\s+/).filter(Boolean);
+  const direction = (tokens.shift() ?? 'row') as LayoutDirection;
+  if (!directions.has(direction)) return { ok: false };
+
+  const wrapTokens = tokens.filter(token => wraps.has(token as LayoutWrap));
+  if (wrapTokens.length > 1) return { ok: false };
+
+  let wrap: LayoutWrap = 'nowrap';
+  let display: LayoutSemantics['display'] = 'flex';
+  for (const token of tokens) {
+    if (wraps.has(token as LayoutWrap)) {
+      wrap = token as LayoutWrap;
+    } else if (token === 'inline' && display === 'flex') {
+      display = 'inline-flex';
+    } else {
+      return { ok: false };
+    }
+  }
+
+  return {
+    ok: true,
+    value: { direction, wrap, explicitWrap: wrapTokens.length === 1, display, boxSizing: 'border-box' },
+  };
+}

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -2,8 +2,21 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
+const tailwindRoot = join(process.cwd(), 'src', 'adapter', 'tailwind');
 const targetTokens = ['flex-row', 'box-border', '[@media_'];
 const tailwindModuleReference = 'adapter/tailwind';
+const adapterModuleReference = 'adapter/';
+
+const scopedStrategies = [
+  ['layout.strategy.ts', 'parseLayout', 'layout.semantic'],
+  ['layout-align.strategy.ts', 'planLayoutAlignment', 'layout-align.semantic'],
+  ['layout-gap.strategy.ts', 'planLayoutGapSemantics', 'layout-gap.semantic'],
+  ['flex-item.strategy.ts', 'planFlexItemSemantics', 'flex-item.semantic'],
+  ['flex-align.strategy.ts', 'planFlexAlignSemantics', 'flex-align.semantic'],
+  ['flex-fill.strategy.ts', 'planFlexFillSemantics', 'flex-fill.semantic'],
+  ['flex-offset.strategy.ts', 'planFlexOffsetSemantics', 'flex-offset.semantic'],
+  ['flex-order.strategy.ts', 'planFlexOrderSemantics', 'flex-order.semantic'],
+] as const;
 
 function sourceFiles(directory: string): readonly string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
@@ -30,10 +43,29 @@ describe('flex semantic boundary', () => {
       const sourcePath = relative(process.cwd(), path);
 
       expect(source, sourcePath).not.toContain(tailwindModuleReference);
+      expect(source, sourcePath).not.toContain(adapterModuleReference);
       for (const token of targetTokens) {
         expect(source, sourcePath).not.toContain(token);
       }
       expect(source, sourcePath).not.toMatch(/\[[a-z-]+:/u);
     }
+  });
+
+  test.each(scopedStrategies)('%s imports its target-neutral planner', (fileName, planner, semanticModule) => {
+    const source = readFileSync(join(tailwindRoot, 'directives', fileName), 'utf8');
+    const plannerImport = new RegExp(
+      String.raw`import\s*\{[^}]*\b${planner}\b[^}]*\}\s*from\s*['"]\.\./\.\./\.\./flex/${semanticModule}['"]`,
+      'u',
+    );
+
+    expect(source).toMatch(plannerImport);
+  });
+
+  test('Tailwind modules no longer originate target-neutral semantic exports', () => {
+    const semanticModel = readFileSync(join(tailwindRoot, 'tailwind-semantic.model.ts'), 'utf8');
+    const valueParser = readFileSync(join(tailwindRoot, 'tailwind-value.parser.ts'), 'utf8');
+
+    expect(semanticModel).not.toMatch(/\b(?:CssLength|ParsedValue|SemanticDiagnostic|SemanticResult)\b/u);
+    expect(valueParser).not.toMatch(/\b(?:CssLength|CssLengthOptions|ParsedValue|parseCssLength)\b/u);
   });
 });

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -1,9 +1,10 @@
 import { readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import ts from 'typescript';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
 const tailwindRoot = join(process.cwd(), 'src', 'adapter', 'tailwind');
+const strategyFixturePath = join(tailwindRoot, 'directives', 'strategy.ts');
 const targetTokens = ['flex-row', 'box-border', '[@media_'];
 const tailwindModuleReference = 'adapter/tailwind';
 const adapterModuleReference = 'adapter/';
@@ -19,12 +20,12 @@ const scopedStrategies = [
   ['flex-order.strategy.ts', 'planFlexOrderSemantics', 'flex-order.semantic'],
 ] as const;
 
-function hasSemanticCoreReExport(source: string): boolean {
-  const sourceFile = ts.createSourceFile('strategy.ts', source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+function hasSemanticCoreReExport(source: string, sourcePath = strategyFixturePath): boolean {
+  const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
   const semanticCoreImports = new Set<string>();
 
   for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement) || !isSemanticCoreModule(statement.moduleSpecifier)) continue;
+    if (!ts.isImportDeclaration(statement) || !isSemanticCoreModule(statement.moduleSpecifier, sourcePath)) continue;
 
     const importClause = statement.importClause;
     if (!importClause) continue;
@@ -39,8 +40,11 @@ function hasSemanticCoreReExport(source: string): boolean {
   }
 
   return sourceFile.statements.some(statement => {
+    if (ts.isExportAssignment(statement)) {
+      return ts.isIdentifier(statement.expression) && semanticCoreImports.has(statement.expression.text);
+    }
     if (!ts.isExportDeclaration(statement)) return false;
-    if (statement.moduleSpecifier) return isSemanticCoreModule(statement.moduleSpecifier);
+    if (statement.moduleSpecifier) return isSemanticCoreModule(statement.moduleSpecifier, sourcePath);
     if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return false;
 
     return statement.exportClause.elements.some(element =>
@@ -49,8 +53,16 @@ function hasSemanticCoreReExport(source: string): boolean {
   });
 }
 
-function isSemanticCoreModule(moduleSpecifier: ts.Expression): boolean {
-  return ts.isStringLiteralLike(moduleSpecifier) && /(?:^|\/)flex\//u.test(moduleSpecifier.text);
+function isSemanticCoreModule(moduleSpecifier: ts.Expression, sourcePath: string): boolean {
+  if (!ts.isStringLiteralLike(moduleSpecifier) || !/^\.{1,2}(?:\/|$)/u.test(moduleSpecifier.text)) return false;
+
+  const resolvedModule = resolve(dirname(sourcePath), moduleSpecifier.text);
+  const pathFromFlexRoot = relative(flexRoot, resolvedModule);
+
+  return (
+    pathFromFlexRoot === '' ||
+    (pathFromFlexRoot !== '..' && !isAbsolute(pathFromFlexRoot) && !pathFromFlexRoot.startsWith(`..${sep}`))
+  );
 }
 
 function sourceFiles(directory: string): readonly string[] {
@@ -97,9 +109,10 @@ describe('flex semantic boundary', () => {
   });
 
   test.each(scopedStrategies)('%s does not re-export target-neutral semantic-core types', fileName => {
-    const source = readFileSync(join(tailwindRoot, 'directives', fileName), 'utf8');
+    const sourcePath = join(tailwindRoot, 'directives', fileName);
+    const source = readFileSync(sourcePath, 'utf8');
 
-    expect(hasSemanticCoreReExport(source)).toBe(false);
+    expect(hasSemanticCoreReExport(source, sourcePath)).toBe(false);
   });
 
   test.each([
@@ -110,6 +123,22 @@ describe('flex semantic boundary', () => {
   ])('rejects semantic-core type re-export: %s', source => {
     expect(hasSemanticCoreReExport(source)).toBe(true);
   });
+
+  test('rejects an imported semantic-core planner assigned as the default export', () => {
+    const source = [
+      "import { planFlexItemSemantics } from '../../../flex/flex-item.semantic';",
+      'export default planFlexItemSemantics;',
+    ].join('\n');
+
+    expect(hasSemanticCoreReExport(source)).toBe(true);
+  });
+
+  test.each(["export * from '@vendor/flex/helpers';", "export * from '../../../';"])(
+    'allows modules outside the project semantic core: %s',
+    source => {
+      expect(hasSemanticCoreReExport(source)).toBe(false);
+    },
+  );
 
   test('Tailwind modules no longer originate target-neutral semantic exports', () => {
     const semanticModel = readFileSync(join(tailwindRoot, 'tailwind-semantic.model.ts'), 'utf8');

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
+import ts from 'typescript';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
 const tailwindRoot = join(process.cwd(), 'src', 'adapter', 'tailwind');
@@ -17,6 +18,40 @@ const scopedStrategies = [
   ['flex-offset.strategy.ts', 'planFlexOffsetSemantics', 'flex-offset.semantic'],
   ['flex-order.strategy.ts', 'planFlexOrderSemantics', 'flex-order.semantic'],
 ] as const;
+
+function hasSemanticCoreReExport(source: string): boolean {
+  const sourceFile = ts.createSourceFile('strategy.ts', source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  const semanticCoreImports = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !isSemanticCoreModule(statement.moduleSpecifier)) continue;
+
+    const importClause = statement.importClause;
+    if (!importClause) continue;
+    if (importClause.name) semanticCoreImports.add(importClause.name.text);
+
+    const bindings = importClause.namedBindings;
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      semanticCoreImports.add(bindings.name.text);
+    } else if (bindings) {
+      for (const element of bindings.elements) semanticCoreImports.add(element.name.text);
+    }
+  }
+
+  return sourceFile.statements.some(statement => {
+    if (!ts.isExportDeclaration(statement)) return false;
+    if (statement.moduleSpecifier) return isSemanticCoreModule(statement.moduleSpecifier);
+    if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return false;
+
+    return statement.exportClause.elements.some(element =>
+      semanticCoreImports.has((element.propertyName ?? element.name).text),
+    );
+  });
+}
+
+function isSemanticCoreModule(moduleSpecifier: ts.Expression): boolean {
+  return ts.isStringLiteralLike(moduleSpecifier) && /(?:^|\/)flex\//u.test(moduleSpecifier.text);
+}
 
 function sourceFiles(directory: string): readonly string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
@@ -64,7 +99,16 @@ describe('flex semantic boundary', () => {
   test.each(scopedStrategies)('%s does not re-export target-neutral semantic-core types', fileName => {
     const source = readFileSync(join(tailwindRoot, 'directives', fileName), 'utf8');
 
-    expect(source).not.toMatch(/\bexport\s+(?:(?:type\s+)?\{[^}]*\}|\*)\s*from\s*['"][^'"]*\/flex\//u);
+    expect(hasSemanticCoreReExport(source)).toBe(false);
+  });
+
+  test.each([
+    "export type * from '../../../flex/flex-item.semantic';",
+    ["import type { FlexItemInput } from '../../../flex/flex-item.semantic';", 'export type { FlexItemInput };'].join(
+      '\n',
+    ),
+  ])('rejects semantic-core type re-export: %s', source => {
+    expect(hasSemanticCoreReExport(source)).toBe(true);
   });
 
   test('Tailwind modules no longer originate target-neutral semantic exports', () => {

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -6,6 +6,19 @@ const flexRoot = join(process.cwd(), 'src', 'flex');
 const tailwindRoot = join(process.cwd(), 'src', 'adapter', 'tailwind');
 const strategyFixturePath = join(tailwindRoot, 'directives', 'strategy.ts');
 const targetTokens = ['flex-row', 'box-border', '[@media_'];
+const targetRenderingHintIdentifiers = new Set([
+  'classNames',
+  'flexClasses',
+  'renderAsLonghands',
+  'renderAsShorthand',
+  'splitProperties',
+  'tailwindClasses',
+]);
+const scopedTargetSyntax = [
+  /^(?:box-border|m-0|(?:min-|max-)?[wh]-full|size-full)$/u,
+  /^(?:basis-|content-|flex-(?:col|nowrap|row|wrap)|gap-|grow-|items-|justify-|m[st]-|order-|self-|shrink-)/u,
+  /^\[(?:flex(?:-(?:basis|grow|shrink))?|m(?:ax|in)-(?:height|width)|order):/u,
+];
 const tailwindModuleReference = 'adapter/tailwind';
 const adapterModuleReference = 'adapter/';
 
@@ -73,6 +86,33 @@ function sourceFiles(directory: string): readonly string[] {
   });
 }
 
+function targetRenderingLeak(source: string, sourcePath = strategyFixturePath): string | undefined {
+  const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  let leak: string | undefined;
+
+  function visit(node: ts.Node): void {
+    if (leak !== undefined) return;
+    if (ts.isIdentifier(node) && targetRenderingHintIdentifiers.has(node.text)) {
+      leak = node.text;
+      return;
+    }
+    if (
+      (ts.isStringLiteralLike(node) ||
+        ts.isTemplateHead(node) ||
+        ts.isTemplateMiddle(node) ||
+        ts.isTemplateTail(node)) &&
+      scopedTargetSyntax.some(pattern => pattern.test(node.text))
+    ) {
+      leak = node.text;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return leak;
+}
+
 describe('flex semantic boundary', () => {
   test.each([
     "import { renderLayout } from '../../adapter/tailwind/directives/layout.strategy';",
@@ -95,7 +135,23 @@ describe('flex semantic boundary', () => {
         expect(source, sourcePath).not.toContain(token);
       }
       expect(source, sourcePath).not.toMatch(/\[[a-z-]+:/u);
+      expect(targetRenderingLeak(source, path), sourcePath).toBeUndefined();
     }
+  });
+
+  test.each([
+    ['const splitProperties = false;', 'splitProperties'],
+    ["const classes = ['flex-row'];", 'flex-row'],
+    ["const classes = ['justify-between'];", 'justify-between'],
+    ['const className = `items-${alignment}`;', 'items-'],
+    ['const className = `gap-${length}`;', 'gap-'],
+    ["const className = '[flex:1_1_0%]';", '[flex:1_1_0%]'],
+    ["const classes = ['self-center'];", 'self-center'],
+    ["const classes = ['w-full'];", 'w-full'],
+    ['const className = `ms-${offset}`;', 'ms-'],
+    ["const className = '[order:2]';", '[order:2]'],
+  ])('recognizes scoped target-rendering leak %s', (source, expected) => {
+    expect(targetRenderingLeak(source)).toBe(expected);
   });
 
   test.each(scopedStrategies)('%s imports its target-neutral planner', (fileName, planner, semanticModule) => {

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -61,6 +61,12 @@ describe('flex semantic boundary', () => {
     expect(source).toMatch(plannerImport);
   });
 
+  test.each(scopedStrategies)('%s does not re-export target-neutral semantic-core types', fileName => {
+    const source = readFileSync(join(tailwindRoot, 'directives', fileName), 'utf8');
+
+    expect(source).not.toMatch(/\bexport\s+(?:(?:type\s+)?\{[^}]*\}|\*)\s*from\s*['"][^'"]*\/flex\//u);
+  });
+
   test('Tailwind modules no longer originate target-neutral semantic exports', () => {
     const semanticModel = readFileSync(join(tailwindRoot, 'tailwind-semantic.model.ts'), 'utf8');
     const valueParser = readFileSync(join(tailwindRoot, 'tailwind-value.parser.ts'), 'utf8');

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -3,6 +3,7 @@ import { join, relative } from 'node:path';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
 const targetTokens = ['flex-row', 'box-border', '[@media_'];
+const tailwindImport = /(?:\bfrom\s*|\bimport\s*\(|\brequire\s*\()\s*['"][^'"]*adapter\/tailwind[^'"]*['"]/u;
 
 function sourceFiles(directory: string): readonly string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
@@ -13,12 +14,20 @@ function sourceFiles(directory: string): readonly string[] {
 }
 
 describe('flex semantic boundary', () => {
+  test.each([
+    "import { renderLayout } from '../../adapter/tailwind/directives/layout.strategy';",
+    "await import('../../adapter/tailwind/tailwind.adapter');",
+    "require('../../adapter/tailwind/tailwind.adapter');",
+  ])('rejects Tailwind module reference: %s', source => {
+    expect(source).toMatch(tailwindImport);
+  });
+
   test('contains no Tailwind dependencies or target syntax', () => {
     for (const path of sourceFiles(flexRoot)) {
       const source = readFileSync(path, 'utf8');
       const sourcePath = relative(process.cwd(), path);
 
-      expect(source, sourcePath).not.toMatch(/from\s+['"][^'"]*adapter\/tailwind[^'"]*['"]/u);
+      expect(source, sourcePath).not.toMatch(tailwindImport);
       for (const token of targetTokens) {
         expect(source, sourcePath).not.toContain(token);
       }

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -1,0 +1,28 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const flexRoot = join(process.cwd(), 'src', 'flex');
+const targetTokens = ['flex-row', 'box-border', '[@media_'];
+
+function sourceFiles(directory: string): readonly string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts') ? [path] : [];
+  });
+}
+
+describe('flex semantic boundary', () => {
+  test('contains no Tailwind dependencies or target syntax', () => {
+    for (const path of sourceFiles(flexRoot)) {
+      const source = readFileSync(path, 'utf8');
+      const sourcePath = relative(process.cwd(), path);
+
+      expect(source, sourcePath).not.toMatch(/from\s+['"][^'"]*adapter\/tailwind[^'"]*['"]/u);
+      for (const token of targetTokens) {
+        expect(source, sourcePath).not.toContain(token);
+      }
+      expect(source, sourcePath).not.toMatch(/\[[a-z-]+:/u);
+    }
+  });
+});

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -3,7 +3,7 @@ import { join, relative } from 'node:path';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
 const targetTokens = ['flex-row', 'box-border', '[@media_'];
-const tailwindImport = /(?:\bfrom\s*|\bimport\s*\(|\brequire\s*\()\s*['"][^'"]*adapter\/tailwind[^'"]*['"]/u;
+const tailwindModuleReference = 'adapter/tailwind';
 
 function sourceFiles(directory: string): readonly string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
@@ -18,8 +18,10 @@ describe('flex semantic boundary', () => {
     "import { renderLayout } from '../../adapter/tailwind/directives/layout.strategy';",
     "await import('../../adapter/tailwind/tailwind.adapter');",
     "require('../../adapter/tailwind/tailwind.adapter');",
+    "import '../../adapter/tailwind/directives/layout.strategy';",
+    "import /* target renderer */ '../../adapter/tailwind/directives/layout.strategy';",
   ])('rejects Tailwind module reference: %s', source => {
-    expect(source).toMatch(tailwindImport);
+    expect(source).toContain(tailwindModuleReference);
   });
 
   test('contains no Tailwind dependencies or target syntax', () => {
@@ -27,7 +29,7 @@ describe('flex semantic boundary', () => {
       const source = readFileSync(path, 'utf8');
       const sourcePath = relative(process.cwd(), path);
 
-      expect(source, sourcePath).not.toMatch(tailwindImport);
+      expect(source, sourcePath).not.toContain(tailwindModuleReference);
       for (const token of targetTokens) {
         expect(source, sourcePath).not.toContain(token);
       }

--- a/test/compatibility/angular-template-engine.test.ts
+++ b/test/compatibility/angular-template-engine.test.ts
@@ -75,6 +75,59 @@ function equivalentResults(results: readonly ConversionResult[]) {
     .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
 }
 
+function normalizedPublicResults(results: readonly ConversionResult[]) {
+  return results
+    .map(result => {
+      if (result.status === 'parse-error') {
+        return { status: result.status, code: result.code, reason: result.reason };
+      }
+
+      const normalized = {
+        status: result.status,
+        sourceName: result.input.sourceName,
+        directive: result.input.directive,
+        value: result.input.value,
+        binding: result.input.binding,
+        breakpoint: result.input.breakpoint,
+      };
+      return result.status === 'converted'
+        ? normalized
+        : { ...normalized, code: result.code, reason: result.reason, suggestion: result.suggestion };
+    })
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+}
+
+const scopedFlexDirectives = [
+  ['fxLayout', 'row', 'self'],
+  ['fxLayoutAlign', 'space-between center', 'local-layout'],
+  ['fxLayoutGap', '8', 'local-layout'],
+  ['fxFlex', '25', 'parent-layout'],
+  ['fxGrow', '2', 'flex-item'],
+  ['fxShrink', '3', 'flex-item'],
+  ['fxFlexAlign', 'center', 'parent-layout'],
+  ['fxFlexFill', '', 'self'],
+  ['fxFill', '', 'self'],
+  ['fxFlexOffset', '10', 'parent-layout'],
+  ['fxFlexOrder', '2', 'parent-layout'],
+] as const;
+
+function scopedFlexCase(
+  [directive, value, context]: (typeof scopedFlexDirectives)[number],
+  alias: (typeof standardAliases)[number],
+  reverse: boolean,
+): string {
+  const target = [`${directive}="${value}"`, `${directive}.${alias}="${value}"`];
+  const flexBasis = ['fxFlex="25"', `fxFlex.${alias}="25"`];
+  const attributes = context === 'flex-item' ? [...flexBasis, ...target] : target;
+  if (context === 'local-layout') attributes.unshift('fxLayout="row"');
+  if (reverse) attributes.reverse();
+
+  const element = `<div ${attributes.join(' ')}></div>`;
+  return context === 'parent-layout' || context === 'flex-item'
+    ? `<section fxLayout="row">${element}</section>\n`
+    : `${element}\n`;
+}
+
 function extendedOccurrenceCounts(results: readonly ConversionResult[]) {
   const counts = { converted: 0, preserved: 0 };
   for (const result of results) {
@@ -253,6 +306,37 @@ describe('Angular template engine compatibility', () => {
 
     expect(baseFirst.output).toBe(responsiveFirst.output);
     expect(equivalentResults(baseFirst.results)).toEqual(equivalentResults(responsiveFirst.results));
+  });
+
+  test('preserves every scoped Flex directive across base and standard aliases independent of order', () => {
+    const coveredSourceNames = new Set<string>();
+
+    for (const directiveCase of scopedFlexDirectives) {
+      for (const alias of standardAliases) {
+        const canonical = migrate(scopedFlexCase(directiveCase, alias, false), 'scoped-flex.html');
+        const reversed = migrate(scopedFlexCase(directiveCase, alias, true), 'scoped-flex.html');
+
+        for (const result of canonical.results) {
+          if (result.status !== 'parse-error') coveredSourceNames.add(result.input.sourceName);
+        }
+        expect(canonical.results.every(result => result.status === 'converted')).toBe(true);
+        expect(reversed.results.every(result => result.status === 'converted')).toBe(true);
+        expect(reversed.output).toBe(canonical.output);
+        expect(normalizedPublicResults(reversed.results)).toEqual(normalizedPublicResults(canonical.results));
+
+        const second = migrate(canonical.output, 'scoped-flex.html');
+        expect(second.output).toBe(canonical.output);
+        expect(second.editCount).toBe(0);
+      }
+    }
+
+    const expectedSourceNames = new Set(
+      scopedFlexDirectives.flatMap(([directive]) => [
+        directive,
+        ...standardAliases.map(alias => `${directive}.${alias}`),
+      ]),
+    );
+    expect(coveredSourceNames).toEqual(expectedSourceNames);
   });
 
   test('emits the same composed visibility family for equivalent attribute orders', () => {


### PR DESCRIPTION
## Summary

Extract Angular Flex Layout directive interpretation into a target-neutral `src/flex` semantic core while keeping Tailwind-specific encoding in render-only adapters.

This covers layout, layout alignment, gap, flex item sizing, align, fill, offset, and order semantics. It also removes transitional semantic re-exports and adds architecture guards plus end-to-end parity coverage for base directives and all 13 responsive aliases.

Public Tailwind output, diagnostic status/code/reason/suggestion, breakpoint authority, and CLI behavior remain unchanged.

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

Fresh verification: 80 test files and 2,347 tests passed, with formatting, ESLint, TypeScript, coverage, build, package checks, and `git diff --check` all clean.

## Migration example

Not applicable — this is an internal architecture refactor with byte-identical migration output and diagnostics.

## Dependencies and compatibility

None. No dependency, Node.js, Angular, CSS, Tailwind, CLI, or Changeset changes.