### PR TITLE
feat: establish native CSS flex renderer

### DIFF
--- a/docs/architecture/native-css-renderer.md
+++ b/docs/architecture/native-css-renderer.md
@@ -89,7 +89,7 @@ Equivalent semantics share one class and rule. Source filename, element ID, sour
 One focused renderer per semantic family maps domain values to ordered CSS declarations:
 
 - layout: `display`, `box-sizing`, `flex-direction`, and explicit wrapping behavior;
-- layout alignment: `justify-content`, `align-items`, `align-content`, and the verified stretch maximum;
+- layout alignment: `justify-content`, `align-items`, `align-content`, the active layout declarations carried by the semantic value, and the verified stretch maximum;
 - gap: `gap`;
 - flex item: `flex` shorthand when valid, otherwise ordered `flex-grow`, `flex-shrink`, and `flex-basis`, followed by the axis-dependent minimum and maximum;
 - self alignment: `align-self`;

--- a/docs/architecture/native-css-renderer.md
+++ b/docs/architecture/native-css-renderer.md
@@ -1,0 +1,206 @@
+# Native CSS Flex Renderer Foundation
+
+## Purpose
+
+This slice proves the first real consumer of the target-neutral Flex semantic core by rendering verified Flex semantics as deterministic native CSS. It establishes the in-memory contract for generated class names, declarations, media rules, ownership, deduplication, and ordering before the CLI or filesystem can select the CSS target.
+
+The slice does not expose `--target css` and does not write a stylesheet. A later slice will compose these in-memory artifacts with template edits and transactional multi-file output.
+
+## Scope
+
+The renderer covers the semantic families already owned by `src/flex`:
+
+- `fxLayout`;
+- `fxLayoutAlign`;
+- `fxLayoutGap`;
+- `fxFlex` with `fxGrow` and `fxShrink`;
+- `fxFlexAlign`;
+- `fxFlexFill` and `fxFill`;
+- `fxFlexOffset`; and
+- `fxFlexOrder`.
+
+It renders base declarations and verified standard viewport aliases. The shared `BreakpointCatalog` remains the only source of breakpoint media definitions and priority.
+
+Grid, visibility, responsive class/style, responsive images, orientation and print opt-in behavior, Tailwind conflict analysis, CLI target selection, stylesheet discovery or merging, source edits, file writes, backups, rollback, and interruption cleanup are outside this slice.
+
+## Design constraints
+
+1. `src/flex` remains target-neutral and cannot import the CSS renderer or contain generated selector syntax.
+2. The CSS renderer accepts successful semantic values. It cannot parse raw Flex-Layout attribute strings or recreate semantic diagnostics.
+3. Rendering is pure and deterministic. Equal semantic inputs and breakpoint context produce equal artifacts regardless of discovery order or process state.
+4. Class identifiers are derived from canonical semantic content, not source paths, element positions, counters, or directive spelling.
+5. Generated rules contain structured ownership metadata. The in-memory renderer does not parse or mutate an existing stylesheet.
+6. Declaration and rule ordering are explicit contracts, not incidental object or map iteration behavior.
+7. CSS output must preserve the same verified behavior as the Tailwind target; it cannot broaden conversion support merely because arbitrary CSS is available.
+
+## Components
+
+### Native CSS artifact model
+
+Modules under `src/adapter/css/` define immutable rendering artifacts:
+
+```ts
+interface CssDeclaration {
+  readonly property: string;
+  readonly value: string;
+}
+
+interface CssMediaCondition {
+  readonly type: 'screen' | 'print';
+  readonly clauses: readonly CssMediaClause[];
+}
+
+interface OwnedCssRule {
+  readonly owner: 'flex-layout-codemod';
+  readonly id: string;
+  readonly className: string;
+  readonly declarations: readonly CssDeclaration[];
+  readonly media?: CssMediaCondition;
+  readonly priority: number;
+}
+
+interface CssRenderArtifact {
+  readonly className: string;
+  readonly rule: OwnedCssRule;
+}
+```
+
+The concrete model may use narrower property and value types where that improves correctness. It must not use an untyped declaration object whose ordering depends on property insertion.
+
+An owned rule represents semantic content, not serialized stylesheet text. Serialization and ownership headers belong to the later stylesheet-output slice.
+
+### Canonical identity and class names
+
+Each rule receives a canonical identity assembled from:
+
+- a schema/version tag;
+- its semantic family;
+- declarations in the family-defined order; and
+- the normalized media definition, when present.
+
+The canonical identity is serialized with an unambiguous length-delimited or JSON representation. A stable SHA-256 digest of that identity forms the identifier. The generated class uses a reserved project prefix and the digest, for example `flm-<digest>`. It contains only CSS-identifier-safe ASCII.
+
+The complete lowercase hexadecimal digest is both the rule identifier and the class suffix: `flm-` followed by all 64 SHA-256 characters. The registry still rejects different canonical identities that receive the same digest. Tests inject the digest function so this fail-closed behavior can be proven rather than assumed.
+
+Equivalent semantics share one class and rule. Source filename, element ID, source offset, base-versus-alias directive spelling, and encounter order never affect identity.
+
+### Flex family renderers
+
+One focused renderer per semantic family maps domain values to ordered CSS declarations:
+
+- layout: `display`, `box-sizing`, `flex-direction`, and explicit wrapping behavior;
+- layout alignment: `justify-content`, `align-items`, `align-content`, and the verified stretch maximum;
+- gap: `gap`;
+- flex item: `flex` shorthand when valid, otherwise ordered `flex-grow`, `flex-shrink`, and `flex-basis`, followed by the axis-dependent minimum and maximum;
+- self alignment: `align-self`;
+- fill: margin, width, height, minimum width, and minimum height;
+- offset: logical `margin-inline-start` or `margin-block-start`;
+- order: `order`, with an absent semantic order producing no artifact.
+
+These mappings consume only semantic fields. Target-specific choices such as shorthand eligibility remain local to the CSS renderer.
+
+Family renderers do not allocate class names independently. They return an ordered declaration plan to the shared artifact registry, which canonicalizes, identifies, and deduplicates it.
+
+### Responsive media rendering
+
+Base semantics have no media condition and priority `0`. A responsive artifact accepts a verified `BreakpointDefinition` supplied from `BreakpointCatalog` and copies its normalized `media` and `priority` into the owned-rule model.
+
+Each media clause is serialized as a conjunction of its present features:
+
+- `min` becomes `(min-width: <value>px)`;
+- `max` becomes `(max-width: <value>px)`;
+- orientation becomes `(orientation: portrait|landscape)`.
+
+Multiple clauses represent comma-separated alternatives. Media feature order is minimum width, maximum width, then orientation. The renderer does not maintain its own alias table or infer breakpoint values from alias names.
+
+Only the 13 standard viewport definitions are exercised in this slice. The model is capable of representing configured definitions, but orientation and print conversion stay outside the acceptance surface until their target behavior and ordering are specified.
+
+### Registry, deduplication, and ordering
+
+A plan-local registry accepts declaration plans and returns their generated class names. It owns three invariants:
+
+1. the same canonical identity always returns the same class;
+2. different canonical identities cannot silently share a class; and
+3. each unique rule appears once in final output.
+
+Final rule order is stable:
+
+1. base rules before media rules;
+2. media rules by descending breakpoint priority, matching the existing responsive planners;
+3. canonical rule identifier as the total-order tie-breaker.
+
+No caller may depend on encounter order.
+
+## Data flow
+
+```text
+decoded literal + verified layout context
+                    |
+                    v
+          Flex semantic planner
+             /             \
+      semantic value     existing diagnostic
+             |
+             v
+       CSS family renderer
+             |
+             v
+ ordered declaration plan + optional verified breakpoint
+             |
+             v
+   canonical artifact registry
+             |
+             +----> generated template class name
+             |
+             +----> deduplicated owned CSS rule
+```
+
+This slice begins at the semantic value and ends at in-memory artifacts. Existing Tailwind adapter orchestration and source editing remain unchanged.
+
+## Errors and invariants
+
+Semantic failures never reach the renderer; callers pass them through unchanged. Rendering a well-typed semantic value should not produce a user-facing diagnostic.
+
+Internal invariant failures throw typed errors for:
+
+- a class collision between different canonical identities;
+- a malformed or non-finite media bound supplied outside catalog construction;
+- duplicate declarations for one property within a family plan; or
+- an unsupported semantic discriminant caused by an implementation mismatch.
+
+These errors indicate programming faults, not unsupported source input. The future adapter boundary will map unexpected invariant failures into the existing internal-error policy.
+
+## Testing
+
+Tests follow TDD and include:
+
+- one focused mapping suite per Flex semantic family;
+- exact declaration order and exact values for every successful semantic variant;
+- absence of output for semantic no-ops such as zero-equivalent `fxFlexOrder`;
+- deterministic identity across repeated renders and different encounter orders;
+- deduplication of equivalent semantic artifacts;
+- injected digest collisions that fail closed;
+- base and all 13 standard viewport aliases sourced through `BreakpointCatalog`;
+- exact normalized media clauses and deterministic rule order;
+- semantic parity assertions showing Tailwind and CSS renderers consume the same planner result rather than separate raw-value interpretations;
+- architecture tests preventing imports from `adapter/css` into `src/flex`, raw directive parsing inside the CSS renderer, and duplicated breakpoint tables; and
+- the complete repository verification command.
+
+Existing Tailwind compatibility fixtures must remain byte-for-byte unchanged. Because this slice has no user-visible CLI behavior, it adds no Changeset and does not alter the compatibility inventory.
+
+## Implementation sequence
+
+1. Establish the typed CSS artifact model and canonical identity registry.
+2. Add pure base renderers for layout, alignment, and gap semantics.
+3. Add flex-item and independent directive renderers.
+4. Add verified breakpoint media artifacts and stable global ordering.
+5. Add cross-target semantic parity and architecture enforcement.
+6. Remove any duplication exposed by the second renderer, then run full verification.
+
+Each step is independently reviewable and preserves the Tailwind path.
+
+## Completion criteria
+
+The slice is complete when every existing Flex semantic family can produce deterministic, deduplicated native-CSS artifacts in memory; base and all standard viewport media definitions come only from `BreakpointCatalog`; identity collision and ordering behavior are executable contracts; the Tailwind migration output remains unchanged; and no CLI or filesystem path exposes the unfinished CSS target.
+
+The next slice may then build stylesheet serialization, owned-rule merging, template integration, and transactional multi-file application on top of this stable artifact contract.

--- a/docs/architecture/native-css-renderer.md
+++ b/docs/architecture/native-css-renderer.md
@@ -91,7 +91,7 @@ One focused renderer per semantic family maps domain values to ordered CSS decla
 - layout: `display`, `box-sizing`, `flex-direction`, and explicit wrapping behavior;
 - layout alignment: `justify-content`, `align-items`, `align-content`, the active layout declarations carried by the semantic value, and the verified stretch maximum;
 - gap: `gap`;
-- flex item: `flex` shorthand when valid, otherwise ordered `flex-grow`, `flex-shrink`, and `flex-basis`, followed by the axis-dependent minimum and maximum;
+- flex item: `flex` shorthand when valid, otherwise ordered `flex-grow`, `flex-shrink`, and `flex-basis`, followed by the axis-dependent minimum and maximum, then `box-sizing`;
 - self alignment: `align-self`;
 - fill: margin, width, height, minimum width, and minimum height;
 - offset: logical `margin-inline-start` or `margin-block-start`;
@@ -127,7 +127,7 @@ Final rule order is stable:
 
 1. base rules before media rules;
 2. media rules by descending breakpoint priority, matching the existing responsive planners;
-3. canonical rule identifier as the total-order tie-breaker.
+3. canonical rule identifier in code-unit order as the total-order tie-breaker.
 
 No caller may depend on encounter order.
 
@@ -165,6 +165,7 @@ Internal invariant failures throw typed errors for:
 
 - a class collision between different canonical identities;
 - a malformed or non-finite media bound supplied outside catalog construction;
+- a non-finite rule priority or a nonzero priority without a media condition;
 - duplicate declarations for one property within a family plan; or
 - an unsupported semantic discriminant caused by an implementation mismatch.
 
@@ -176,6 +177,7 @@ Tests follow TDD and include:
 
 - one focused mapping suite per Flex semantic family;
 - exact declaration order and exact values for every successful semantic variant;
+- shared flex-item `boxSizing` semantics rendered as final `box-sizing: border-box` CSS and the existing final Tailwind `box-border` utility;
 - absence of output for semantic no-ops such as zero-equivalent `fxFlexOrder`;
 - deterministic identity across repeated renders and different encounter orders;
 - deduplication of equivalent semantic artifacts;

--- a/src/adapter/css/css-artifact.model.ts
+++ b/src/adapter/css/css-artifact.model.ts
@@ -1,0 +1,25 @@
+import type { MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+
+export interface CssDeclaration {
+  readonly property: string;
+  readonly value: string;
+}
+
+export interface CssRuleContext {
+  readonly priority: number;
+  readonly media?: MediaDefinition;
+}
+
+export type CssSemanticFamily =
+  'layout' | 'layout-align' | 'layout-gap' | 'flex-item' | 'flex-align' | 'flex-fill' | 'flex-offset' | 'flex-order';
+
+export interface OwnedCssRule {
+  readonly owner: 'flex-layout-codemod';
+  readonly id: string;
+  readonly className: string;
+  readonly family: CssSemanticFamily;
+  readonly declarations: readonly CssDeclaration[];
+  readonly context: CssRuleContext;
+}
+
+export type CssDigest = (canonicalIdentity: string) => string;

--- a/src/adapter/css/css-artifact.registry.spec.ts
+++ b/src/adapter/css/css-artifact.registry.spec.ts
@@ -1,4 +1,5 @@
-import type { MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+import { BreakpointCatalog, type MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+import { cssRuleContext } from './css-breakpoint.context';
 import { CssInvariantError } from './css-invariant.error';
 import { CssArtifactRegistry } from './css-artifact.registry';
 
@@ -54,6 +55,22 @@ describe('CssArtifactRegistry', () => {
 
     expect(responsive.className).not.toBe(base.className);
     expect(responsive.context).toEqual({ media: viewportMedia, priority: 900 });
+  });
+
+  test('accepts a defensive context copied from a verified breakpoint definition', () => {
+    const breakpoint = new BreakpointCatalog().classify('sm');
+    if (breakpoint.kind !== 'verified') throw new Error('Expected sm to be verified');
+
+    const rule = new CssArtifactRegistry().register(
+      'layout-gap',
+      [{ property: 'gap', value: '1rem' }],
+      cssRuleContext(breakpoint.definition),
+    );
+
+    expect(rule.context).toEqual({
+      priority: 900,
+      media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] },
+    });
   });
 
   test('deduplicates equivalent rules by canonical identity', () => {

--- a/src/adapter/css/css-artifact.registry.spec.ts
+++ b/src/adapter/css/css-artifact.registry.spec.ts
@@ -133,6 +133,28 @@ describe('CssArtifactRegistry', () => {
     },
   );
 
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects a non-finite rule priority of %s',
+    priority => {
+      const registry = new CssArtifactRegistry();
+
+      expect(() =>
+        registry.register('layout-gap', [{ property: 'gap', value: '1rem' }], {
+          priority,
+          media: viewportMedia,
+        }),
+      ).toThrow(CssInvariantError);
+    },
+  );
+
+  test.each([-1, 1])('rejects a base rule with nonzero priority %s', priority => {
+    const registry = new CssArtifactRegistry();
+
+    expect(() => registry.register('layout-gap', [{ property: 'gap', value: '1rem' }], { priority })).toThrow(
+      CssInvariantError,
+    );
+  });
+
   test('rejects malformed digest output', () => {
     const registry = new CssArtifactRegistry(() => 'not-a-sha256-digest');
 

--- a/src/adapter/css/css-artifact.registry.spec.ts
+++ b/src/adapter/css/css-artifact.registry.spec.ts
@@ -1,0 +1,133 @@
+import type { MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+import { CssInvariantError } from './css-invariant.error';
+import { CssArtifactRegistry } from './css-artifact.registry';
+
+const viewportMedia: MediaDefinition = {
+  type: 'screen',
+  clauses: [{ min: 600, max: 959.98, orientation: 'landscape' }],
+};
+
+describe('CssArtifactRegistry', () => {
+  test('registers a base rule with the canonical SHA-256 class name', () => {
+    const rule = new CssArtifactRegistry().register('layout', [{ property: 'display', value: 'flex' }]);
+
+    expect(rule).toEqual({
+      owner: 'flex-layout-codemod',
+      id: 'adfe22f4b447241ec535540d3638405b3d08ee49fda39beaf07563e450256a61',
+      className: 'flm-adfe22f4b447241ec535540d3638405b3d08ee49fda39beaf07563e450256a61',
+      family: 'layout',
+      declarations: [{ property: 'display', value: 'flex' }],
+      context: { priority: 0 },
+    });
+    expect(rule.className).toMatch(/^flm-[a-f0-9]{64}$/);
+  });
+
+  test('keeps canonical identities stable across registry instances', () => {
+    const declarations = [{ property: 'display', value: 'flex' }] as const;
+    const first = new CssArtifactRegistry().register('layout', declarations);
+    const second = new CssArtifactRegistry().register('layout', declarations);
+
+    expect(second).toEqual(first);
+  });
+
+  test('treats declaration order as part of a rule identity', () => {
+    const registry = new CssArtifactRegistry();
+    const first = registry.register('layout', [
+      { property: 'display', value: 'flex' },
+      { property: 'flex-direction', value: 'row' },
+    ]);
+    const second = registry.register('layout', [
+      { property: 'flex-direction', value: 'row' },
+      { property: 'display', value: 'flex' },
+    ]);
+
+    expect(second.className).not.toBe(first.className);
+  });
+
+  test('treats normalized media and priority as part of a rule identity', () => {
+    const registry = new CssArtifactRegistry();
+    const base = registry.register('layout-gap', [{ property: 'gap', value: '1rem' }]);
+    const responsive = registry.register('layout-gap', [{ property: 'gap', value: '1rem' }], {
+      media: viewportMedia,
+      priority: 900,
+    });
+
+    expect(responsive.className).not.toBe(base.className);
+    expect(responsive.context).toEqual({ media: viewportMedia, priority: 900 });
+  });
+
+  test('deduplicates equivalent rules by canonical identity', () => {
+    const registry = new CssArtifactRegistry();
+    const first = registry.register('layout', [{ property: 'display', value: 'flex' }]);
+    const second = registry.register('layout', [{ property: 'display', value: 'flex' }]);
+
+    expect(second).toBe(first);
+    expect(registry.rules()).toEqual([first]);
+  });
+
+  test('defensively copies and freezes registered artifacts', () => {
+    const declarations = [{ property: 'gap', value: '1rem' }];
+    const media = { type: 'screen' as const, clauses: [{ min: 600 }] };
+    const context = { priority: 900, media };
+    const registry = new CssArtifactRegistry();
+    const rule = registry.register('layout-gap', declarations, context);
+    const snapshot = registry.rules();
+
+    declarations[0]!.value = '2rem';
+    media.clauses[0]!.min = 700;
+    context.priority = 0;
+
+    expect(rule).toMatchObject({
+      declarations: [{ property: 'gap', value: '1rem' }],
+      context: { priority: 900, media: { type: 'screen', clauses: [{ min: 600 }] } },
+    });
+    expect(Object.isFrozen(rule)).toBe(true);
+    expect(Object.isFrozen(rule.declarations)).toBe(true);
+    expect(Object.isFrozen(rule.declarations[0])).toBe(true);
+    expect(Object.isFrozen(rule.context)).toBe(true);
+    expect(Object.isFrozen(rule.context.media)).toBe(true);
+    expect(Object.isFrozen(rule.context.media?.clauses)).toBe(true);
+    expect(Object.isFrozen(rule.context.media?.clauses[0])).toBe(true);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+
+  test('rejects duplicate declaration properties', () => {
+    const registry = new CssArtifactRegistry();
+
+    expect(() =>
+      registry.register('layout', [
+        { property: 'display', value: 'flex' },
+        { property: 'display', value: 'inline-flex' },
+      ]),
+    ).toThrow(CssInvariantError);
+  });
+
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects a non-finite media bound of %s',
+    bound => {
+      const registry = new CssArtifactRegistry();
+
+      expect(() =>
+        registry.register('layout-gap', [{ property: 'gap', value: '1rem' }], {
+          priority: 900,
+          media: { type: 'screen', clauses: [{ min: bound }] },
+        }),
+      ).toThrow(CssInvariantError);
+    },
+  );
+
+  test('rejects malformed digest output', () => {
+    const registry = new CssArtifactRegistry(() => 'not-a-sha256-digest');
+
+    expect(() => registry.register('layout', [{ property: 'display', value: 'flex' }])).toThrow(CssInvariantError);
+  });
+
+  test('rejects a digest collision between different canonical identities', () => {
+    const registry = new CssArtifactRegistry(() => 'a'.repeat(64));
+    const first = registry.register('layout', [{ property: 'display', value: 'flex' }]);
+
+    expect(first.className).toBe(`flm-${'a'.repeat(64)}`);
+    expect(registry.register('layout', [{ property: 'display', value: 'flex' }])).toBe(first);
+    expect(() => registry.register('layout-gap', [{ property: 'gap', value: '1rem' }])).toThrow(CssInvariantError);
+  });
+});

--- a/src/adapter/css/css-artifact.registry.ts
+++ b/src/adapter/css/css-artifact.registry.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { MediaDefinition } from '../../breakpoint/breakpoint-catalog';
 import { CssInvariantError } from './css-invariant.error';
 import type { CssDeclaration, CssDigest, CssRuleContext, CssSemanticFamily, OwnedCssRule } from './css-artifact.model';
+import { compareOwnedCssRules } from './css-rule-order';
 
 const SHA_256_DIGEST = /^[a-f0-9]{64}$/;
 
@@ -121,6 +122,6 @@ export class CssArtifactRegistry {
   }
 
   rules(): readonly OwnedCssRule[] {
-    return Object.freeze([...this.registeredRules]);
+    return Object.freeze([...this.registeredRules].sort(compareOwnedCssRules));
   }
 }

--- a/src/adapter/css/css-artifact.registry.ts
+++ b/src/adapter/css/css-artifact.registry.ts
@@ -47,7 +47,14 @@ function freezeMedia(media: MediaDefinition): MediaDefinition {
 }
 
 function freezeContext(context: CssRuleContext): CssRuleContext {
+  if (!Number.isFinite(context.priority)) {
+    throw new CssInvariantError('CSS rule priority must be a finite number');
+  }
+
   if (context.media === undefined) {
+    if (context.priority !== 0) {
+      throw new CssInvariantError('CSS base rules must have priority 0');
+    }
     return Object.freeze({ priority: context.priority });
   }
 

--- a/src/adapter/css/css-artifact.registry.ts
+++ b/src/adapter/css/css-artifact.registry.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+
+import type { MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+import { CssInvariantError } from './css-invariant.error';
+import type { CssDeclaration, CssDigest, CssRuleContext, CssSemanticFamily, OwnedCssRule } from './css-artifact.model';
+
+const SHA_256_DIGEST = /^[a-f0-9]{64}$/;
+
+function sha256(canonicalIdentity: string): string {
+  return createHash('sha256').update(canonicalIdentity, 'utf8').digest('hex');
+}
+
+function freezeDeclarations(declarations: readonly CssDeclaration[]): readonly CssDeclaration[] {
+  const properties = new Set<string>();
+
+  for (const declaration of declarations) {
+    if (properties.has(declaration.property)) {
+      throw new CssInvariantError(`Duplicate CSS declaration property: ${declaration.property}`);
+    }
+    properties.add(declaration.property);
+  }
+
+  return Object.freeze(declarations.map(declaration => Object.freeze({ ...declaration })));
+}
+
+function assertFiniteMediaBounds(media: MediaDefinition): void {
+  for (const clause of media.clauses) {
+    for (const bound of [clause.min, clause.max]) {
+      if (bound !== undefined && !Number.isFinite(bound)) {
+        throw new CssInvariantError('CSS media bounds must be finite numbers');
+      }
+    }
+
+    if (clause.min !== undefined && clause.max !== undefined && clause.min > clause.max) {
+      throw new CssInvariantError('CSS media minimum bound must not exceed its maximum bound');
+    }
+  }
+}
+
+function freezeMedia(media: MediaDefinition): MediaDefinition {
+  assertFiniteMediaBounds(media);
+  return Object.freeze({
+    type: media.type,
+    clauses: Object.freeze(media.clauses.map(clause => Object.freeze({ ...clause }))),
+  });
+}
+
+function freezeContext(context: CssRuleContext): CssRuleContext {
+  if (context.media === undefined) {
+    return Object.freeze({ priority: context.priority });
+  }
+
+  return Object.freeze({ priority: context.priority, media: freezeMedia(context.media) });
+}
+
+function canonicalIdentity(
+  family: CssSemanticFamily,
+  declarations: readonly CssDeclaration[],
+  context: CssRuleContext,
+): string {
+  return JSON.stringify({
+    schema: 1,
+    family,
+    declarations: declarations.map(({ property, value }) => [property, value]),
+    media: context.media
+      ? {
+          type: context.media.type,
+          clauses: context.media.clauses.map(({ min, max, orientation }) => [
+            min ?? null,
+            max ?? null,
+            orientation ?? null,
+          ]),
+        }
+      : null,
+    priority: context.priority,
+  });
+}
+
+export class CssArtifactRegistry {
+  private readonly rulesByCanonicalIdentity = new Map<string, OwnedCssRule>();
+  private readonly canonicalIdentityByDigest = new Map<string, string>();
+  private readonly registeredRules: OwnedCssRule[] = [];
+
+  constructor(private readonly digest: CssDigest = sha256) {}
+
+  register(
+    family: CssSemanticFamily,
+    declarations: readonly CssDeclaration[],
+    context: CssRuleContext = { priority: 0 },
+  ): OwnedCssRule {
+    const frozenDeclarations = freezeDeclarations(declarations);
+    const frozenContext = freezeContext(context);
+    const identity = canonicalIdentity(family, frozenDeclarations, frozenContext);
+    const existingRule = this.rulesByCanonicalIdentity.get(identity);
+
+    if (existingRule) return existingRule;
+
+    const id = this.digest(identity);
+    if (!SHA_256_DIGEST.test(id)) {
+      throw new CssInvariantError('CSS artifact digest must be a 64-character lowercase hexadecimal SHA-256 value');
+    }
+
+    const collidingIdentity = this.canonicalIdentityByDigest.get(id);
+    if (collidingIdentity !== undefined && collidingIdentity !== identity) {
+      throw new CssInvariantError('Distinct CSS artifact identities must not share a digest');
+    }
+
+    const rule: OwnedCssRule = Object.freeze({
+      owner: 'flex-layout-codemod',
+      id,
+      className: `flm-${id}`,
+      family,
+      declarations: frozenDeclarations,
+      context: frozenContext,
+    });
+
+    this.rulesByCanonicalIdentity.set(identity, rule);
+    this.canonicalIdentityByDigest.set(id, identity);
+    this.registeredRules.push(rule);
+    return rule;
+  }
+
+  rules(): readonly OwnedCssRule[] {
+    return Object.freeze([...this.registeredRules]);
+  }
+}

--- a/src/adapter/css/css-breakpoint.context.spec.ts
+++ b/src/adapter/css/css-breakpoint.context.spec.ts
@@ -1,0 +1,48 @@
+import { BreakpointCatalog, type BreakpointDefinition } from '../../breakpoint/breakpoint-catalog';
+import { cssRuleContext } from './css-breakpoint.context';
+
+const aliases = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'lt-sm',
+  'lt-md',
+  'lt-lg',
+  'lt-xl',
+  'gt-xs',
+  'gt-sm',
+  'gt-md',
+  'gt-lg',
+] as const;
+
+function verifiedDefinition(alias: (typeof aliases)[number]): BreakpointDefinition {
+  const classification = new BreakpointCatalog().classify(alias);
+
+  if (classification.kind !== 'verified') {
+    throw new Error(`Expected ${alias} to be a verified breakpoint`);
+  }
+
+  return classification.definition;
+}
+
+describe('cssRuleContext', () => {
+  test('returns the base rule context', () => {
+    expect(cssRuleContext()).toEqual({ priority: 0 });
+  });
+
+  test.each(aliases)('copies the exact verified %s media definition and priority', alias => {
+    const definition = verifiedDefinition(alias);
+    const context = cssRuleContext(definition);
+
+    expect(context).toEqual({ media: definition.media, priority: definition.priority });
+    expect(context.media).not.toBe(definition.media);
+    expect(context.media?.clauses).not.toBe(definition.media.clauses);
+    expect(context.media?.clauses[0]).not.toBe(definition.media.clauses[0]);
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context.media)).toBe(true);
+    expect(Object.isFrozen(context.media?.clauses)).toBe(true);
+    expect(Object.isFrozen(context.media?.clauses[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/css-breakpoint.context.ts
+++ b/src/adapter/css/css-breakpoint.context.ts
@@ -1,0 +1,17 @@
+import type { BreakpointDefinition, MediaDefinition } from '../../breakpoint/breakpoint-catalog';
+import type { CssRuleContext } from './css-artifact.model';
+
+function copyMedia(media: MediaDefinition): MediaDefinition {
+  return Object.freeze({
+    type: media.type,
+    clauses: Object.freeze(media.clauses.map(clause => Object.freeze({ ...clause }))),
+  });
+}
+
+export function cssRuleContext(definition?: BreakpointDefinition): CssRuleContext {
+  if (definition === undefined) {
+    return Object.freeze({ priority: 0 });
+  }
+
+  return Object.freeze({ priority: definition.priority, media: copyMedia(definition.media) });
+}

--- a/src/adapter/css/css-invariant.error.ts
+++ b/src/adapter/css/css-invariant.error.ts
@@ -1,0 +1,6 @@
+export class CssInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CssInvariantError';
+  }
+}

--- a/src/adapter/css/css-rule-order.spec.ts
+++ b/src/adapter/css/css-rule-order.spec.ts
@@ -98,6 +98,20 @@ describe('compareOwnedCssRules', () => {
     ]);
   });
 
+  test('uses code-unit ordering rather than locale collation for identifier ties', () => {
+    const uppercase: OwnedCssRule = {
+      owner: 'flex-layout-codemod',
+      id: 'Z',
+      className: 'flm-Z',
+      family: 'layout-gap',
+      declarations: [{ property: 'gap', value: '1rem' }],
+      context: { priority: 0 },
+    };
+    const lowercase: OwnedCssRule = { ...uppercase, id: 'a', className: 'flm-a' };
+
+    expect([lowercase, uppercase].sort(compareOwnedCssRules).map(rule => rule.id)).toEqual(['Z', 'a']);
+  });
+
   test('returns a frozen ordered array without changing future registry results', () => {
     const registry = registerRules(['responsive-low', 'base-zeta', 'base-alpha']);
     const rules = registry.rules();

--- a/src/adapter/css/css-rule-order.spec.ts
+++ b/src/adapter/css/css-rule-order.spec.ts
@@ -1,0 +1,109 @@
+import type { OwnedCssRule } from './css-artifact.model';
+import { CssArtifactRegistry } from './css-artifact.registry';
+import { compareOwnedCssRules } from './css-rule-order';
+
+const ids = {
+  baseAlpha: 'a'.repeat(64),
+  baseZeta: 'b'.repeat(64),
+  responsiveLow: 'c'.repeat(64),
+  responsiveFirst: 'd'.repeat(64),
+  responsiveSecond: 'e'.repeat(64),
+  responsiveHigh: 'f'.repeat(64),
+} as const;
+
+function digestFor(canonicalIdentity: string): string {
+  if (canonicalIdentity.includes('base-alpha')) return ids.baseAlpha;
+  if (canonicalIdentity.includes('base-zeta')) return ids.baseZeta;
+  if (canonicalIdentity.includes('responsive-low')) return ids.responsiveLow;
+  if (canonicalIdentity.includes('responsive-first')) return ids.responsiveFirst;
+  if (canonicalIdentity.includes('responsive-second')) return ids.responsiveSecond;
+  if (canonicalIdentity.includes('responsive-high')) return ids.responsiveHigh;
+  throw new Error(`Unexpected canonical identity: ${canonicalIdentity}`);
+}
+
+function registerRules(order: readonly string[]) {
+  const registry = new CssArtifactRegistry(digestFor);
+  const register = (value: string, context?: Parameters<CssArtifactRegistry['register']>[2]) =>
+    registry.register('layout-gap', [{ property: 'gap', value }], context);
+  const definitions = {
+    'base-alpha': () => register('base-alpha'),
+    'base-zeta': () => register('base-zeta'),
+    'responsive-low': () =>
+      register('responsive-low', { priority: 800, media: { type: 'screen', clauses: [{ min: 960 }] } }),
+    'responsive-first': () =>
+      register('responsive-first', { priority: 900, media: { type: 'screen', clauses: [{ min: 600 }] } }),
+    'responsive-second': () =>
+      register('responsive-second', { priority: 900, media: { type: 'screen', clauses: [{ min: 600 }] } }),
+    'responsive-high': () =>
+      register('responsive-high', { priority: 1000, media: { type: 'screen', clauses: [{ max: 599.98 }] } }),
+  } as const;
+
+  order.forEach(key => definitions[key as keyof typeof definitions]());
+  return registry;
+}
+
+describe('compareOwnedCssRules', () => {
+  test('orders base rules first, then descending priority, then identifier', () => {
+    const registry = registerRules([
+      'responsive-low',
+      'responsive-second',
+      'base-zeta',
+      'responsive-high',
+      'base-alpha',
+      'responsive-first',
+    ]);
+
+    expect(registry.rules().map(rule => rule.id)).toEqual([
+      ids.baseAlpha,
+      ids.baseZeta,
+      ids.responsiveHigh,
+      ids.responsiveFirst,
+      ids.responsiveSecond,
+      ids.responsiveLow,
+    ]);
+  });
+
+  test.each([
+    [['base-alpha', 'responsive-high', 'responsive-second', 'responsive-low', 'base-zeta', 'responsive-first']],
+    [['responsive-first', 'base-zeta', 'responsive-low', 'responsive-high', 'base-alpha', 'responsive-second']],
+  ] as const)('does not use registration order for %j', order => {
+    expect(
+      registerRules(order)
+        .rules()
+        .map(rule => rule.id),
+    ).toEqual([
+      ids.baseAlpha,
+      ids.baseZeta,
+      ids.responsiveHigh,
+      ids.responsiveFirst,
+      ids.responsiveSecond,
+      ids.responsiveLow,
+    ]);
+  });
+
+  test('uses the digest as a deterministic tie-breaker for equal priority and declarations', () => {
+    const first: OwnedCssRule = {
+      owner: 'flex-layout-codemod',
+      id: ids.responsiveSecond,
+      className: `flm-${ids.responsiveSecond}`,
+      family: 'layout-gap',
+      declarations: [{ property: 'gap', value: '1rem' }],
+      context: { priority: 900, media: { type: 'screen', clauses: [{ min: 600 }] } },
+    };
+    const second: OwnedCssRule = { ...first, id: ids.responsiveFirst, className: `flm-${ids.responsiveFirst}` };
+
+    expect([first, second].sort(compareOwnedCssRules).map(rule => rule.id)).toEqual([
+      ids.responsiveFirst,
+      ids.responsiveSecond,
+    ]);
+  });
+
+  test('returns a frozen ordered array without changing future registry results', () => {
+    const registry = registerRules(['responsive-low', 'base-zeta', 'base-alpha']);
+    const rules = registry.rules();
+
+    expect(Object.isFrozen(rules)).toBe(true);
+    expect(rules.map(rule => rule.id)).toEqual([ids.baseAlpha, ids.baseZeta, ids.responsiveLow]);
+    expect(registry.rules().map(rule => rule.id)).toEqual([ids.baseAlpha, ids.baseZeta, ids.responsiveLow]);
+  });
+});

--- a/src/adapter/css/css-rule-order.ts
+++ b/src/adapter/css/css-rule-order.ts
@@ -1,8 +1,9 @@
 import type { OwnedCssRule } from './css-artifact.model';
+import { compareCodeUnits } from '../../util/compare-code-units';
 
 export function compareOwnedCssRules(left: OwnedCssRule, right: OwnedCssRule): number {
   const baseOrder = Number(left.context.media !== undefined) - Number(right.context.media !== undefined);
   if (baseOrder !== 0) return baseOrder;
   const priorityOrder = right.context.priority - left.context.priority;
-  return priorityOrder || left.id.localeCompare(right.id);
+  return priorityOrder || compareCodeUnits(left.id, right.id);
 }

--- a/src/adapter/css/css-rule-order.ts
+++ b/src/adapter/css/css-rule-order.ts
@@ -1,0 +1,8 @@
+import type { OwnedCssRule } from './css-artifact.model';
+
+export function compareOwnedCssRules(left: OwnedCssRule, right: OwnedCssRule): number {
+  const baseOrder = Number(left.context.media !== undefined) - Number(right.context.media !== undefined);
+  if (baseOrder !== 0) return baseOrder;
+  const priorityOrder = right.context.priority - left.context.priority;
+  return priorityOrder || left.id.localeCompare(right.id);
+}

--- a/src/adapter/css/flex/flex-align.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-align.css-renderer.spec.ts
@@ -1,0 +1,32 @@
+import { planFlexAlignSemantics } from '../../../flex/flex-align.semantic';
+import { renderFlexAlignCss } from './flex-align.css-renderer';
+
+describe('renderFlexAlignCss', () => {
+  test.each([
+    ['auto', 'auto'],
+    ['start', 'flex-start'],
+    ['end', 'flex-end'],
+    ['center', 'center'],
+    ['baseline', 'baseline'],
+    ['stretch', 'stretch'],
+  ] as const)('renders %j self alignment as %j', (source, expectedValue) => {
+    const planned = planFlexAlignSemantics(source);
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex alignment semantic value');
+
+    expect(renderFlexAlignCss(planned.value)).toEqual([{ property: 'align-self', value: expectedValue }]);
+  });
+
+  test('returns immutable self alignment declarations', () => {
+    const planned = planFlexAlignSemantics('start');
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex alignment semantic value');
+
+    const declarations = renderFlexAlignCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/flex-align.css-renderer.ts
+++ b/src/adapter/css/flex/flex-align.css-renderer.ts
@@ -1,0 +1,15 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { FlexAlignSemantics, FlexSelfAlignment } from '../../../flex/flex-align.semantic';
+
+const alignmentValues: Readonly<Record<FlexSelfAlignment, CssDeclaration['value']>> = {
+  auto: 'auto',
+  start: 'flex-start',
+  end: 'flex-end',
+  center: 'center',
+  baseline: 'baseline',
+  stretch: 'stretch',
+};
+
+export function renderFlexAlignCss(value: FlexAlignSemantics): readonly CssDeclaration[] {
+  return Object.freeze([Object.freeze({ property: 'align-self', value: alignmentValues[value.alignment] })]);
+}

--- a/src/adapter/css/flex/flex-fill.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-fill.css-renderer.spec.ts
@@ -1,0 +1,31 @@
+import { planFlexFillSemantics } from '../../../flex/flex-fill.semantic';
+import { renderFlexFillCss } from './flex-fill.css-renderer';
+
+describe('renderFlexFillCss', () => {
+  test('renders verified fill semantics in the CSS family order', () => {
+    const planned = planFlexFillSemantics();
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex fill semantic value');
+
+    expect(renderFlexFillCss(planned.value)).toEqual([
+      { property: 'margin', value: '0' },
+      { property: 'width', value: '100%' },
+      { property: 'height', value: '100%' },
+      { property: 'min-width', value: '100%' },
+      { property: 'min-height', value: '100%' },
+    ]);
+  });
+
+  test('returns immutable fill declarations', () => {
+    const planned = planFlexFillSemantics();
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex fill semantic value');
+
+    const declarations = renderFlexFillCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/flex-fill.css-renderer.ts
+++ b/src/adapter/css/flex/flex-fill.css-renderer.ts
@@ -1,0 +1,16 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { FlexFillSemantics } from '../../../flex/flex-fill.semantic';
+
+function freezeDeclarations(declarations: readonly CssDeclaration[]): readonly CssDeclaration[] {
+  return Object.freeze(declarations.map(declaration => Object.freeze({ ...declaration })));
+}
+
+export function renderFlexFillCss(value: FlexFillSemantics): readonly CssDeclaration[] {
+  return freezeDeclarations([
+    { property: 'margin', value: value.margin },
+    { property: 'width', value: value.width },
+    { property: 'height', value: value.height },
+    { property: 'min-width', value: value.minWidth },
+    { property: 'min-height', value: value.minHeight },
+  ]);
+}

--- a/src/adapter/css/flex/flex-item.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-item.css-renderer.spec.ts
@@ -1,0 +1,82 @@
+import { planFlexItemSemantics } from '../../../flex/flex-item.semantic';
+import { renderFlexItemCss } from './flex-item.css-renderer';
+
+describe('renderFlexItemCss', () => {
+  test.each([
+    [
+      { basis: '3 2 calc(100% - 2rem)', layout: 'row' },
+      [
+        { property: 'flex-grow', value: '3' },
+        { property: 'flex-shrink', value: '2' },
+        { property: 'flex-basis', value: 'calc(100% - 2rem)' },
+        { property: 'min-width', value: 'calc(100% - 2rem)' },
+      ],
+    ],
+    [
+      { basis: '0 0 calc(50% - 1rem)', layout: 'column wrap' },
+      [
+        { property: 'flex-grow', value: '0' },
+        { property: 'flex-shrink', value: '0' },
+        { property: 'flex-basis', value: 'calc(50% - 1rem)' },
+        { property: 'min-height', value: 'calc(50% - 1rem)' },
+        { property: 'max-height', value: 'calc(50% - 1rem)' },
+      ],
+    ],
+    [{ basis: 'auto', layout: 'row' }, [{ property: 'flex', value: '1 1 auto' }]],
+    [{ basis: '', layout: 'row' }, [{ property: 'flex', value: '1 1 0%' }]],
+    [{ basis: '', layout: 'column' }, [{ property: 'flex', value: '1 1 0.000000001px' }]],
+    [
+      { basis: '0 0 10rem', layout: 'row' },
+      [
+        { property: 'flex', value: '0 0 10rem' },
+        { property: 'min-width', value: '10rem' },
+        { property: 'max-width', value: '10rem' },
+      ],
+    ],
+    [
+      { basis: '12px', layout: 'column' },
+      [
+        { property: 'flex', value: '1 1 12px' },
+        { property: 'min-height', value: '12px' },
+        { property: 'max-height', value: '12px' },
+      ],
+    ],
+    [
+      { basis: '25%', layout: 'row wrap' },
+      [
+        { property: 'flex', value: '1 1 25%' },
+        { property: 'max-width', value: '25%' },
+      ],
+    ],
+    [{ basis: 'initial', layout: 'row' }, [{ property: 'flex', value: '0 1 auto' }]],
+    [{ basis: 'nogrow', layout: 'row' }, [{ property: 'flex', value: '0 1 auto' }]],
+    [
+      { basis: 'grow', layout: 'row' },
+      [
+        { property: 'flex', value: '1 1 100%' },
+        { property: 'max-width', value: '100%' },
+      ],
+    ],
+    [{ basis: 'noshrink', layout: 'row' }, [{ property: 'flex', value: '1 0 auto' }]],
+    [{ basis: 'none', layout: 'row' }, [{ property: 'flex', value: '0 0 auto' }]],
+  ] as const)('renders verified item semantics from %o as ordered native CSS declarations', (input, expected) => {
+    const planned = planFlexItemSemantics(input);
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex item semantic value');
+
+    expect(renderFlexItemCss(planned.value)).toEqual(expected);
+  });
+
+  test('returns immutable flex item declarations', () => {
+    const planned = planFlexItemSemantics({ basis: '12px', layout: 'column' });
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex item semantic value');
+
+    const declarations = renderFlexItemCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/flex-item.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-item.css-renderer.spec.ts
@@ -10,6 +10,7 @@ describe('renderFlexItemCss', () => {
         { property: 'flex-shrink', value: '2' },
         { property: 'flex-basis', value: 'calc(100% - 2rem)' },
         { property: 'min-width', value: 'calc(100% - 2rem)' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
     [
@@ -20,17 +21,37 @@ describe('renderFlexItemCss', () => {
         { property: 'flex-basis', value: 'calc(50% - 1rem)' },
         { property: 'min-height', value: 'calc(50% - 1rem)' },
         { property: 'max-height', value: 'calc(50% - 1rem)' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
-    [{ basis: 'auto', layout: 'row' }, [{ property: 'flex', value: '1 1 auto' }]],
-    [{ basis: '', layout: 'row' }, [{ property: 'flex', value: '1 1 0%' }]],
-    [{ basis: '', layout: 'column' }, [{ property: 'flex', value: '1 1 0.000000001px' }]],
+    [
+      { basis: 'auto', layout: 'row' },
+      [
+        { property: 'flex', value: '1 1 auto' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
+    [
+      { basis: '', layout: 'row' },
+      [
+        { property: 'flex', value: '1 1 0%' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
+    [
+      { basis: '', layout: 'column' },
+      [
+        { property: 'flex', value: '1 1 0.000000001px' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
     [
       { basis: '0 0 10rem', layout: 'row' },
       [
         { property: 'flex', value: '0 0 10rem' },
         { property: 'min-width', value: '10rem' },
         { property: 'max-width', value: '10rem' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
     [
@@ -39,6 +60,7 @@ describe('renderFlexItemCss', () => {
         { property: 'flex', value: '1 1 12px' },
         { property: 'min-height', value: '12px' },
         { property: 'max-height', value: '12px' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
     [
@@ -46,19 +68,45 @@ describe('renderFlexItemCss', () => {
       [
         { property: 'flex', value: '1 1 25%' },
         { property: 'max-width', value: '25%' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
-    [{ basis: 'initial', layout: 'row' }, [{ property: 'flex', value: '0 1 auto' }]],
-    [{ basis: 'nogrow', layout: 'row' }, [{ property: 'flex', value: '0 1 auto' }]],
+    [
+      { basis: 'initial', layout: 'row' },
+      [
+        { property: 'flex', value: '0 1 auto' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
+    [
+      { basis: 'nogrow', layout: 'row' },
+      [
+        { property: 'flex', value: '0 1 auto' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
     [
       { basis: 'grow', layout: 'row' },
       [
         { property: 'flex', value: '1 1 100%' },
         { property: 'max-width', value: '100%' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
-    [{ basis: 'noshrink', layout: 'row' }, [{ property: 'flex', value: '1 0 auto' }]],
-    [{ basis: 'none', layout: 'row' }, [{ property: 'flex', value: '0 0 auto' }]],
+    [
+      { basis: 'noshrink', layout: 'row' },
+      [
+        { property: 'flex', value: '1 0 auto' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
+    [
+      { basis: 'none', layout: 'row' },
+      [
+        { property: 'flex', value: '0 0 auto' },
+        { property: 'box-sizing', value: 'border-box' },
+      ],
+    ],
   ] as const)('renders verified item semantics from %o as ordered native CSS declarations', (input, expected) => {
     const planned = planFlexItemSemantics(input);
 

--- a/src/adapter/css/flex/flex-item.css-renderer.ts
+++ b/src/adapter/css/flex/flex-item.css-renderer.ts
@@ -1,0 +1,23 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { FlexItemSemantics } from '../../../flex/flex-item.semantic';
+
+function freezeDeclarations(declarations: readonly CssDeclaration[]): readonly CssDeclaration[] {
+  return Object.freeze(declarations.map(declaration => Object.freeze({ ...declaration })));
+}
+
+export function renderFlexItemCss(value: FlexItemSemantics): readonly CssDeclaration[] {
+  const flexDeclarations =
+    value.basis.kind === 'computed'
+      ? [
+          { property: 'flex-grow', value: value.grow },
+          { property: 'flex-shrink', value: value.shrink },
+          { property: 'flex-basis', value: value.basis.value },
+        ]
+      : [{ property: 'flex', value: `${value.grow} ${value.shrink} ${value.basis.value}` }];
+
+  return freezeDeclarations([
+    ...flexDeclarations,
+    ...(value.min ? [{ property: `min-${value.axis}`, value: value.min }] : []),
+    ...(value.max ? [{ property: `max-${value.axis}`, value: value.max }] : []),
+  ]);
+}

--- a/src/adapter/css/flex/flex-item.css-renderer.ts
+++ b/src/adapter/css/flex/flex-item.css-renderer.ts
@@ -19,5 +19,6 @@ export function renderFlexItemCss(value: FlexItemSemantics): readonly CssDeclara
     ...flexDeclarations,
     ...(value.min ? [{ property: `min-${value.axis}`, value: value.min }] : []),
     ...(value.max ? [{ property: `max-${value.axis}`, value: value.max }] : []),
+    { property: 'box-sizing', value: value.boxSizing },
   ]);
 }

--- a/src/adapter/css/flex/flex-offset.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-offset.css-renderer.spec.ts
@@ -1,0 +1,28 @@
+import { planFlexOffsetSemantics } from '../../../flex/flex-offset.semantic';
+import { renderFlexOffsetCss } from './flex-offset.css-renderer';
+
+describe('renderFlexOffsetCss', () => {
+  test.each([
+    ['10px', 'row', [{ property: 'margin-inline-start', value: '10px' }]],
+    ['2rem', 'column', [{ property: 'margin-block-start', value: '2rem' }]],
+  ] as const)('renders %j on the verified %j axis', (source, layout, expected) => {
+    const planned = planFlexOffsetSemantics(source, layout);
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex offset semantic value');
+
+    expect(renderFlexOffsetCss(planned.value)).toEqual(expected);
+  });
+
+  test('returns immutable offset declarations', () => {
+    const planned = planFlexOffsetSemantics('10px', 'row');
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned flex offset semantic value');
+
+    const declarations = renderFlexOffsetCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/flex-offset.css-renderer.ts
+++ b/src/adapter/css/flex/flex-offset.css-renderer.ts
@@ -1,0 +1,11 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { FlexOffsetSemantics } from '../../../flex/flex-offset.semantic';
+
+const propertyByAxis: Readonly<Record<FlexOffsetSemantics['axis'], CssDeclaration['property']>> = {
+  'inline-start': 'margin-inline-start',
+  'block-start': 'margin-block-start',
+};
+
+export function renderFlexOffsetCss(value: FlexOffsetSemantics): readonly CssDeclaration[] {
+  return Object.freeze([Object.freeze({ property: propertyByAxis[value.axis], value: value.length })]);
+}

--- a/src/adapter/css/flex/flex-order.css-renderer.spec.ts
+++ b/src/adapter/css/flex/flex-order.css-renderer.spec.ts
@@ -1,0 +1,42 @@
+import { planFlexOrderSemantics } from '../../../flex/flex-order.semantic';
+import { renderFlexOrderCss } from './flex-order.css-renderer';
+
+describe('renderFlexOrderCss', () => {
+  test.each([
+    ['2', [{ property: 'order', value: '2' }]],
+    ['-3', [{ property: 'order', value: '-3' }]],
+    ['0', []],
+    ['first', []],
+  ] as const)(
+    'renders source order %j without introducing an artifact for zero-equivalent values',
+    (source, expected) => {
+      const planned = planFlexOrderSemantics(source);
+
+      expect(planned.status).toBe('planned');
+      if (planned.status !== 'planned') throw new Error('Expected a planned flex order semantic value');
+
+      expect(renderFlexOrderCss(planned.value)).toEqual(expected);
+    },
+  );
+
+  test('returns frozen declarations and shares the empty no-order result', () => {
+    const positive = planFlexOrderSemantics('2');
+    const zero = planFlexOrderSemantics('0');
+    const nonnumeric = planFlexOrderSemantics('first');
+
+    expect(positive.status).toBe('planned');
+    expect(zero.status).toBe('planned');
+    expect(nonnumeric.status).toBe('planned');
+    if (positive.status !== 'planned' || zero.status !== 'planned' || nonnumeric.status !== 'planned') {
+      throw new Error('Expected planned flex order semantic values');
+    }
+
+    const positiveDeclarations = renderFlexOrderCss(positive.value);
+    const zeroDeclarations = renderFlexOrderCss(zero.value);
+
+    expect(Object.isFrozen(positiveDeclarations)).toBe(true);
+    expect(Object.isFrozen(positiveDeclarations[0])).toBe(true);
+    expect(Object.isFrozen(zeroDeclarations)).toBe(true);
+    expect(renderFlexOrderCss(nonnumeric.value)).toBe(zeroDeclarations);
+  });
+});

--- a/src/adapter/css/flex/flex-order.css-renderer.ts
+++ b/src/adapter/css/flex/flex-order.css-renderer.ts
@@ -1,0 +1,10 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { FlexOrderSemantics } from '../../../flex/flex-order.semantic';
+
+const noDeclarations: readonly CssDeclaration[] = Object.freeze([]);
+
+export function renderFlexOrderCss(value: FlexOrderSemantics): readonly CssDeclaration[] {
+  return value.order === undefined
+    ? noDeclarations
+    : Object.freeze([Object.freeze({ property: 'order', value: String(value.order) })]);
+}

--- a/src/adapter/css/flex/layout-align.css-renderer.spec.ts
+++ b/src/adapter/css/flex/layout-align.css-renderer.spec.ts
@@ -1,0 +1,115 @@
+import { planLayoutAlignment } from '../../../flex/layout-align.semantic';
+import { renderLayoutAlignmentCss } from './layout-align.css-renderer';
+
+describe('renderLayoutAlignmentCss', () => {
+  test.each([
+    [
+      'start start',
+      'row',
+      [
+        { property: 'justify-content', value: 'flex-start' },
+        { property: 'align-items', value: 'flex-start' },
+        { property: 'align-content', value: 'flex-start' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'end end',
+      'row-reverse inline',
+      [
+        { property: 'justify-content', value: 'flex-end' },
+        { property: 'align-items', value: 'flex-end' },
+        { property: 'align-content', value: 'flex-end' },
+        { property: 'display', value: 'inline-flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row-reverse' },
+      ],
+    ],
+    [
+      'center baseline',
+      'column nowrap',
+      [
+        { property: 'justify-content', value: 'center' },
+        { property: 'align-items', value: 'baseline' },
+        { property: 'align-content', value: 'stretch' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+        { property: 'flex-wrap', value: 'nowrap' },
+      ],
+    ],
+    [
+      'space-around space-around',
+      'row wrap',
+      [
+        { property: 'justify-content', value: 'space-around' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'space-around' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+        { property: 'flex-wrap', value: 'wrap' },
+      ],
+    ],
+    [
+      'space-between space-between',
+      'column wrap-reverse',
+      [
+        { property: 'justify-content', value: 'space-between' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'space-between' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+        { property: 'flex-wrap', value: 'wrap-reverse' },
+      ],
+    ],
+    [
+      'space-evenly stretch',
+      'column-reverse',
+      [
+        { property: 'justify-content', value: 'space-evenly' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'stretch' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column-reverse' },
+        { property: 'max-width', value: '100%' },
+      ],
+    ],
+    [
+      'center stretch',
+      'row',
+      [
+        { property: 'justify-content', value: 'center' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'stretch' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+        { property: 'max-height', value: '100%' },
+      ],
+    ],
+  ] as const)('renders verified %j alignment semantics with its active %j layout', (source, layout, expected) => {
+    const planned = planLayoutAlignment(source, layout);
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned layout alignment semantic value');
+
+    expect(renderLayoutAlignmentCss(planned.value)).toEqual(expected);
+  });
+
+  test('returns immutable alignment declarations', () => {
+    const planned = planLayoutAlignment('center stretch', 'row');
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned layout alignment semantic value');
+
+    const declarations = renderLayoutAlignmentCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/layout-align.css-renderer.ts
+++ b/src/adapter/css/flex/layout-align.css-renderer.ts
@@ -1,0 +1,55 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type {
+  LayoutContentAlignment,
+  LayoutItemsAlignment,
+  LayoutMainAlignment,
+  LayoutAlignmentSemantics,
+} from '../../../flex/layout-align.semantic';
+import { renderLayoutCss } from './layout.css-renderer';
+
+const mainAlignmentValues: Readonly<Record<LayoutMainAlignment, CssDeclaration['value']>> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  'space-around': 'space-around',
+  'space-between': 'space-between',
+  'space-evenly': 'space-evenly',
+};
+
+const itemsAlignmentValues: Readonly<Record<LayoutItemsAlignment, CssDeclaration['value']>> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  baseline: 'baseline',
+  stretch: 'stretch',
+};
+
+const contentAlignmentValues: Readonly<Record<LayoutContentAlignment, CssDeclaration['value']>> = {
+  start: 'flex-start',
+  center: 'center',
+  end: 'flex-end',
+  stretch: 'stretch',
+  'space-around': 'space-around',
+  'space-between': 'space-between',
+};
+
+const stretchMaximumProperties: Readonly<Record<NonNullable<LayoutAlignmentSemantics['stretchMaximum']>, string>> = {
+  width: 'max-width',
+  height: 'max-height',
+};
+
+function freezeDeclarations(declarations: readonly CssDeclaration[]): readonly CssDeclaration[] {
+  return Object.freeze(declarations.map(declaration => Object.freeze({ ...declaration })));
+}
+
+export function renderLayoutAlignmentCss(value: LayoutAlignmentSemantics): readonly CssDeclaration[] {
+  return freezeDeclarations([
+    { property: 'justify-content', value: mainAlignmentValues[value.main] },
+    { property: 'align-items', value: itemsAlignmentValues[value.items] },
+    { property: 'align-content', value: contentAlignmentValues[value.content] },
+    ...renderLayoutCss(value.layout),
+    ...(value.stretchMaximum === undefined
+      ? []
+      : [{ property: stretchMaximumProperties[value.stretchMaximum], value: '100%' }]),
+  ]);
+}

--- a/src/adapter/css/flex/layout-gap.css-renderer.spec.ts
+++ b/src/adapter/css/flex/layout-gap.css-renderer.spec.ts
@@ -1,0 +1,29 @@
+import { planLayoutGapSemantics } from '../../../flex/layout-gap.semantic';
+import { renderLayoutGapCss } from './layout-gap.css-renderer';
+
+describe('renderLayoutGapCss', () => {
+  test.each([
+    ['4', 'row', [{ property: 'gap', value: '4px' }]],
+    ['1.5rem', 'column', [{ property: 'gap', value: '1.5rem' }]],
+    ['0', '', [{ property: 'gap', value: '0px' }]],
+  ] as const)('renders verified %j gap semantics as %j', (source, layout, expected) => {
+    const planned = planLayoutGapSemantics(source, layout);
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned layout gap semantic value');
+
+    expect(renderLayoutGapCss(planned.value)).toEqual(expected);
+  });
+
+  test('returns immutable gap declarations', () => {
+    const planned = planLayoutGapSemantics('4', 'row');
+
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected a planned layout gap semantic value');
+
+    const declarations = renderLayoutGapCss(planned.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/layout-gap.css-renderer.ts
+++ b/src/adapter/css/flex/layout-gap.css-renderer.ts
@@ -1,0 +1,6 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { LayoutGapSemantics } from '../../../flex/layout-gap.semantic';
+
+export function renderLayoutGapCss(value: LayoutGapSemantics): readonly CssDeclaration[] {
+  return Object.freeze([Object.freeze({ property: 'gap', value: value.length })]);
+}

--- a/src/adapter/css/flex/layout.css-renderer.spec.ts
+++ b/src/adapter/css/flex/layout.css-renderer.spec.ts
@@ -1,0 +1,101 @@
+import { parseLayout } from '../../../flex/layout.semantic';
+import { renderLayoutCss } from './layout.css-renderer';
+
+describe('renderLayoutCss', () => {
+  test.each([
+    [
+      '',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'row',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'row-reverse',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row-reverse' },
+      ],
+    ],
+    [
+      'column',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+      ],
+    ],
+    [
+      'column-reverse',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column-reverse' },
+      ],
+    ],
+    [
+      'row inline',
+      [
+        { property: 'display', value: 'inline-flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'column nowrap',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+        { property: 'flex-wrap', value: 'nowrap' },
+      ],
+    ],
+    [
+      'row wrap',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+        { property: 'flex-wrap', value: 'wrap' },
+      ],
+    ],
+    [
+      'column-reverse wrap-reverse',
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column-reverse' },
+        { property: 'flex-wrap', value: 'wrap-reverse' },
+      ],
+    ],
+  ] as const)('renders the verified %j layout semantics in declaration order', (source, expected) => {
+    const parsed = parseLayout(source);
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error('Expected a planned layout semantic value');
+
+    expect(renderLayoutCss(parsed.value)).toEqual(expected);
+  });
+
+  test('returns immutable layout declarations', () => {
+    const parsed = parseLayout('row wrap');
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error('Expected a planned layout semantic value');
+
+    const declarations = renderLayoutCss(parsed.value);
+
+    expect(Object.isFrozen(declarations)).toBe(true);
+    expect(Object.isFrozen(declarations[0])).toBe(true);
+  });
+});

--- a/src/adapter/css/flex/layout.css-renderer.ts
+++ b/src/adapter/css/flex/layout.css-renderer.ts
@@ -1,0 +1,33 @@
+import type { CssDeclaration } from '../css-artifact.model';
+import type { LayoutDirection, LayoutSemantics, LayoutWrap } from '../../../flex/layout.semantic';
+
+const displayValues: Readonly<Record<LayoutSemantics['display'], CssDeclaration['value']>> = {
+  flex: 'flex',
+  'inline-flex': 'inline-flex',
+};
+
+const directionValues: Readonly<Record<LayoutDirection, CssDeclaration['value']>> = {
+  row: 'row',
+  'row-reverse': 'row-reverse',
+  column: 'column',
+  'column-reverse': 'column-reverse',
+};
+
+const wrapValues: Readonly<Record<LayoutWrap, CssDeclaration['value']>> = {
+  nowrap: 'nowrap',
+  wrap: 'wrap',
+  'wrap-reverse': 'wrap-reverse',
+};
+
+function freezeDeclarations(declarations: readonly CssDeclaration[]): readonly CssDeclaration[] {
+  return Object.freeze(declarations.map(declaration => Object.freeze({ ...declaration })));
+}
+
+export function renderLayoutCss(value: LayoutSemantics): readonly CssDeclaration[] {
+  return freezeDeclarations([
+    { property: 'display', value: displayValues[value.display] },
+    { property: 'box-sizing', value: value.boxSizing },
+    { property: 'flex-direction', value: directionValues[value.direction] },
+    ...(value.explicitWrap ? [{ property: 'flex-wrap', value: wrapValues[value.wrap] }] : []),
+  ]);
+}

--- a/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.spec.ts
@@ -58,6 +58,7 @@ describe('renderFlexItem', () => {
         axis: 'height',
         min: '10rem' as CssLength,
         max: '10rem' as CssLength,
+        boxSizing: 'border-box',
       }),
     ).toEqual(['[flex:1_1_10rem]', '[min-height:10rem]', '[max-height:10rem]', 'box-border']);
   });
@@ -70,6 +71,7 @@ describe('renderFlexItem', () => {
         basis: { kind: 'computed', value: 'calc(100% - 2rem)' as CssLength },
         axis: 'width',
         min: 'calc(100% - 2rem)' as CssLength,
+        boxSizing: 'border-box',
       }),
     ).toEqual([
       '[flex-grow:3]',

--- a/src/adapter/tailwind/directives/flex-item.strategy.ts
+++ b/src/adapter/tailwind/directives/flex-item.strategy.ts
@@ -16,7 +16,7 @@ export function renderFlexItem(value: FlexItemSemantics): readonly string[] {
     ...flexClasses,
     ...(value.min ? [property(`min-${value.axis}`, value.min)] : []),
     ...(value.max ? [property(`max-${value.axis}`, value.max)] : []),
-    'box-border',
+    { 'border-box': 'box-border' }[value.boxSizing],
   ];
 }
 

--- a/src/flex/flex-item.semantic.spec.ts
+++ b/src/flex/flex-item.semantic.spec.ts
@@ -4,27 +4,54 @@ describe('planFlexItemSemantics', () => {
   test.each([
     [
       { basis: '', layout: 'row' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width' },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width', boxSizing: 'border-box' },
     ],
     [
       { basis: '0px', layout: 'row-reverse' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width' },
+      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0%' }, axis: 'width', boxSizing: 'border-box' },
     ],
     [
       { basis: '', layout: 'column' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '0.000000001px' }, axis: 'height' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: { kind: 'literal', value: '0.000000001px' },
+        axis: 'height',
+        boxSizing: 'border-box',
+      },
     ],
     [
       { basis: '25', layout: 'row' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '100%' }, axis: 'width', max: '25%' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: { kind: 'literal', value: '100%' },
+        axis: 'width',
+        max: '25%',
+        boxSizing: 'border-box',
+      },
     ],
     [
       { basis: '25%', layout: 'row wrap' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '25%' }, axis: 'width', max: '25%' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: { kind: 'literal', value: '25%' },
+        axis: 'width',
+        max: '25%',
+        boxSizing: 'border-box',
+      },
     ],
     [
       { basis: '25%', layout: 'row wrap-reverse' },
-      { grow: '1', shrink: '1', basis: { kind: 'literal', value: '100%' }, axis: 'width', max: '25%' },
+      {
+        grow: '1',
+        shrink: '1',
+        basis: { kind: 'literal', value: '100%' },
+        axis: 'width',
+        max: '25%',
+        boxSizing: 'border-box',
+      },
     ],
     [
       { basis: '10rem', layout: 'column' },
@@ -35,6 +62,7 @@ describe('planFlexItemSemantics', () => {
         axis: 'height',
         min: '10rem',
         max: '10rem',
+        boxSizing: 'border-box',
       },
     ],
     [
@@ -46,6 +74,7 @@ describe('planFlexItemSemantics', () => {
         axis: 'height',
         min: '12px',
         max: '12px',
+        boxSizing: 'border-box',
       },
     ],
   ] as const)('derives effective sizing for %o', (input, expected) => {
@@ -61,14 +90,20 @@ describe('planFlexItemSemantics', () => {
   ] as const)('expands the %j sizing keyword', (basis, expected) => {
     expect(planFlexItemSemantics({ basis, layout: 'row' })).toEqual({
       status: 'planned',
-      value: { ...expected, axis: 'width' },
+      value: { ...expected, axis: 'width', boxSizing: 'border-box' },
     });
   });
 
   test('lets explicit factors control percentage constraints', () => {
     expect(planFlexItemSemantics({ basis: '25', grow: '2', shrink: '0', layout: 'row' })).toEqual({
       status: 'planned',
-      value: { grow: '2', shrink: '0', basis: { kind: 'literal', value: '25%' }, axis: 'width' },
+      value: {
+        grow: '2',
+        shrink: '0',
+        basis: { kind: 'literal', value: '25%' },
+        axis: 'width',
+        boxSizing: 'border-box',
+      },
     });
   });
 
@@ -82,6 +117,7 @@ describe('planFlexItemSemantics', () => {
         axis: 'width',
         min: '10rem',
         max: '10rem',
+        boxSizing: 'border-box',
       },
     });
   });
@@ -95,6 +131,7 @@ describe('planFlexItemSemantics', () => {
         basis: { kind: 'computed', value: 'calc(100% - 2rem)' },
         axis: 'width',
         min: 'calc(100% - 2rem)',
+        boxSizing: 'border-box',
       },
     });
   });
@@ -109,6 +146,7 @@ describe('planFlexItemSemantics', () => {
         axis: 'height',
         min: 'calc(50% - 1rem)',
         max: 'calc(50% - 1rem)',
+        boxSizing: 'border-box',
       },
     });
   });

--- a/src/flex/flex-item.semantic.ts
+++ b/src/flex/flex-item.semantic.ts
@@ -20,6 +20,7 @@ export interface FlexItemSemantics {
   readonly axis: 'width' | 'height';
   readonly min?: CssLength;
   readonly max?: CssLength;
+  readonly boxSizing: 'border-box';
 }
 
 const FACTOR = /^\d+(?:\.\d+)?$/;
@@ -96,6 +97,6 @@ export function planFlexItemSemantics(input: FlexItemInput): SemanticResult<Flex
 
   return {
     status: 'planned',
-    value: { grow, shrink, basis: semanticBasis, axis, min, max },
+    value: { grow, shrink, basis: semanticBasis, axis, min, max, boxSizing: 'border-box' },
   };
 }

--- a/test/architecture/flex-semantic-boundary.test.ts
+++ b/test/architecture/flex-semantic-boundary.test.ts
@@ -1,6 +1,8 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import ts from 'typescript';
+
+import { inspectTypeScript, productionTypeScriptFiles } from './typescript-boundary';
 
 const flexRoot = join(process.cwd(), 'src', 'flex');
 const tailwindRoot = join(process.cwd(), 'src', 'adapter', 'tailwind');
@@ -78,14 +80,6 @@ function isSemanticCoreModule(moduleSpecifier: ts.Expression, sourcePath: string
   );
 }
 
-function sourceFiles(directory: string): readonly string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) return sourceFiles(path);
-    return entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts') ? [path] : [];
-  });
-}
-
 function targetRenderingLeak(source: string, sourcePath = strategyFixturePath): string | undefined {
   const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
   let leak: string | undefined;
@@ -121,20 +115,37 @@ describe('flex semantic boundary', () => {
     "import '../../adapter/tailwind/directives/layout.strategy';",
     "import /* target renderer */ '../../adapter/tailwind/directives/layout.strategy';",
   ])('rejects Tailwind module reference: %s', source => {
-    expect(source).toContain(tailwindModuleReference);
+    expect(
+      inspectTypeScript(source, strategyFixturePath).moduleReferences.some(reference =>
+        reference.includes(tailwindModuleReference),
+      ),
+    ).toBe(true);
   });
 
   test('contains no Tailwind dependencies or target syntax', () => {
-    for (const path of sourceFiles(flexRoot)) {
+    for (const path of productionTypeScriptFiles(flexRoot)) {
       const source = readFileSync(path, 'utf8');
       const sourcePath = relative(process.cwd(), path);
+      const inspection = inspectTypeScript(source, path);
 
-      expect(source, sourcePath).not.toContain(tailwindModuleReference);
-      expect(source, sourcePath).not.toContain(adapterModuleReference);
+      expect(
+        inspection.moduleReferences.some(reference => reference.includes(tailwindModuleReference)),
+        sourcePath,
+      ).toBe(false);
+      expect(
+        inspection.moduleReferences.some(reference => reference.includes(adapterModuleReference)),
+        sourcePath,
+      ).toBe(false);
       for (const token of targetTokens) {
-        expect(source, sourcePath).not.toContain(token);
+        expect(
+          inspection.literalTexts.some(text => text.includes(token)),
+          sourcePath,
+        ).toBe(false);
       }
-      expect(source, sourcePath).not.toMatch(/\[[a-z-]+:/u);
+      expect(
+        inspection.literalTexts.some(text => /\[[a-z-]+:/u.test(text)),
+        sourcePath,
+      ).toBe(false);
       expect(targetRenderingLeak(source, path), sourcePath).toBeUndefined();
     }
   });

--- a/test/architecture/native-css-boundary.test.ts
+++ b/test/architecture/native-css-boundary.test.ts
@@ -25,15 +25,18 @@ const standardAliases = new Set([
   'gt-md',
   'gt-lg',
 ]);
-const rendererParameterTypes: Readonly<Record<string, string>> = {
-  'layout.css-renderer.ts': 'LayoutSemantics',
-  'layout-align.css-renderer.ts': 'LayoutAlignmentSemantics',
-  'layout-gap.css-renderer.ts': 'LayoutGapSemantics',
-  'flex-item.css-renderer.ts': 'FlexItemSemantics',
-  'flex-align.css-renderer.ts': 'FlexAlignSemantics',
-  'flex-fill.css-renderer.ts': 'FlexFillSemantics',
-  'flex-offset.css-renderer.ts': 'FlexOffsetSemantics',
-  'flex-order.css-renderer.ts': 'FlexOrderSemantics',
+const rendererContracts: Readonly<Record<string, { readonly name: string; readonly parameterType: string }>> = {
+  'layout.css-renderer.ts': { name: 'renderLayoutCss', parameterType: 'LayoutSemantics' },
+  'layout-align.css-renderer.ts': {
+    name: 'renderLayoutAlignmentCss',
+    parameterType: 'LayoutAlignmentSemantics',
+  },
+  'layout-gap.css-renderer.ts': { name: 'renderLayoutGapCss', parameterType: 'LayoutGapSemantics' },
+  'flex-item.css-renderer.ts': { name: 'renderFlexItemCss', parameterType: 'FlexItemSemantics' },
+  'flex-align.css-renderer.ts': { name: 'renderFlexAlignCss', parameterType: 'FlexAlignSemantics' },
+  'flex-fill.css-renderer.ts': { name: 'renderFlexFillCss', parameterType: 'FlexFillSemantics' },
+  'flex-offset.css-renderer.ts': { name: 'renderFlexOffsetCss', parameterType: 'FlexOffsetSemantics' },
+  'flex-order.css-renderer.ts': { name: 'renderFlexOrderCss', parameterType: 'FlexOrderSemantics' },
 };
 
 function forbiddenCssModule(inspection: TypeScriptInspection): string | undefined {
@@ -48,7 +51,32 @@ function directiveSyntax(inspection: TypeScriptInspection): string | undefined {
 }
 
 function copiedBreakpointAlias(inspection: TypeScriptInspection): string | undefined {
-  return inspection.literalTexts.find(token => standardAliases.has(token));
+  const literalAlias = inspection.literalTexts.find(token => standardAliases.has(token));
+  if (literalAlias !== undefined) return literalAlias;
+
+  for (const propertyNames of inspection.objectPropertyTables) {
+    const aliases = propertyNames.filter(propertyName => standardAliases.has(propertyName));
+    if (aliases.length >= 2) return aliases[0];
+  }
+  return undefined;
+}
+
+function rendererSignatureViolation(
+  inspection: TypeScriptInspection,
+  contract: { readonly name: string; readonly parameterType: string },
+): string | undefined {
+  const renderers = inspection.exportedFunctions.filter(declaration => declaration.name.endsWith('Css'));
+  if (renderers.length !== 1) return 'expected exactly one CSS renderer export';
+  const renderer = renderers[0];
+  if (renderer?.name !== contract.name) return 'missing intended renderer';
+  if (
+    renderer.parameters.length !== 1 ||
+    renderer.parameters[0]?.name !== 'value' ||
+    renderer.parameters[0]?.type !== contract.parameterType
+  ) {
+    return 'renderer must accept only its semantic value type';
+  }
+  return undefined;
 }
 
 function semanticRendererLeak(inspection: TypeScriptInspection): string | undefined {
@@ -103,6 +131,7 @@ describe('native CSS architecture boundary', () => {
     'export function renderLayoutCss(value: string) { return value.trim().split(/\\s+/); }',
     "const directive = 'fxLayout';",
     'const input = { fxFlexOrder: value };',
+    'const directivePattern = /fxLayout|fxFlex/;',
   ])('rejects raw Flex-Layout directive interpretation in CSS production syntax: %s', source => {
     const inspection = inspectTypeScript(source, fixturePath);
     const rawParameter = inspection.exportedFunctions.some(
@@ -135,16 +164,29 @@ describe('native CSS architecture boundary', () => {
     expect(copiedBreakpointAlias(inspectTypeScript(source, fixturePath))).toBe('xs');
   });
 
-  test.each(["const selector = '.flm-' + digest;", 'function renderFlexItemCss() { return []; }'])(
-    'rejects target renderer leakage from semantic modules: %s',
-    source => {
-      const inspection = inspectTypeScript(source, join(flexRoot, 'fixture.semantic.ts'));
+  test('rejects a standard breakpoint table with identifier-keyed aliases', () => {
+    const source = `
+      const breakpoints = {
+        xs: { min: 0, max: 599.98 },
+        sm: { min: 600, max: 959.98 },
+        md: { min: 960, max: 1279.98 },
+      };
+    `;
 
-      expect(
-        inspection.literalTexts.some(text => text.includes('flm-')) || semanticRendererLeak(inspection) !== undefined,
-      ).toBe(true);
-    },
-  );
+    expect(copiedBreakpointAlias(inspectTypeScript(source, fixturePath))).toBe('xs');
+  });
+
+  test.each([
+    "const selector = '.flm-' + digest;",
+    'const selectorPattern = /^\\.flm-/;',
+    'function renderFlexItemCss() { return []; }',
+  ])('rejects target renderer leakage from semantic modules: %s', source => {
+    const inspection = inspectTypeScript(source, join(flexRoot, 'fixture.semantic.ts'));
+
+    expect(
+      inspection.literalTexts.some(text => text.includes('flm-')) || semanticRendererLeak(inspection) !== undefined,
+    ).toBe(true);
+  });
 
   test('keeps selector prefixes and renderer names out of semantic production code', () => {
     for (const path of productionTypeScriptFiles(flexRoot)) {
@@ -163,24 +205,37 @@ describe('native CSS architecture boundary', () => {
     const rendererRoot = join(cssRoot, 'flex');
 
     for (const path of productionTypeScriptFiles(rendererRoot)) {
-      const expectedType = rendererParameterTypes[basename(path)];
+      const contract = rendererContracts[basename(path)];
       const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
-      const renderer = inspection.exportedFunctions.find(declaration => declaration.name.endsWith('Css'));
+      const renderers = inspection.exportedFunctions.filter(declaration => declaration.name.endsWith('Css'));
 
-      expect(expectedType, relative(process.cwd(), path)).toBeDefined();
-      expect(renderer?.parameters).toEqual([{ name: 'value', type: expectedType }]);
-      expect(
-        renderer?.parameters.some(
-          parameter => parameter.type === 'string' || parameter.type.includes('SemanticResult'),
-        ),
-      ).toBe(false);
+      expect(contract, relative(process.cwd(), path)).toBeDefined();
+      if (contract === undefined) continue;
+      expect(renderers, relative(process.cwd(), path)).toEqual([
+        { name: contract.name, parameters: [{ name: 'value', type: contract.parameterType }] },
+      ]);
+      expect(rendererSignatureViolation(inspection, contract), relative(process.cwd(), path)).toBeUndefined();
     }
+  });
+
+  test('rejects a raw-string renderer after a valid renderer export', () => {
+    const source = `
+      export function renderLayoutCss(value: LayoutSemantics) { return value; }
+      export function renderRawCss(value: string) { return value.trim(); }
+    `;
+    const inspection = inspectTypeScript(source, fixturePath);
+
+    expect(
+      rendererSignatureViolation(inspection, { name: 'renderLayoutCss', parameterType: 'LayoutSemantics' }),
+    ).toBeDefined();
   });
 
   test('does not scan comments as production syntax', () => {
     const source = `
       // import { renderLayoutCss } from '../adapter/css/flex/layout.css-renderer';
       // fxLayout='row' and .flm-deadbeef
+      // const directivePattern = /fxLayout|fxFlex/;
+      // const selectorPattern = /^\\.flm-/;
       /* const copied = [{ alias: 'xs', min: 0, max: 599.98 }]; */
       export function harmless(value: LayoutSemantics): LayoutSemantics { return value; }
     `;

--- a/test/architecture/native-css-boundary.test.ts
+++ b/test/architecture/native-css-boundary.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+
+import { inspectTypeScript, productionTypeScriptFiles, type TypeScriptInspection } from './typescript-boundary';
+
+const flexRoot = join(process.cwd(), 'src', 'flex');
+const cssRoot = join(process.cwd(), 'src', 'adapter', 'css');
+const fixturePath = join(cssRoot, 'flex', 'fixture.css-renderer.ts');
+
+const cssForbiddenModuleSegments = ['/analyzer/', '/template/', '/edit/', '/tailwind/', '/cli/'];
+const filesystemModules = new Set(['fs', 'fs/promises', 'node:fs', 'node:fs/promises']);
+const directiveNames = /\bfx(?:Layout(?:Align|Gap)?|Flex(?:Align|Fill|Offset|Order)?|Fill)\b/u;
+const standardAliases = new Set([
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'lt-sm',
+  'lt-md',
+  'lt-lg',
+  'lt-xl',
+  'gt-xs',
+  'gt-sm',
+  'gt-md',
+  'gt-lg',
+]);
+const rendererParameterTypes: Readonly<Record<string, string>> = {
+  'layout.css-renderer.ts': 'LayoutSemantics',
+  'layout-align.css-renderer.ts': 'LayoutAlignmentSemantics',
+  'layout-gap.css-renderer.ts': 'LayoutGapSemantics',
+  'flex-item.css-renderer.ts': 'FlexItemSemantics',
+  'flex-align.css-renderer.ts': 'FlexAlignSemantics',
+  'flex-fill.css-renderer.ts': 'FlexFillSemantics',
+  'flex-offset.css-renderer.ts': 'FlexOffsetSemantics',
+  'flex-order.css-renderer.ts': 'FlexOrderSemantics',
+};
+
+function forbiddenCssModule(inspection: TypeScriptInspection): string | undefined {
+  return inspection.moduleReferences.find(
+    reference =>
+      filesystemModules.has(reference) || cssForbiddenModuleSegments.some(segment => reference.includes(segment)),
+  );
+}
+
+function directiveSyntax(inspection: TypeScriptInspection): string | undefined {
+  return [...inspection.identifiers, ...inspection.literalTexts].find(token => directiveNames.test(token));
+}
+
+function copiedBreakpointAlias(inspection: TypeScriptInspection): string | undefined {
+  return inspection.literalTexts.find(token => standardAliases.has(token));
+}
+
+function semanticRendererLeak(inspection: TypeScriptInspection): string | undefined {
+  return inspection.identifiers.find(identifier => /^render[A-Z]/u.test(identifier));
+}
+
+describe('native CSS architecture boundary', () => {
+  test.each([
+    "import { renderLayoutCss } from '../adapter/css/flex/layout.css-renderer';",
+    "export { renderLayoutCss } from '../adapter/css/flex/layout.css-renderer';",
+    "export * from '../adapter/css/flex/layout.css-renderer';",
+    "const renderer = await import('../adapter/css/flex/layout.css-renderer');",
+    "const renderer = require('../adapter/css/flex/layout.css-renderer');",
+  ])('recognizes an adapter/css module reference in production syntax: %s', source => {
+    expect(inspectTypeScript(source, join(flexRoot, 'fixture.ts')).moduleReferences).toContain(
+      '../adapter/css/flex/layout.css-renderer',
+    );
+  });
+
+  test('keeps target-neutral Flex semantics independent from the CSS adapter', () => {
+    for (const path of productionTypeScriptFiles(flexRoot)) {
+      const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
+
+      expect(
+        inspection.moduleReferences.some(reference => reference.includes('adapter/css')),
+        relative(process.cwd(), path),
+      ).toBe(false);
+    }
+  });
+
+  test.each([
+    "import type { FlexLayoutInput } from '../../../analyzer/flex-layout-attribute.analyzer';",
+    "export type { TemplateElement } from '../../../template/template.model';",
+    "const editor = await import('../../../edit/source-editor');",
+    "const tailwind = require('../../tailwind/directives/layout.strategy');",
+    "import '../../../cli/run-cli';",
+    "import { readFile } from 'node:fs/promises';",
+  ])('rejects a forbidden CSS dependency: %s', source => {
+    expect(forbiddenCssModule(inspectTypeScript(source, fixturePath))).toBeDefined();
+  });
+
+  test('keeps CSS production code independent from analyzer, template, editing, Tailwind, CLI, and filesystem modules', () => {
+    for (const path of productionTypeScriptFiles(cssRoot)) {
+      expect(
+        forbiddenCssModule(inspectTypeScript(readFileSync(path, 'utf8'), path)),
+        relative(process.cwd(), path),
+      ).toBe(undefined);
+    }
+  });
+
+  test.each([
+    'export function renderLayoutCss(value: string) { return value.trim().split(/\\s+/); }',
+    "const directive = 'fxLayout';",
+    'const input = { fxFlexOrder: value };',
+  ])('rejects raw Flex-Layout directive interpretation in CSS production syntax: %s', source => {
+    const inspection = inspectTypeScript(source, fixturePath);
+    const rawParameter = inspection.exportedFunctions.some(
+      declaration =>
+        declaration.name.endsWith('Css') && declaration.parameters.some(parameter => parameter.type === 'string'),
+    );
+
+    expect(rawParameter || directiveSyntax(inspection) !== undefined).toBe(true);
+  });
+
+  test('keeps directive names and copied standard breakpoint aliases out of CSS production code', () => {
+    for (const path of productionTypeScriptFiles(cssRoot)) {
+      const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
+      const sourcePath = relative(process.cwd(), path);
+
+      expect(directiveSyntax(inspection), sourcePath).toBeUndefined();
+      expect(copiedBreakpointAlias(inspection), sourcePath).toBeUndefined();
+    }
+  });
+
+  test('rejects a copied standard breakpoint alias/range table', () => {
+    const source = `
+      const breakpoints = [
+        { alias: 'xs', min: 0, max: 599.98 },
+        { alias: 'sm', min: 600, max: 959.98 },
+        { alias: 'md', min: 960, max: 1279.98 },
+      ];
+    `;
+
+    expect(copiedBreakpointAlias(inspectTypeScript(source, fixturePath))).toBe('xs');
+  });
+
+  test.each(["const selector = '.flm-' + digest;", 'function renderFlexItemCss() { return []; }'])(
+    'rejects target renderer leakage from semantic modules: %s',
+    source => {
+      const inspection = inspectTypeScript(source, join(flexRoot, 'fixture.semantic.ts'));
+
+      expect(
+        inspection.literalTexts.some(text => text.includes('flm-')) || semanticRendererLeak(inspection) !== undefined,
+      ).toBe(true);
+    },
+  );
+
+  test('keeps selector prefixes and renderer names out of semantic production code', () => {
+    for (const path of productionTypeScriptFiles(flexRoot)) {
+      const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
+      const sourcePath = relative(process.cwd(), path);
+
+      expect(
+        inspection.literalTexts.some(text => text.includes('flm-')),
+        sourcePath,
+      ).toBe(false);
+      expect(semanticRendererLeak(inspection), sourcePath).toBeUndefined();
+    }
+  });
+
+  test('requires every CSS family renderer to accept its semantic value type', () => {
+    const rendererRoot = join(cssRoot, 'flex');
+
+    for (const path of productionTypeScriptFiles(rendererRoot)) {
+      const expectedType = rendererParameterTypes[basename(path)];
+      const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
+      const renderer = inspection.exportedFunctions.find(declaration => declaration.name.endsWith('Css'));
+
+      expect(expectedType, relative(process.cwd(), path)).toBeDefined();
+      expect(renderer?.parameters).toEqual([{ name: 'value', type: expectedType }]);
+      expect(
+        renderer?.parameters.some(
+          parameter => parameter.type === 'string' || parameter.type.includes('SemanticResult'),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test('does not scan comments as production syntax', () => {
+    const source = `
+      // import { renderLayoutCss } from '../adapter/css/flex/layout.css-renderer';
+      // fxLayout='row' and .flm-deadbeef
+      /* const copied = [{ alias: 'xs', min: 0, max: 599.98 }]; */
+      export function harmless(value: LayoutSemantics): LayoutSemantics { return value; }
+    `;
+    const inspection = inspectTypeScript(source, join(flexRoot, 'fixture.semantic.ts'));
+
+    expect(inspection.moduleReferences).toEqual([]);
+    expect(directiveSyntax(inspection)).toBeUndefined();
+    expect(copiedBreakpointAlias(inspection)).toBeUndefined();
+    expect(inspection.literalTexts.some(text => text.includes('flm-'))).toBe(false);
+  });
+});

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -1,0 +1,85 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+
+export interface InspectedParameter {
+  readonly name: string;
+  readonly type: string;
+}
+
+export interface InspectedExportedFunction {
+  readonly name: string;
+  readonly parameters: readonly InspectedParameter[];
+}
+
+export interface TypeScriptInspection {
+  readonly moduleReferences: readonly string[];
+  readonly identifiers: readonly string[];
+  readonly literalTexts: readonly string[];
+  readonly exportedFunctions: readonly InspectedExportedFunction[];
+}
+
+function moduleText(expression: ts.Expression | undefined): string | undefined {
+  return expression && ts.isStringLiteralLike(expression) ? expression.text : undefined;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    ts.getModifiers(node)?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true
+  );
+}
+
+export function inspectTypeScript(source: string, sourcePath: string): TypeScriptInspection {
+  const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  const moduleReferences: string[] = [];
+  const identifiers: string[] = [];
+  const literalTexts: string[] = [];
+  const exportedFunctions: InspectedExportedFunction[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isIdentifier(node)) identifiers.push(node.text);
+    if (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node)) literalTexts.push(node.text);
+
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      const reference = moduleText(node.moduleSpecifier);
+      if (reference !== undefined) moduleReferences.push(reference);
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      const reference = moduleText(node.moduleReference.expression);
+      if (reference !== undefined) moduleReferences.push(reference);
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+    ) {
+      const reference = moduleText(node.arguments[0]);
+      if (reference !== undefined) moduleReferences.push(reference);
+    }
+
+    if (ts.isFunctionDeclaration(node) && node.name && hasExportModifier(node)) {
+      exportedFunctions.push({
+        name: node.name.text,
+        parameters: node.parameters.map(parameter => ({
+          name: parameter.name.getText(sourceFile),
+          type: parameter.type?.getText(sourceFile) ?? '',
+        })),
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return { moduleReferences, identifiers, literalTexts, exportedFunctions };
+}
+
+export function productionTypeScriptFiles(directory: string): readonly string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return productionTypeScriptFiles(path);
+    if (!entry.isFile() || !entry.name.endsWith('.ts')) return [];
+    return entry.name.endsWith('.spec.ts') || entry.name.endsWith('.test.ts') || entry.name.endsWith('.d.ts')
+      ? []
+      : [path];
+  });
+}

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -16,6 +16,7 @@ export interface TypeScriptInspection {
   readonly moduleReferences: readonly string[];
   readonly identifiers: readonly string[];
   readonly literalTexts: readonly string[];
+  readonly objectPropertyTables: readonly (readonly string[])[];
   readonly exportedFunctions: readonly InspectedExportedFunction[];
 }
 
@@ -30,16 +31,33 @@ function hasExportModifier(node: ts.Node): boolean {
   );
 }
 
+function objectPropertyName(property: ts.ObjectLiteralElementLike): string | undefined {
+  if (ts.isSpreadAssignment(property)) return undefined;
+  const name = property.name;
+  return ts.isIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name) ? name.text : undefined;
+}
+
 export function inspectTypeScript(source: string, sourcePath: string): TypeScriptInspection {
   const sourceFile = ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
   const moduleReferences: string[] = [];
   const identifiers: string[] = [];
   const literalTexts: string[] = [];
+  const objectPropertyTables: string[][] = [];
   const exportedFunctions: InspectedExportedFunction[] = [];
 
   function visit(node: ts.Node): void {
     if (ts.isIdentifier(node)) identifiers.push(node.text);
-    if (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node)) literalTexts.push(node.text);
+    if (ts.isStringLiteralLike(node) || ts.isTemplateLiteralToken(node) || ts.isRegularExpressionLiteral(node)) {
+      literalTexts.push(node.text);
+    }
+    if (ts.isObjectLiteralExpression(node)) {
+      objectPropertyTables.push(
+        node.properties.flatMap(property => {
+          const name = objectPropertyName(property);
+          return name === undefined ? [] : [name];
+        }),
+      );
+    }
 
     if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const reference = moduleText(node.moduleSpecifier);
@@ -70,7 +88,7 @@ export function inspectTypeScript(source: string, sourcePath: string): TypeScrip
   }
 
   visit(sourceFile);
-  return { moduleReferences, identifiers, literalTexts, exportedFunctions };
+  return { moduleReferences, identifiers, literalTexts, objectPropertyTables, exportedFunctions };
 }
 
 export function productionTypeScriptFiles(directory: string): readonly string[] {

--- a/test/compatibility/flex-renderer-parity.test.ts
+++ b/test/compatibility/flex-renderer-parity.test.ts
@@ -1,0 +1,372 @@
+import { CssArtifactRegistry } from '../../src/adapter/css/css-artifact.registry';
+import type { CssDeclaration, CssRuleContext } from '../../src/adapter/css/css-artifact.model';
+import { cssRuleContext } from '../../src/adapter/css/css-breakpoint.context';
+import { renderFlexAlignCss } from '../../src/adapter/css/flex/flex-align.css-renderer';
+import { renderFlexFillCss } from '../../src/adapter/css/flex/flex-fill.css-renderer';
+import { renderFlexItemCss } from '../../src/adapter/css/flex/flex-item.css-renderer';
+import { renderFlexOffsetCss } from '../../src/adapter/css/flex/flex-offset.css-renderer';
+import { renderFlexOrderCss } from '../../src/adapter/css/flex/flex-order.css-renderer';
+import { renderLayoutAlignmentCss } from '../../src/adapter/css/flex/layout-align.css-renderer';
+import { renderLayoutGapCss } from '../../src/adapter/css/flex/layout-gap.css-renderer';
+import { renderLayoutCss } from '../../src/adapter/css/flex/layout.css-renderer';
+import { renderFlexAlign } from '../../src/adapter/tailwind/directives/flex-align.strategy';
+import { renderFlexFill } from '../../src/adapter/tailwind/directives/flex-fill.strategy';
+import { renderFlexItem } from '../../src/adapter/tailwind/directives/flex-item.strategy';
+import { renderFlexOffset } from '../../src/adapter/tailwind/directives/flex-offset.strategy';
+import { renderFlexOrder } from '../../src/adapter/tailwind/directives/flex-order.strategy';
+import { renderLayoutAlignment } from '../../src/adapter/tailwind/directives/layout-align.strategy';
+import { renderLayoutGap } from '../../src/adapter/tailwind/directives/layout-gap.strategy';
+import { renderLayout } from '../../src/adapter/tailwind/directives/layout.strategy';
+import { BreakpointCatalog, type BreakpointDefinition } from '../../src/breakpoint/breakpoint-catalog';
+import { planFlexAlignSemantics } from '../../src/flex/flex-align.semantic';
+import { planFlexFillSemantics } from '../../src/flex/flex-fill.semantic';
+import { planFlexItemSemantics } from '../../src/flex/flex-item.semantic';
+import { planFlexOffsetSemantics } from '../../src/flex/flex-offset.semantic';
+import { planFlexOrderSemantics } from '../../src/flex/flex-order.semantic';
+import { planLayoutAlignment } from '../../src/flex/layout-align.semantic';
+import { planLayoutGapSemantics } from '../../src/flex/layout-gap.semantic';
+import { parseLayout } from '../../src/flex/layout.semantic';
+
+describe('cross-target Flex renderer parity', () => {
+  test.each([
+    [
+      'row-reverse wrap',
+      ['flex', 'flex-row-reverse', 'flex-wrap', 'box-border'],
+      [
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row-reverse' },
+        { property: 'flex-wrap', value: 'wrap' },
+      ],
+    ],
+    [
+      'column-reverse nowrap inline',
+      ['inline-flex', 'flex-col-reverse', 'flex-nowrap', 'box-border'],
+      [
+        { property: 'display', value: 'inline-flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column-reverse' },
+        { property: 'flex-wrap', value: 'nowrap' },
+      ],
+    ],
+  ] as const)('renders one planned %j layout through both targets', (source, tailwind, css) => {
+    const planned = parseLayout(source);
+    expect(planned.ok).toBe(true);
+    if (!planned.ok) throw new Error('Expected planned layout semantics');
+
+    const semantics = planned.value;
+    expect(renderLayout(semantics)).toEqual(tailwind);
+    expect(renderLayoutCss(semantics)).toEqual(css);
+  });
+
+  test.each([
+    [
+      'start start',
+      'row',
+      ['justify-start', 'items-start', 'content-start', 'flex', 'flex-row', 'box-border'],
+      [
+        { property: 'justify-content', value: 'flex-start' },
+        { property: 'align-items', value: 'flex-start' },
+        { property: 'align-content', value: 'flex-start' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'center center',
+      'row-reverse',
+      ['justify-center', 'items-center', 'content-center', 'flex', 'flex-row-reverse', 'box-border'],
+      [
+        { property: 'justify-content', value: 'center' },
+        { property: 'align-items', value: 'center' },
+        { property: 'align-content', value: 'center' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row-reverse' },
+      ],
+    ],
+    [
+      'end end',
+      'column',
+      ['justify-end', 'items-end', 'content-end', 'flex', 'flex-col', 'box-border'],
+      [
+        { property: 'justify-content', value: 'flex-end' },
+        { property: 'align-items', value: 'flex-end' },
+        { property: 'align-content', value: 'flex-end' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+      ],
+    ],
+    [
+      'space-around space-around',
+      'column-reverse',
+      ['justify-around', 'items-stretch', 'content-around', 'flex', 'flex-col-reverse', 'box-border'],
+      [
+        { property: 'justify-content', value: 'space-around' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'space-around' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column-reverse' },
+      ],
+    ],
+    [
+      'space-between space-between',
+      'row',
+      ['justify-between', 'items-stretch', 'content-between', 'flex', 'flex-row', 'box-border'],
+      [
+        { property: 'justify-content', value: 'space-between' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'space-between' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+      ],
+    ],
+    [
+      'space-evenly baseline',
+      'column',
+      ['justify-evenly', 'items-baseline', 'content-stretch', 'flex', 'flex-col', 'box-border'],
+      [
+        { property: 'justify-content', value: 'space-evenly' },
+        { property: 'align-items', value: 'baseline' },
+        { property: 'align-content', value: 'stretch' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'column' },
+      ],
+    ],
+    [
+      'start stretch',
+      'row',
+      ['justify-start', 'items-stretch', 'content-stretch', 'flex', 'flex-row', 'box-border', 'max-h-full'],
+      [
+        { property: 'justify-content', value: 'flex-start' },
+        { property: 'align-items', value: 'stretch' },
+        { property: 'align-content', value: 'stretch' },
+        { property: 'display', value: 'flex' },
+        { property: 'box-sizing', value: 'border-box' },
+        { property: 'flex-direction', value: 'row' },
+        { property: 'max-height', value: '100%' },
+      ],
+    ],
+  ] as const)('renders one planned %j alignment in %j through both targets', (source, layout, tailwind, css) => {
+    const planned = planLayoutAlignment(source, layout);
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned layout alignment semantics');
+
+    const semantics = planned.value;
+    expect(renderLayoutAlignment(semantics)).toEqual({ classNames: tailwind });
+    expect(renderLayoutAlignmentCss(semantics)).toEqual(css);
+  });
+
+  test('renders one planned gap through both targets and preserves wrapping diagnostics at the planner', () => {
+    const planned = planLayoutGapSemantics('1.5rem', 'row');
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned layout gap semantics');
+
+    const semantics = planned.value;
+    expect(renderLayoutGap(semantics)).toEqual({ status: 'converted', classNames: ['gap-[1.5rem]'] });
+    expect(renderLayoutGapCss(semantics)).toEqual([{ property: 'gap', value: '1.5rem' }]);
+    expect(planLayoutGapSemantics('4', 'row wrap')).toEqual({
+      status: 'review',
+      code: 'semantic-unsupported',
+      reason: 'Flex-Layout margins and CSS gap differ when flex items wrap across lines.',
+      suggestion: 'Verify the wrapped layout and migrate its spacing manually.',
+    });
+  });
+
+  test.each([
+    [
+      { basis: '3 2 calc(100% - 2rem)', layout: 'row-reverse' },
+      [
+        '[flex-grow:3]',
+        '[flex-shrink:2]',
+        '[flex-basis:calc(100%_-_2rem)]',
+        '[min-width:calc(100%_-_2rem)]',
+        'box-border',
+      ],
+      [
+        { property: 'flex-grow', value: '3' },
+        { property: 'flex-shrink', value: '2' },
+        { property: 'flex-basis', value: 'calc(100% - 2rem)' },
+        { property: 'min-width', value: 'calc(100% - 2rem)' },
+      ],
+    ],
+    [
+      { basis: '10rem', layout: 'column-reverse' },
+      ['[flex:1_1_10rem]', '[min-height:10rem]', '[max-height:10rem]', 'box-border'],
+      [
+        { property: 'flex', value: '1 1 10rem' },
+        { property: 'min-height', value: '10rem' },
+        { property: 'max-height', value: '10rem' },
+      ],
+    ],
+  ] as const)('renders one planned flex item with parent context %o through both targets', (input, tailwind, css) => {
+    const planned = planFlexItemSemantics(input);
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned flex item semantics');
+
+    const semantics = planned.value;
+    expect(renderFlexItem(semantics)).toEqual(tailwind);
+    expect(renderFlexItemCss(semantics)).toEqual(css);
+  });
+
+  test.each([
+    ['', ['self-stretch'], [{ property: 'align-self', value: 'stretch' }]],
+    ['auto', ['self-auto'], [{ property: 'align-self', value: 'auto' }]],
+    ['start', ['self-start'], [{ property: 'align-self', value: 'flex-start' }]],
+    ['end', ['self-end'], [{ property: 'align-self', value: 'flex-end' }]],
+    ['center', ['self-center'], [{ property: 'align-self', value: 'center' }]],
+    ['baseline', ['self-baseline'], [{ property: 'align-self', value: 'baseline' }]],
+  ] as const)('renders one planned %j self alignment through both targets', (source, tailwind, css) => {
+    const planned = planFlexAlignSemantics(source);
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned flex alignment semantics');
+
+    const semantics = planned.value;
+    expect(renderFlexAlign(semantics)).toEqual({ status: 'converted', classNames: tailwind });
+    expect(renderFlexAlignCss(semantics)).toEqual(css);
+  });
+
+  test('renders the one planned fill value through both targets', () => {
+    const planned = planFlexFillSemantics();
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned flex fill semantics');
+
+    const semantics = planned.value;
+    expect(renderFlexFill(semantics)).toEqual({
+      status: 'converted',
+      classNames: ['m-0', 'w-full', 'h-full', 'min-w-full', 'min-h-full'],
+    });
+    expect(renderFlexFillCss(semantics)).toEqual([
+      { property: 'margin', value: '0' },
+      { property: 'width', value: '100%' },
+      { property: 'height', value: '100%' },
+      { property: 'min-width', value: '100%' },
+      { property: 'min-height', value: '100%' },
+    ]);
+  });
+
+  test.each([
+    ['4', 'row-reverse', ['ms-[4%]'], [{ property: 'margin-inline-start', value: '4%' }]],
+    ['2rem', 'column-reverse', ['mt-[2rem]'], [{ property: 'margin-block-start', value: '2rem' }]],
+  ] as const)('renders one planned %j offset in %j through both targets', (source, layout, tailwind, css) => {
+    const planned = planFlexOffsetSemantics(source, layout);
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned flex offset semantics');
+
+    const semantics = planned.value;
+    expect(renderFlexOffset(semantics)).toEqual({ status: 'converted', classNames: tailwind });
+    expect(renderFlexOffsetCss(semantics)).toEqual(css);
+  });
+
+  test.each([
+    ['2', ['[order:2]'], [{ property: 'order', value: '2' }]],
+    ['-3', ['[order:-3]'], [{ property: 'order', value: '-3' }]],
+    ['0', [], []],
+  ] as const)('renders one planned %j order through both targets', (source, tailwind, css) => {
+    const planned = planFlexOrderSemantics(source);
+    expect(planned.status).toBe('planned');
+    if (planned.status !== 'planned') throw new Error('Expected planned flex order semantics');
+
+    const semantics = planned.value;
+    expect(renderFlexOrder(semantics)).toEqual({ status: 'converted', classNames: tailwind });
+    expect(renderFlexOrderCss(semantics)).toEqual(css);
+  });
+});
+
+const breakpointRows = [
+  ['base', undefined, { priority: 0 }],
+  ['xs', 'xs', { priority: 1000, media: { type: 'screen', clauses: [{ min: 0, max: 599.98 }] } }],
+  ['sm', 'sm', { priority: 900, media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] } }],
+  ['md', 'md', { priority: 800, media: { type: 'screen', clauses: [{ min: 960, max: 1279.98 }] } }],
+  ['lg', 'lg', { priority: 700, media: { type: 'screen', clauses: [{ min: 1280, max: 1919.98 }] } }],
+  ['xl', 'xl', { priority: 600, media: { type: 'screen', clauses: [{ min: 1920, max: 4999.98 }] } }],
+  ['lt-sm', 'lt-sm', { priority: 950, media: { type: 'screen', clauses: [{ max: 599.98 }] } }],
+  ['lt-md', 'lt-md', { priority: 850, media: { type: 'screen', clauses: [{ max: 959.98 }] } }],
+  ['lt-lg', 'lt-lg', { priority: 750, media: { type: 'screen', clauses: [{ max: 1279.98 }] } }],
+  ['lt-xl', 'lt-xl', { priority: 650, media: { type: 'screen', clauses: [{ max: 1919.98 }] } }],
+  ['gt-xs', 'gt-xs', { priority: -950, media: { type: 'screen', clauses: [{ min: 600 }] } }],
+  ['gt-sm', 'gt-sm', { priority: -850, media: { type: 'screen', clauses: [{ min: 960 }] } }],
+  ['gt-md', 'gt-md', { priority: -750, media: { type: 'screen', clauses: [{ min: 1280 }] } }],
+  ['gt-lg', 'gt-lg', { priority: -650, media: { type: 'screen', clauses: [{ min: 1920 }] } }],
+] as const satisfies readonly (readonly [string, string | undefined, CssRuleContext])[];
+
+function verifiedDefinition(alias: string): BreakpointDefinition {
+  const classification = new BreakpointCatalog().classify(alias);
+  if (classification.kind !== 'verified') throw new Error(`Expected ${alias} to be a standard verified breakpoint`);
+  return classification.definition;
+}
+
+function breakpointDefinition(alias: string | undefined): BreakpointDefinition | undefined {
+  return alias === undefined ? undefined : verifiedDefinition(alias);
+}
+
+function plannedGapDeclarations(): readonly CssDeclaration[] {
+  const planned = planLayoutGapSemantics('8px', 'row');
+  if (planned.status !== 'planned') throw new Error('Expected planned layout gap semantics');
+  return renderLayoutGapCss(planned.value);
+}
+
+type BreakpointRow = (typeof breakpointRows)[number];
+
+function registerBreakpointRows(rows: readonly BreakpointRow[]) {
+  const registry = new CssArtifactRegistry();
+  const declarations = plannedGapDeclarations();
+  const rulesByAlias = new Map<string, ReturnType<CssArtifactRegistry['register']>>();
+
+  for (const [label, alias] of rows) {
+    rulesByAlias.set(label, registry.register('layout-gap', declarations, cssRuleContext(breakpointDefinition(alias))));
+  }
+
+  return { registry, rulesByAlias };
+}
+
+describe('catalog-derived cross-target CSS artifact contexts', () => {
+  test.each(breakpointRows)('registers stable identity and exact catalog media for %s', (_label, alias, expected) => {
+    const registry = new CssArtifactRegistry();
+    const declarations = plannedGapDeclarations();
+    const context = cssRuleContext(breakpointDefinition(alias));
+    const first = registry.register('layout-gap', declarations, context);
+    const duplicate = registry.register('layout-gap', declarations, cssRuleContext(breakpointDefinition(alias)));
+
+    expect(first.context).toEqual(expected);
+    expect(duplicate).toBe(first);
+    expect(first.className).toMatch(/^flm-[a-f0-9]{64}$/u);
+    expect(registry.rules()).toEqual([first]);
+  });
+
+  test('deduplicates every context and orders rules independently of source order', () => {
+    const forward = registerBreakpointRows(breakpointRows);
+    const reverse = registerBreakpointRows([...breakpointRows].reverse());
+    const expectedAliasOrder = [
+      'base',
+      'xs',
+      'lt-sm',
+      'sm',
+      'lt-md',
+      'md',
+      'lt-lg',
+      'lg',
+      'lt-xl',
+      'xl',
+      'gt-lg',
+      'gt-md',
+      'gt-sm',
+      'gt-xs',
+    ];
+    const orderedAliases = (
+      rulesByAlias: ReadonlyMap<string, ReturnType<CssArtifactRegistry['register']>>,
+      rules: ReturnType<CssArtifactRegistry['rules']>,
+    ) => rules.map(rule => [...rulesByAlias].find(([, registered]) => registered.id === rule.id)?.[0]);
+
+    expect(forward.registry.rules()).toHaveLength(14);
+    expect(reverse.registry.rules()).toHaveLength(14);
+    expect(orderedAliases(forward.rulesByAlias, forward.registry.rules())).toEqual(expectedAliasOrder);
+    expect(orderedAliases(reverse.rulesByAlias, reverse.registry.rules())).toEqual(expectedAliasOrder);
+    expect(forward.registry.rules().map(rule => rule.id)).toEqual(reverse.registry.rules().map(rule => rule.id));
+  });
+});

--- a/test/compatibility/flex-renderer-parity.test.ts
+++ b/test/compatibility/flex-renderer-parity.test.ts
@@ -193,6 +193,7 @@ describe('cross-target Flex renderer parity', () => {
         { property: 'flex-shrink', value: '2' },
         { property: 'flex-basis', value: 'calc(100% - 2rem)' },
         { property: 'min-width', value: 'calc(100% - 2rem)' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
     [
@@ -202,6 +203,7 @@ describe('cross-target Flex renderer parity', () => {
         { property: 'flex', value: '1 1 10rem' },
         { property: 'min-height', value: '10rem' },
         { property: 'max-height', value: '10rem' },
+        { property: 'box-sizing', value: 'border-box' },
       ],
     ],
   ] as const)('renders one planned flex item with parent context %o through both targets', (input, tailwind, css) => {
@@ -210,6 +212,7 @@ describe('cross-target Flex renderer parity', () => {
     if (planned.status !== 'planned') throw new Error('Expected planned flex item semantics');
 
     const semantics = planned.value;
+    expect(semantics.boxSizing).toBe('border-box');
     expect(renderFlexItem(semantics)).toEqual(tailwind);
     expect(renderFlexItemCss(semantics)).toEqual(css);
   });


### PR DESCRIPTION
## Summary

Establish the in-memory native CSS renderer foundation for the target-neutral Flex semantic core.

This adds:

- pure declaration renderers for all eight scoped Flex semantic families;
- deterministic `flm-<sha256>` class identities;
- immutable owned-rule artifacts with deduplication and collision detection;
- responsive contexts sourced exclusively from `BreakpointCatalog`;
- base-first, priority-aware deterministic rule ordering;
- architecture guards and cross-target semantic parity coverage.

The CSS target is intentionally not exposed through the CLI yet. Stylesheet serialization, template integration, file writes, and multi-file transactions remain for later slices.

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

Fresh controller verification passed with 93 test files and 2,504 tests, plus formatting, ESLint, TypeScript, coverage, build, package validation, whitespace checks, and protected-scope checks.

## Migration example

Not applicable — this is an internal renderer foundation and does not expose new CLI behavior or change generated migration output.

## Dependencies and compatibility

None. No dependencies, Changesets, CLI contracts, existing Tailwind output, or public diagnostics changed.