### PR TITLE
feat: serialize and merge owned native CSS

### DIFF
--- a/docs/architecture/native-css-stylesheet.md
+++ b/docs/architecture/native-css-stylesheet.md
@@ -59,7 +59,7 @@ Violations throw `CssStylesheetError` with stable internal codes. They are progr
 
 `src/adapter/css/stylesheet/css-rule.serializer.ts` serializes an already ordered rule list. It does not sort, deduplicate, repair, or reinterpret artifacts.
 
-Base rules retain input order. Responsive rules are grouped only when both normalized media definition and priority are identical. Groups retain the order of their first rule, and rules retain input order within the group. `CssArtifactRegistry.rules()` remains the semantic ordering authority.
+Base rules retain input order. Adjacent responsive rules are grouped only when both normalized media definition and priority are identical. A later rule never moves across another rule to join an earlier media group. Groups and rules therefore retain exact input order, and `CssArtifactRegistry.rules()` remains the semantic ordering authority.
 
 Each base rule is formatted as:
 
@@ -116,8 +116,13 @@ Unterminated strings and comments are stylesheet parse failures. The scanner doe
 ```ts
 type OwnedCssBlockParseResult =
   | { readonly status: 'absent' }
-  | { readonly status: 'found'; readonly range: SourceRange; readonly newline: '\n' | '\r\n' }
+  | { readonly status: 'found'; readonly range: CssSourceRange; readonly newline: '\n' | '\r\n' }
   | { readonly status: 'invalid'; readonly code: CssStylesheetErrorCode; readonly reason: string };
+
+interface CssSourceRange {
+  readonly start: number;
+  readonly end: number;
+}
 ```
 
 It examines only scanner comment tokens. Marker-looking text inside strings or unrelated comments is ignored unless the complete trimmed comment content begins with `flex-layout-codemod:`.

--- a/docs/architecture/native-css-stylesheet.md
+++ b/docs/architecture/native-css-stylesheet.md
@@ -1,0 +1,233 @@
+# Native CSS Stylesheet Serialization and Ownership
+
+## Purpose
+
+This slice turns in-memory native CSS artifacts into a deterministic stylesheet block and safely composes that block with an existing companion stylesheet. It defines the durable on-disk ownership format before the CLI, template planner, or transaction layer can write CSS files.
+
+The operation is pure: existing stylesheet bytes plus ordered owned rules produce proposed stylesheet bytes. No filesystem path is read or written by this slice.
+
+## Scope
+
+The slice provides validation and deterministic serialization of `OwnedCssRule` values, one versioned codemod-owned block, lexical marker discovery, exact replacement or removal on rerun, byte preservation outside the block, deterministic LF/CRLF handling, and fail-closed errors for malformed ownership.
+
+CLI target selection, path validation, file I/O, template class edits, adapter orchestration, multi-file staging, backup, rollback, interruption handling, Grid, visibility, orientation, and print migration remain outside this slice.
+
+## Ownership format
+
+The generated region is one contiguous block:
+
+```css
+/* flex-layout-codemod:start schema=1 */
+/* flex-layout-codemod:rule id=<64 lowercase hex characters> */
+.flm-<same 64 lowercase hex characters > {
+  display: flex;
+}
+/* flex-layout-codemod:end */
+```
+
+The marker grammar is exact and ASCII-only:
+
+- start: `/* flex-layout-codemod:start schema=1 */`;
+- rule: `/* flex-layout-codemod:rule id=<id> */`; and
+- end: `/* flex-layout-codemod:end */`.
+
+The serializer emits no timestamp, source path, package version, counter, or process-dependent content. Schema `1` identifies this ownership and serialization contract. Only start and end comments delimit ownership; rule comments cannot independently claim handwritten content.
+
+## Components
+
+### Artifact validator
+
+`src/adapter/css/stylesheet/css-artifact.validator.ts` validates every rule before serialization. Normal rules come from `CssArtifactRegistry`, but this boundary must fail closed for manually constructed or corrupted values.
+
+Validation requires:
+
+- `owner` is exactly `flex-layout-codemod`;
+- `id` is exactly 64 lowercase hexadecimal characters;
+- `className` is exactly `flm-${id}`;
+- `family` is a declared `CssSemanticFamily`;
+- declarations are nonempty and property names are unique;
+- a property matches `^-?[a-z][a-z0-9-]*$`;
+- a value is nonempty, trimmed, and contains no NUL, CR, LF, braces, semicolon, or CSS comment delimiter;
+- priority is finite and a base rule has priority `0`;
+- media contains at least one clause;
+- every bound is finite and minimum does not exceed maximum; and
+- every clause has at least one feature unless its media type is `print`.
+
+Violations throw `CssStylesheetError` with stable internal codes. They are programming or configuration-boundary failures, not per-directive diagnostics.
+
+### Rule serializer
+
+`src/adapter/css/stylesheet/css-rule.serializer.ts` serializes an already ordered rule list. It does not sort, deduplicate, repair, or reinterpret artifacts.
+
+Base rules retain input order. Responsive rules are grouped only when both normalized media definition and priority are identical. Groups retain the order of their first rule, and rules retain input order within the group. `CssArtifactRegistry.rules()` remains the semantic ordering authority.
+
+Each base rule is formatted as:
+
+```css
+/* flex-layout-codemod:rule id=<id> */
+.<className > {
+  <property>: <value>;
+}
+```
+
+Declarations remain in artifact order. A single newline separates adjacent base rules.
+
+Each responsive group is formatted as:
+
+```css
+@media screen and (min-width: 600px) and (max-width: 959.98px) {
+  /* flex-layout-codemod:rule id=<id> */
+  .<className > {
+    <property>: <value>;
+  }
+}
+```
+
+Rules within one media block, base rules, and media blocks are separated by one newline. There is no blank line inside the generated block.
+
+### Media serialization
+
+Media serialization consumes `MediaDefinition`; it never accepts or looks up an alias. One clause becomes the media type followed by each present feature joined with `and`. Feature order is minimum width, maximum width, then orientation. Width values use finite-number `String()` conversion followed by `px`.
+
+Multiple clauses are comma-separated and repeat the media type:
+
+```css
+@media screen and (max-width: 599.98px) and (orientation: portrait), screen and (max-width: 959.98px) and (orientation: landscape) {
+```
+
+The acceptance surface remains the 13 standard screen aliases. Serializing the existing media model does not enable orientation or print CLI conversion.
+
+### Owned block serializer
+
+`src/adapter/css/stylesheet/owned-css-block.serializer.ts` wraps serialized rules with schema markers. It accepts an explicit newline restricted to `\n` or `\r\n`.
+
+For one or more rules, output is `<start marker>`, newline, serialized rules, newline, and `<end marker>`. The block has no leading or trailing newline. An empty rule list serializes to `''`, allowing removal without claiming adjacent handwritten whitespace.
+
+### CSS comment scanner
+
+`src/adapter/css/stylesheet/css-comment.scanner.ts` performs the minimum lexical scan needed to identify real CSS comments while ignoring marker-like text inside quoted strings. It recognizes single- and double-quoted strings, backslash escapes, CSS comments, and ordinary code points, and returns comment contents with exact source offsets.
+
+Unterminated strings and comments are stylesheet parse failures. The scanner does not parse selectors, declarations, nesting, or at-rules.
+
+### Ownership parser
+
+`src/adapter/css/stylesheet/owned-css-block.parser.ts` returns:
+
+```ts
+type OwnedCssBlockParseResult =
+  | { readonly status: 'absent' }
+  | { readonly status: 'found'; readonly range: SourceRange; readonly newline: '\n' | '\r\n' }
+  | { readonly status: 'invalid'; readonly code: CssStylesheetErrorCode; readonly reason: string };
+```
+
+It examines only scanner comment tokens. Marker-looking text inside strings or unrelated comments is ignored unless the complete trimmed comment content begins with `flex-layout-codemod:`.
+
+The parser rejects unsupported schemas, unknown marker kinds, duplicate starts or ends, end-before-start, missing matches, nested regions, rule markers outside the region, malformed rule IDs, and a rule metadata ID that does not match its exact following `.flm-<id>` selector.
+
+For a found block, `range` starts at the slash of the start comment and ends after the slash of the end comment. Adjacent handwritten whitespace remains outside the range. The newline is the first terminator inside the block; a marker-only single-line block uses the document newline preference.
+
+### Stylesheet merger
+
+`src/adapter/css/stylesheet/owned-stylesheet.merger.ts` exposes:
+
+```ts
+interface OwnedStylesheetMergeResult {
+  readonly changed: boolean;
+  readonly output: string;
+}
+
+export function mergeOwnedStylesheet(existing: string, rules: readonly OwnedCssRule[]): OwnedStylesheetMergeResult;
+```
+
+The merger parses ownership first. Invalid ownership throws `CssStylesheetError`; it never edits ambiguous input.
+
+Newline preference is deterministic:
+
+1. retain the newline found inside an existing valid block;
+2. otherwise use the first terminator in the stylesheet; and
+3. default to LF when no terminator exists.
+
+Behavior is exact:
+
+- absent block plus rules: append the serialized block directly at end of input;
+- found block plus rules: replace exactly the parsed range;
+- found block plus no rules: remove exactly the parsed range;
+- absent block plus no rules: return input unchanged.
+
+The merger inserts no separator outside the owned block. If handwritten CSS lacks a trailing newline, the start marker immediately follows its final token; CSS comments are valid token separators and this preserves every existing byte. A later CLI may recommend a conventional stylesheet ending but cannot rewrite one implicitly.
+
+`changed` is `output !== existing`. Repeating a merge with the same ordered rules is byte-idempotent.
+
+## Error model
+
+`CssStylesheetError` carries one stable internal code:
+
+- `invalid-artifact`;
+- `invalid-css-lexeme`;
+- `unterminated-css-token`;
+- `unknown-ownership-marker`;
+- `unsupported-ownership-schema`;
+- `malformed-ownership-block`; or
+- `ownership-rule-mismatch`.
+
+The reason is concise and contains no absolute path. A later application boundary adds path context and maps failures into configuration or internal-invariant reporting. This slice does not alter public `DiagnosticCode`.
+
+## Data flow
+
+```text
+CssArtifactRegistry.rules()
+           |
+           v
+  validate and serialize rules
+           |
+           v
+    versioned owned block
+           |
+           +--------------------+
+                                |
+existing CSS -> comment scan -> ownership parse
+                                |
+                                v
+                     exact range replacement
+                                |
+                                v
+                      proposed CSS in memory
+```
+
+## Testing
+
+Behavior changes follow TDD. Verification includes:
+
+- exact base-rule and declaration formatting;
+- exact min-only, max-only, bounded, multi-clause, orientation, and print media-model formatting;
+- grouping only identical media-plus-priority contexts;
+- preservation of registry rule order;
+- artifact validation and injection-resistant rejection;
+- LF and CRLF block output;
+- empty, handwritten-only, owned-only, prefix, suffix, and surrounding handwritten content;
+- exact preservation outside the owned range;
+- marker-looking strings, unrelated comments, escaped quotes, and comment delimiters inside strings;
+- every malformed, duplicate, nested, unknown, unsupported, unterminated, and mismatched-marker case;
+- append, replace, remove, unchanged, rule-set shrink/growth, and idempotent merge behavior;
+- architecture tests preventing filesystem, CLI, template, planner, or Tailwind dependencies; and
+- the complete repository verification command.
+
+Property-based testing is unnecessary for this bounded grammar; table-driven lexical fixtures and mutation cases provide clearer evidence.
+
+No Changeset or compatibility-inventory update is added because no user-facing target can reach this code.
+
+## Implementation sequence
+
+1. Establish stable stylesheet errors and artifact validation.
+2. Serialize rules, media groups, and complete owned blocks.
+3. Scan CSS comments and parse ownership ranges.
+4. Merge blocks with exact byte preservation and newline/idempotence contracts.
+5. Add architecture, corruption, and end-to-end registry-to-stylesheet verification.
+
+Each step is independently reviewable. Existing Tailwind and native artifact-generation behavior remains unchanged.
+
+## Completion criteria
+
+The slice is complete when ordered `OwnedCssRule` values serialize deterministically; a valid block can be appended, replaced, or removed without changing surrounding bytes; malformed ownership fails closed with stable codes; repeated merges are byte-identical; and no CLI, template, or filesystem path exposes the unfinished CSS target.
+
+The following slice can integrate native CSS planning with template class edits and transactional application using this pure merge operation.

--- a/src/adapter/css/stylesheet/css-artifact.validator.spec.ts
+++ b/src/adapter/css/stylesheet/css-artifact.validator.spec.ts
@@ -53,6 +53,12 @@ describe('validateOwnedCssRule', () => {
     invalidArtifact({ ...validRule, ...mutation } as OwnedCssRule);
   });
 
+  test('rejects an ID with a final newline', () => {
+    const id = `${ID}\n`;
+
+    invalidArtifact({ ...validRule, id, className: `flm-${id}` });
+  });
+
   test('rejects empty declarations', () => {
     invalidArtifact({ ...validRule, declarations: [] });
   });
@@ -69,6 +75,10 @@ describe('validateOwnedCssRule', () => {
 
   test.each(['display:', 'Display', '1display', '--custom'])('rejects malformed property %j', property => {
     invalidLexeme({ ...validRule, declarations: [{ property, value: 'flex' }] });
+  });
+
+  test('rejects a property with a final newline', () => {
+    invalidLexeme({ ...validRule, declarations: [{ property: 'display\n', value: 'flex' }] });
   });
 
   test.each([

--- a/src/adapter/css/stylesheet/css-artifact.validator.spec.ts
+++ b/src/adapter/css/stylesheet/css-artifact.validator.spec.ts
@@ -1,0 +1,137 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { validateOwnedCssRule } from './css-artifact.validator';
+
+const ID = 'a'.repeat(64);
+
+const validRule: OwnedCssRule = Object.freeze({
+  owner: 'flex-layout-codemod',
+  id: ID,
+  className: `flm-${ID}`,
+  family: 'layout',
+  declarations: Object.freeze([Object.freeze({ property: 'display', value: 'flex' })]),
+  context: Object.freeze({ priority: 0 }),
+});
+
+function invalidArtifact(rule: OwnedCssRule): void {
+  expect(() => validateOwnedCssRule(rule)).toThrow(expect.objectContaining({ code: 'invalid-artifact' }));
+}
+
+function invalidLexeme(rule: OwnedCssRule): void {
+  expect(() => validateOwnedCssRule(rule)).toThrow(expect.objectContaining({ code: 'invalid-css-lexeme' }));
+}
+
+function ruleWithValue(value: string): OwnedCssRule {
+  return { ...validRule, declarations: [{ property: 'color', value }] };
+}
+
+describe('validateOwnedCssRule', () => {
+  test('accepts a valid frozen base rule', () => {
+    expect(() => validateOwnedCssRule(validRule)).not.toThrow();
+  });
+
+  test.each([
+    ['layout', [{ property: 'display', value: 'flex' }]],
+    ['layout-align', [{ property: 'justify-content', value: 'space-between' }]],
+    ['layout-gap', [{ property: 'gap', value: 'calc(50% - 1rem)' }]],
+    ['flex-item', [{ property: 'box-sizing', value: 'border-box' }]],
+    ['flex-align', [{ property: 'align-self', value: 'center' }]],
+    ['flex-fill', [{ property: 'flex', value: '1 1 auto' }]],
+    ['flex-offset', [{ property: 'margin-inline-start', value: '12.5px' }]],
+    ['flex-order', [{ property: 'order', value: '-1' }]],
+  ] as const)('accepts safe declarations for the %s family', (family, declarations) => {
+    expect(() => validateOwnedCssRule({ ...validRule, family, declarations })).not.toThrow();
+  });
+
+  test.each([
+    ['owner', { owner: 'other-codemod' }],
+    ['short ID', { id: 'a'.repeat(63) }],
+    ['uppercase ID', { id: `${'a'.repeat(63)}A` }],
+    ['non-hexadecimal ID', { id: `${'a'.repeat(63)}g` }],
+    ['class name', { className: 'flm-wrong' }],
+    ['unknown family', { family: 'grid' }],
+  ])('rejects an invalid %s identity field', (_label, mutation) => {
+    invalidArtifact({ ...validRule, ...mutation } as OwnedCssRule);
+  });
+
+  test('rejects empty declarations', () => {
+    invalidArtifact({ ...validRule, declarations: [] });
+  });
+
+  test('rejects duplicate declaration properties', () => {
+    invalidArtifact({
+      ...validRule,
+      declarations: [
+        { property: 'display', value: 'flex' },
+        { property: 'display', value: 'inline-flex' },
+      ],
+    });
+  });
+
+  test.each(['display:', 'Display', '1display', '--custom'])('rejects malformed property %j', property => {
+    invalidLexeme({ ...validRule, declarations: [{ property, value: 'flex' }] });
+  });
+
+  test.each([
+    '',
+    ' flex',
+    'flex ',
+    'red;display:none',
+    'red{display:none}',
+    'red/* comment */',
+    'red\nblue',
+    'red\rblue',
+    'red\0blue',
+  ])('rejects an unsafe declaration value %j', value => {
+    invalidLexeme(ruleWithValue(value));
+  });
+
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects non-finite priority %s',
+    priority => {
+      invalidArtifact({ ...validRule, context: { priority } });
+    },
+  );
+
+  test.each([-1, 1])('rejects nonzero base priority %s', priority => {
+    invalidArtifact({ ...validRule, context: { priority } });
+  });
+
+  test('rejects media without clauses', () => {
+    invalidArtifact({ ...validRule, context: { priority: 1, media: { type: 'screen', clauses: [] } } });
+  });
+
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects a non-finite media bound %s',
+    bound => {
+      invalidArtifact({
+        ...validRule,
+        context: { priority: 1, media: { type: 'screen', clauses: [{ min: bound }] } },
+      });
+    },
+  );
+
+  test('rejects reversed media bounds', () => {
+    invalidArtifact({
+      ...validRule,
+      context: { priority: 1, media: { type: 'screen', clauses: [{ min: 960, max: 600 }] } },
+    });
+  });
+
+  test('rejects a featureless screen clause', () => {
+    invalidArtifact({ ...validRule, context: { priority: 1, media: { type: 'screen', clauses: [{}] } } });
+  });
+
+  test('accepts a featureless print clause', () => {
+    expect(() =>
+      validateOwnedCssRule({ ...validRule, context: { priority: -1000, media: { type: 'print', clauses: [{}] } } }),
+    ).not.toThrow();
+  });
+
+  test('rejects malformed runtime structures despite their static cast', () => {
+    invalidArtifact({
+      ...validRule,
+      declarations: [null],
+      context: { priority: 1, media: { type: 'screen', clauses: [{ orientation: 'diagonal' }] } },
+    } as unknown as OwnedCssRule);
+  });
+});

--- a/src/adapter/css/stylesheet/css-artifact.validator.ts
+++ b/src/adapter/css/stylesheet/css-artifact.validator.ts
@@ -1,8 +1,8 @@
 import type { CssSemanticFamily, OwnedCssRule } from '../css-artifact.model';
 import { CssStylesheetError } from './css-stylesheet.error';
 
-const ID = /^[a-f0-9]{64}$/;
-const PROPERTY = /^-?[a-z][a-z0-9-]*$/;
+const ID = /^(?:[a-f0-9]{64})$(?![\s\S])/;
+const PROPERTY = /^(?:-?[a-z][a-z0-9-]*)$(?![\s\S])/;
 const FORBIDDEN_VALUE = /[\0\r\n{};]|\/\*|\*\//;
 const FAMILIES = new Set<CssSemanticFamily>([
   'layout',

--- a/src/adapter/css/stylesheet/css-artifact.validator.ts
+++ b/src/adapter/css/stylesheet/css-artifact.validator.ts
@@ -1,0 +1,140 @@
+import type { CssSemanticFamily, OwnedCssRule } from '../css-artifact.model';
+import { CssStylesheetError } from './css-stylesheet.error';
+
+const ID = /^[a-f0-9]{64}$/;
+const PROPERTY = /^-?[a-z][a-z0-9-]*$/;
+const FORBIDDEN_VALUE = /[\0\r\n{};]|\/\*|\*\//;
+const FAMILIES = new Set<CssSemanticFamily>([
+  'layout',
+  'layout-align',
+  'layout-gap',
+  'flex-item',
+  'flex-align',
+  'flex-fill',
+  'flex-offset',
+  'flex-order',
+]);
+
+type ArtifactRecord = Record<string, unknown>;
+
+function isArtifactRecord(value: unknown): value is ArtifactRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalidArtifact(message: string): never {
+  throw new CssStylesheetError('invalid-artifact', message);
+}
+
+function invalidLexeme(message: string): never {
+  throw new CssStylesheetError('invalid-css-lexeme', message);
+}
+
+function validateDeclarations(value: unknown): void {
+  if (!Array.isArray(value) || value.length === 0) {
+    invalidArtifact('CSS declarations must be a nonempty array');
+  }
+
+  const properties = new Set<string>();
+  for (const declaration of value) {
+    if (!isArtifactRecord(declaration)) {
+      invalidArtifact('CSS declaration must be an object');
+    }
+
+    const { property, value: declarationValue } = declaration;
+    if (typeof property !== 'string' || !PROPERTY.test(property)) {
+      invalidLexeme('CSS declaration property is unsafe');
+    }
+    if (properties.has(property)) {
+      invalidArtifact('CSS declaration properties must be unique');
+    }
+    properties.add(property);
+
+    if (
+      typeof declarationValue !== 'string' ||
+      declarationValue.length === 0 ||
+      declarationValue.trim() !== declarationValue ||
+      FORBIDDEN_VALUE.test(declarationValue)
+    ) {
+      invalidLexeme('CSS declaration value is unsafe');
+    }
+  }
+}
+
+function validateMedia(value: unknown): void {
+  if (!isArtifactRecord(value)) {
+    invalidArtifact('CSS media must be an object');
+  }
+
+  const { type, clauses } = value;
+  if (type !== 'screen' && type !== 'print') {
+    invalidArtifact('CSS media type is invalid');
+  }
+  if (!Array.isArray(clauses) || clauses.length === 0) {
+    invalidArtifact('CSS media must contain at least one clause');
+  }
+
+  for (const clause of clauses) {
+    if (!isArtifactRecord(clause)) {
+      invalidArtifact('CSS media clause must be an object');
+    }
+
+    const { min, max, orientation } = clause;
+    if (
+      (min !== undefined && (typeof min !== 'number' || !Number.isFinite(min))) ||
+      (max !== undefined && (typeof max !== 'number' || !Number.isFinite(max)))
+    ) {
+      invalidArtifact('CSS media bounds must be finite numbers');
+    }
+    if (min !== undefined && max !== undefined && min > max) {
+      invalidArtifact('CSS media minimum must not exceed maximum');
+    }
+    if (orientation !== undefined && orientation !== 'portrait' && orientation !== 'landscape') {
+      invalidArtifact('CSS media orientation is invalid');
+    }
+    if (type === 'screen' && min === undefined && max === undefined && orientation === undefined) {
+      invalidArtifact('CSS screen media clause must contain a feature');
+    }
+  }
+}
+
+function validateContext(value: unknown): void {
+  if (!isArtifactRecord(value)) {
+    invalidArtifact('CSS rule context must be an object');
+  }
+
+  const { priority, media } = value;
+  if (typeof priority !== 'number' || !Number.isFinite(priority)) {
+    invalidArtifact('CSS rule priority must be a finite number');
+  }
+  if (media === undefined) {
+    if (priority !== 0) {
+      invalidArtifact('CSS base rule priority must be zero');
+    }
+    return;
+  }
+
+  validateMedia(media);
+}
+
+export function validateOwnedCssRule(rule: OwnedCssRule): void {
+  if (!isArtifactRecord(rule)) {
+    invalidArtifact('CSS rule must be an object');
+  }
+
+  const { owner, id, className, family, declarations, context } = rule;
+  if (owner !== 'flex-layout-codemod') {
+    invalidArtifact('CSS rule owner is invalid');
+  }
+  if (typeof id !== 'string' || !ID.test(id)) {
+    invalidArtifact('CSS rule ID is invalid');
+  }
+  if (className !== `flm-${id}`) {
+    invalidArtifact('CSS rule class name is invalid');
+  }
+  if (typeof family !== 'string' || !FAMILIES.has(family as CssSemanticFamily)) {
+    invalidArtifact('CSS rule family is invalid');
+  }
+
+  validateDeclarations(declarations);
+  validateContext(context);
+}

--- a/src/adapter/css/stylesheet/css-comment.scanner.spec.ts
+++ b/src/adapter/css/stylesheet/css-comment.scanner.spec.ts
@@ -1,0 +1,67 @@
+import { CssStylesheetError } from './css-stylesheet.error';
+import { scanCssComments } from './css-comment.scanner';
+
+describe('scanCssComments', () => {
+  test('returns no comments for empty CSS', () => {
+    expect(scanCssComments('')).toEqual([]);
+  });
+
+  test('returns exact offsets and content for an ordinary comment', () => {
+    const source = '.x {} /* ordinary */ .y {}';
+
+    expect(scanCssComments(source)).toEqual([
+      {
+        start: 6,
+        end: 20,
+        content: ' ordinary ',
+      },
+    ]);
+  });
+
+  test('returns adjacent comments as separate tokens', () => {
+    expect(scanCssComments('/* one *//*two*/')).toEqual([
+      { start: 0, end: 9, content: ' one ' },
+      { start: 9, end: 16, content: 'two' },
+    ]);
+  });
+
+  test('ignores marker-looking text inside a quoted string', () => {
+    const source = `.x::before{content:"/* flex-layout-codemod:start schema=1 */"}/* real */`;
+
+    expect(scanCssComments(source)).toEqual([
+      { start: source.indexOf('/* real */'), end: source.length, content: ' real ' },
+    ]);
+  });
+
+  test('honors escaped quotes and backslashes in both quote styles', () => {
+    const source = String.raw`.a{content:"escaped \" quote and \\ slash"}.b{content:'escaped \' quote and \\ slash'}/* after */`;
+
+    expect(scanCssComments(source)).toEqual([
+      { start: source.indexOf('/* after */'), end: source.length, content: ' after ' },
+    ]);
+  });
+
+  test('recognizes a comment delimiter immediately after a string', () => {
+    const source = `.x{content:'done'}/* after */`;
+
+    expect(scanCssComments(source)).toEqual([
+      { start: source.indexOf('/* after */'), end: source.length, content: ' after ' },
+    ]);
+  });
+
+  test.each([
+    ['LF', '.x{}\n/* line\ncomment */', 5, 23, ' line\ncomment '],
+    ['CRLF', '.x{}\r\n/* line\r\ncomment */', 6, 25, ' line\r\ncomment '],
+  ] as const)('preserves exact offsets and content in %s input', (_label, source, start, end, content) => {
+    expect(scanCssComments(source)).toEqual([{ start, end, content }]);
+  });
+
+  test.each([
+    ['comment', '/* unfinished', 'Unterminated CSS comment'],
+    ['single-quoted string', ".x{content:'unfinished}", 'Unterminated CSS single-quoted string'],
+    ['double-quoted string', '.x{content:"unfinished}', 'Unterminated CSS double-quoted string'],
+  ])('throws a stable stylesheet error for an unterminated %s', (_label, source, message) => {
+    expect(() => scanCssComments(source)).toThrow(CssStylesheetError);
+    expect(() => scanCssComments(source)).toThrow(expect.objectContaining({ code: 'unterminated-css-token', message }));
+  });
+});

--- a/src/adapter/css/stylesheet/css-comment.scanner.spec.ts
+++ b/src/adapter/css/stylesheet/css-comment.scanner.spec.ts
@@ -50,6 +50,36 @@ describe('scanCssComments', () => {
   });
 
   test.each([
+    ['escaped quote', String.raw`.escaped\"text"/* flex-layout-codemod:start schema=1 */"/* real */`],
+    ['escaped comment opener', String.raw`.escaped\/* flex-layout-codemod:start schema=1 */;/* real */`],
+  ])('does not expose marker text after an %s in normal CSS', (_label, source) => {
+    const realCommentStart = source.indexOf('/* real */');
+
+    expect(scanCssComments(source)).toEqual([{ start: realCommentStart, end: source.length, content: ' real ' }]);
+  });
+
+  test.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n'],
+    ['CR', '\r'],
+    ['form feed', '\f'],
+  ])('does not consume a %s terminator as a normal-state escape', (_label, terminator) => {
+    const source = `\\${terminator}/* real */`;
+    const commentStart = 1 + terminator.length;
+
+    expect(scanCssComments(source)).toEqual([{ start: commentStart, end: source.length, content: ' real ' }]);
+  });
+
+  test.each([
+    ['without trailing whitespace', String.raw`.escaped\2f/* real */`],
+    ['with CRLF trailing whitespace', `.escaped\\00002f\r\n/* real */`],
+  ])('recognizes a real comment after a hex escape %s', (_label, source) => {
+    const commentStart = source.indexOf('/* real */');
+
+    expect(scanCssComments(source)).toEqual([{ start: commentStart, end: source.length, content: ' real ' }]);
+  });
+
+  test.each([
     ['LF', '.x{}\n/* line\ncomment */', 5, 23, ' line\ncomment '],
     ['CRLF', '.x{}\r\n/* line\r\ncomment */', 6, 25, ' line\r\ncomment '],
   ] as const)('preserves exact offsets and content in %s input', (_label, source, start, end, content) => {

--- a/src/adapter/css/stylesheet/css-comment.scanner.ts
+++ b/src/adapter/css/stylesheet/css-comment.scanner.ts
@@ -1,0 +1,69 @@
+import { CssStylesheetError } from './css-stylesheet.error';
+
+export interface CssSourceRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+export interface CssCommentToken extends CssSourceRange {
+  readonly content: string;
+}
+
+type ScannerState = 'normal' | 'single-quote' | 'double-quote' | 'comment';
+
+export function scanCssComments(source: string): readonly CssCommentToken[] {
+  const comments: CssCommentToken[] = [];
+  let state: ScannerState = 'normal';
+  let commentStart = -1;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const codeUnit = source[index];
+
+    if (state === 'normal') {
+      if (codeUnit === "'") {
+        state = 'single-quote';
+      } else if (codeUnit === '"') {
+        state = 'double-quote';
+      } else if (codeUnit === '/' && source[index + 1] === '*') {
+        state = 'comment';
+        commentStart = index;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (state === 'comment') {
+      if (codeUnit === '*' && source[index + 1] === '/') {
+        comments.push({
+          start: commentStart,
+          end: index + 2,
+          content: source.slice(commentStart + 2, index),
+        });
+        state = 'normal';
+        index += 1;
+      }
+      continue;
+    }
+
+    if (codeUnit === '\\') {
+      index += 1;
+      continue;
+    }
+
+    if ((state === 'single-quote' && codeUnit === "'") || (state === 'double-quote' && codeUnit === '"')) {
+      state = 'normal';
+    }
+  }
+
+  if (state === 'comment') {
+    throw new CssStylesheetError('unterminated-css-token', 'Unterminated CSS comment');
+  }
+  if (state === 'single-quote') {
+    throw new CssStylesheetError('unterminated-css-token', 'Unterminated CSS single-quoted string');
+  }
+  if (state === 'double-quote') {
+    throw new CssStylesheetError('unterminated-css-token', 'Unterminated CSS double-quoted string');
+  }
+
+  return comments;
+}

--- a/src/adapter/css/stylesheet/css-comment.scanner.ts
+++ b/src/adapter/css/stylesheet/css-comment.scanner.ts
@@ -11,6 +11,33 @@ export interface CssCommentToken extends CssSourceRange {
 
 type ScannerState = 'normal' | 'single-quote' | 'double-quote' | 'comment';
 
+function cssNewlineEnd(source: string, start: number): number | undefined {
+  const codeUnit = source[start];
+  if (codeUnit === '\r') return source[start + 1] === '\n' ? start + 1 : start;
+  return codeUnit === '\n' || codeUnit === '\f' ? start : undefined;
+}
+
+function isHexDigit(codeUnit: string | undefined): boolean {
+  return codeUnit !== undefined && /^[0-9a-f]$/iu.test(codeUnit);
+}
+
+function consumeCssEscape(source: string, backslash: number): number | undefined {
+  let index = backslash + 1;
+  if (cssNewlineEnd(source, index) !== undefined) return undefined;
+  if (!isHexDigit(source[index])) return index < source.length ? index : backslash;
+
+  let hexDigits = 0;
+  while (hexDigits < 6 && isHexDigit(source[index])) {
+    index += 1;
+    hexDigits += 1;
+  }
+
+  const newlineEnd = cssNewlineEnd(source, index);
+  if (newlineEnd !== undefined) return newlineEnd;
+  if (source[index] === ' ' || source[index] === '\t') return index;
+  return index - 1;
+}
+
 export function scanCssComments(source: string): readonly CssCommentToken[] {
   const comments: CssCommentToken[] = [];
   let state: ScannerState = 'normal';
@@ -20,7 +47,9 @@ export function scanCssComments(source: string): readonly CssCommentToken[] {
     const codeUnit = source[index];
 
     if (state === 'normal') {
-      if (codeUnit === "'") {
+      if (codeUnit === '\\') {
+        index = consumeCssEscape(source, index) ?? index;
+      } else if (codeUnit === "'") {
         state = 'single-quote';
       } else if (codeUnit === '"') {
         state = 'double-quote';
@@ -46,7 +75,8 @@ export function scanCssComments(source: string): readonly CssCommentToken[] {
     }
 
     if (codeUnit === '\\') {
-      index += 1;
+      const newlineEnd = cssNewlineEnd(source, index + 1);
+      index = newlineEnd ?? consumeCssEscape(source, index) ?? index;
       continue;
     }
 

--- a/src/adapter/css/stylesheet/css-media.serializer.spec.ts
+++ b/src/adapter/css/stylesheet/css-media.serializer.spec.ts
@@ -1,0 +1,30 @@
+import type { MediaDefinition } from '../../../breakpoint/breakpoint-catalog';
+import { serializeCssMedia } from './css-media.serializer';
+
+describe('serializeCssMedia', () => {
+  test.each([
+    [{ type: 'screen', clauses: [{ min: 600 }] }, 'screen and (min-width: 600px)'],
+    [{ type: 'screen', clauses: [{ max: 599.98 }] }, 'screen and (max-width: 599.98px)'],
+    [
+      { type: 'screen', clauses: [{ min: 600, max: 959.98 }] },
+      'screen and (min-width: 600px) and (max-width: 959.98px)',
+    ],
+    [
+      { type: 'screen', clauses: [{ min: 600, orientation: 'landscape' }] },
+      'screen and (min-width: 600px) and (orientation: landscape)',
+    ],
+    [{ type: 'print', clauses: [{}] }, 'print'],
+    [
+      {
+        type: 'screen',
+        clauses: [
+          { max: 599.98, orientation: 'portrait' },
+          { max: 959.98, orientation: 'landscape' },
+        ],
+      },
+      'screen and (max-width: 599.98px) and (orientation: portrait), screen and (max-width: 959.98px) and (orientation: landscape)',
+    ],
+  ] as const)('serializes %o exactly', (media: MediaDefinition, expected) => {
+    expect(serializeCssMedia(media)).toBe(expected);
+  });
+});

--- a/src/adapter/css/stylesheet/css-media.serializer.ts
+++ b/src/adapter/css/stylesheet/css-media.serializer.ts
@@ -1,0 +1,14 @@
+import type { MediaDefinition, MediaRange } from '../../../breakpoint/breakpoint-catalog';
+
+function serializeClause(type: MediaDefinition['type'], clause: MediaRange): string {
+  const features: string[] = [];
+  if (clause.min !== undefined) features.push(`(min-width: ${String(clause.min)}px)`);
+  if (clause.max !== undefined) features.push(`(max-width: ${String(clause.max)}px)`);
+  if (clause.orientation !== undefined) features.push(`(orientation: ${clause.orientation})`);
+
+  return [type, ...features].join(' and ');
+}
+
+export function serializeCssMedia(media: MediaDefinition): string {
+  return media.clauses.map(clause => serializeClause(media.type, clause)).join(', ');
+}

--- a/src/adapter/css/stylesheet/css-rule.serializer.spec.ts
+++ b/src/adapter/css/stylesheet/css-rule.serializer.spec.ts
@@ -49,6 +49,14 @@ describe('serializeCssRules', () => {
     );
   });
 
+  test('serializes a valid base rule with a caller-owned key property normally', () => {
+    const baseRule = { ...rule(A), key: 'caller-owned metadata' };
+
+    expect(serializeCssRules([baseRule], '\n')).toBe(
+      `/* flex-layout-codemod:rule id=${A} */\n.flm-${A} {\n  display: flex;\n}`,
+    );
+  });
+
   test('indents responsive rules inside their media block', () => {
     expect(serializeCssRules([rule(A, { priority: 900, media: MEDIA })], '\n')).toBe(
       `@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${A} */\n  .flm-${A} {\n    display: flex;\n  }\n}`,

--- a/src/adapter/css/stylesheet/css-rule.serializer.spec.ts
+++ b/src/adapter/css/stylesheet/css-rule.serializer.spec.ts
@@ -1,0 +1,96 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { serializeCssRules } from './css-rule.serializer';
+
+function rule(
+  id: string,
+  context: OwnedCssRule['context'] = { priority: 0 },
+  declarations: OwnedCssRule['declarations'] = [{ property: 'display', value: 'flex' }],
+): OwnedCssRule {
+  return {
+    owner: 'flex-layout-codemod',
+    id,
+    className: `flm-${id}`,
+    family: 'layout',
+    declarations,
+    context,
+  };
+}
+
+const A = 'a'.repeat(64);
+const B = 'b'.repeat(64);
+const C = 'c'.repeat(64);
+const D = 'd'.repeat(64);
+const MEDIA = { type: 'screen' as const, clauses: [{ min: 600, max: 959.98 }] };
+
+describe('serializeCssRules', () => {
+  test('serializes a base rule with declarations in artifact order using LF', () => {
+    expect(
+      serializeCssRules(
+        [
+          rule(A, { priority: 0 }, [
+            { property: 'display', value: 'flex' },
+            { property: 'flex-direction', value: 'row' },
+          ]),
+        ],
+        '\n',
+      ),
+    ).toBe(`/* flex-layout-codemod:rule id=${A} */\n.flm-${A} {\n  display: flex;\n  flex-direction: row;\n}`);
+  });
+
+  test('uses the requested CRLF newline sequence', () => {
+    expect(serializeCssRules([rule(A)], '\r\n')).toBe(
+      `/* flex-layout-codemod:rule id=${A} */\r\n.flm-${A} {\r\n  display: flex;\r\n}`,
+    );
+  });
+
+  test('separates adjacent base rules without reordering them', () => {
+    expect(serializeCssRules([rule(A), rule(B)], '\n')).toBe(
+      `/* flex-layout-codemod:rule id=${A} */\n.flm-${A} {\n  display: flex;\n}\n/* flex-layout-codemod:rule id=${B} */\n.flm-${B} {\n  display: flex;\n}`,
+    );
+  });
+
+  test('indents responsive rules inside their media block', () => {
+    expect(serializeCssRules([rule(A, { priority: 900, media: MEDIA })], '\n')).toBe(
+      `@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${A} */\n  .flm-${A} {\n    display: flex;\n  }\n}`,
+    );
+  });
+
+  test('groups only adjacent rules with structurally equal media and priority', () => {
+    expect(
+      serializeCssRules(
+        [
+          rule(A, { priority: 900, media: MEDIA }),
+          rule(B, { priority: 900, media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] } }),
+        ],
+        '\n',
+      ),
+    ).toBe(
+      `@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${A} */\n  .flm-${A} {\n    display: flex;\n  }\n  /* flex-layout-codemod:rule id=${B} */\n  .flm-${B} {\n    display: flex;\n  }\n}`,
+    );
+  });
+
+  test('keeps equal media with different priorities in separate adjacent blocks', () => {
+    expect(
+      serializeCssRules([rule(A, { priority: 900, media: MEDIA }), rule(B, { priority: 800, media: MEDIA })], '\n'),
+    ).toBe(
+      `@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${A} */\n  .flm-${A} {\n    display: flex;\n  }\n}\n@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${B} */\n  .flm-${B} {\n    display: flex;\n  }\n}`,
+    );
+  });
+
+  test('does not regroup matching contexts across another rule', () => {
+    expect(
+      serializeCssRules(
+        [rule(A, { priority: 900, media: MEDIA }), rule(C), rule(B, { priority: 900, media: MEDIA }), rule(D)],
+        '\n',
+      ),
+    ).toBe(
+      `@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${A} */\n  .flm-${A} {\n    display: flex;\n  }\n}\n/* flex-layout-codemod:rule id=${C} */\n.flm-${C} {\n  display: flex;\n}\n@media screen and (min-width: 600px) and (max-width: 959.98px) {\n  /* flex-layout-codemod:rule id=${B} */\n  .flm-${B} {\n    display: flex;\n  }\n}\n/* flex-layout-codemod:rule id=${D} */\n.flm-${D} {\n  display: flex;\n}`,
+    );
+  });
+
+  test('rejects a newline outside the artifact contract', () => {
+    expect(() => serializeCssRules([rule(A)], '\r' as never)).toThrow(
+      expect.objectContaining({ code: 'invalid-artifact' }),
+    );
+  });
+});

--- a/src/adapter/css/stylesheet/css-rule.serializer.ts
+++ b/src/adapter/css/stylesheet/css-rule.serializer.ts
@@ -1,0 +1,80 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import type { MediaDefinition } from '../../../breakpoint/breakpoint-catalog';
+import { validateOwnedCssRule } from './css-artifact.validator';
+import { CssStylesheetError } from './css-stylesheet.error';
+import { serializeCssMedia } from './css-media.serializer';
+
+export type CssNewline = '\n' | '\r\n';
+
+interface ResponsiveGroup {
+  readonly key: string;
+  readonly media: MediaDefinition;
+  readonly rules: readonly OwnedCssRule[];
+}
+
+type RuleGroup = OwnedCssRule | ResponsiveGroup;
+
+function validateNewline(newline: CssNewline): void {
+  if (newline !== '\n' && newline !== '\r\n') {
+    throw new CssStylesheetError('invalid-artifact', 'CSS newline must be LF or CRLF');
+  }
+}
+
+function mediaGroupKey(rule: OwnedCssRule): string {
+  const media = rule.context.media;
+  if (media === undefined) throw new CssStylesheetError('invalid-artifact', 'CSS responsive rule media is required');
+
+  return JSON.stringify([
+    media.type,
+    media.clauses.map(clause => [clause.min ?? null, clause.max ?? null, clause.orientation ?? null]),
+    rule.context.priority,
+  ]);
+}
+
+function serializeBaseRule(rule: OwnedCssRule, newline: CssNewline): string {
+  return [
+    `/* flex-layout-codemod:rule id=${rule.id} */`,
+    `.${rule.className} {`,
+    ...rule.declarations.map(({ property, value }) => `  ${property}: ${value};`),
+    '}',
+  ].join(newline);
+}
+
+function serializeResponsiveGroup(group: ResponsiveGroup, newline: CssNewline): string {
+  const rules = group.rules
+    .map(rule =>
+      serializeBaseRule(rule, newline)
+        .split(newline)
+        .map(line => `  ${line}`)
+        .join(newline),
+    )
+    .join(newline);
+
+  return [`@media ${serializeCssMedia(group.media)} {`, rules, '}'].join(newline);
+}
+
+export function serializeCssRules(rules: readonly OwnedCssRule[], newline: CssNewline): string {
+  validateNewline(newline);
+  rules.forEach(validateOwnedCssRule);
+
+  const groups: RuleGroup[] = [];
+  for (const rule of rules) {
+    if (rule.context.media === undefined) {
+      groups.push(rule);
+      continue;
+    }
+
+    const key = mediaGroupKey(rule);
+    const previous = groups.at(-1);
+    if (previous !== undefined && 'key' in previous && previous.key === key) {
+      groups[groups.length - 1] = { ...previous, rules: [...previous.rules, rule] };
+      continue;
+    }
+
+    groups.push({ key, media: rule.context.media, rules: [rule] });
+  }
+
+  return groups
+    .map(group => ('key' in group ? serializeResponsiveGroup(group, newline) : serializeBaseRule(group, newline)))
+    .join(newline);
+}

--- a/src/adapter/css/stylesheet/css-rule.serializer.ts
+++ b/src/adapter/css/stylesheet/css-rule.serializer.ts
@@ -6,13 +6,19 @@ import { serializeCssMedia } from './css-media.serializer';
 
 export type CssNewline = '\n' | '\r\n';
 
+interface BaseRuleGroup {
+  readonly kind: 'base';
+  readonly rule: OwnedCssRule;
+}
+
 interface ResponsiveGroup {
+  readonly kind: 'responsive';
   readonly key: string;
   readonly media: MediaDefinition;
   readonly rules: readonly OwnedCssRule[];
 }
 
-type RuleGroup = OwnedCssRule | ResponsiveGroup;
+type RuleGroup = BaseRuleGroup | ResponsiveGroup;
 
 function validateNewline(newline: CssNewline): void {
   if (newline !== '\n' && newline !== '\r\n') {
@@ -60,21 +66,23 @@ export function serializeCssRules(rules: readonly OwnedCssRule[], newline: CssNe
   const groups: RuleGroup[] = [];
   for (const rule of rules) {
     if (rule.context.media === undefined) {
-      groups.push(rule);
+      groups.push({ kind: 'base', rule });
       continue;
     }
 
     const key = mediaGroupKey(rule);
     const previous = groups.at(-1);
-    if (previous !== undefined && 'key' in previous && previous.key === key) {
+    if (previous?.kind === 'responsive' && previous.key === key) {
       groups[groups.length - 1] = { ...previous, rules: [...previous.rules, rule] };
       continue;
     }
 
-    groups.push({ key, media: rule.context.media, rules: [rule] });
+    groups.push({ kind: 'responsive', key, media: rule.context.media, rules: [rule] });
   }
 
   return groups
-    .map(group => ('key' in group ? serializeResponsiveGroup(group, newline) : serializeBaseRule(group, newline)))
+    .map(group =>
+      group.kind === 'responsive' ? serializeResponsiveGroup(group, newline) : serializeBaseRule(group.rule, newline),
+    )
     .join(newline);
 }

--- a/src/adapter/css/stylesheet/css-stylesheet.error.ts
+++ b/src/adapter/css/stylesheet/css-stylesheet.error.ts
@@ -1,0 +1,18 @@
+export type CssStylesheetErrorCode =
+  | 'invalid-artifact'
+  | 'invalid-css-lexeme'
+  | 'unterminated-css-token'
+  | 'unknown-ownership-marker'
+  | 'unsupported-ownership-schema'
+  | 'malformed-ownership-block'
+  | 'ownership-rule-mismatch';
+
+export class CssStylesheetError extends Error {
+  constructor(
+    readonly code: CssStylesheetErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CssStylesheetError';
+  }
+}

--- a/src/adapter/css/stylesheet/owned-css-block.parser.spec.ts
+++ b/src/adapter/css/stylesheet/owned-css-block.parser.spec.ts
@@ -1,0 +1,137 @@
+import { parseOwnedCssBlock } from './owned-css-block.parser';
+
+const A = 'a'.repeat(64);
+const B = 'b'.repeat(64);
+const START = '/* flex-layout-codemod:start schema=1 */';
+const END = '/* flex-layout-codemod:end */';
+const RULE_A = `/* flex-layout-codemod:rule id=${A} */`;
+
+describe('parseOwnedCssBlock', () => {
+  test.each([
+    ['', 'empty CSS'],
+    ['.handwritten { display: block; }', 'handwritten CSS'],
+    ['/* ordinary comment */', 'an unrelated comment'],
+    [`/* note: ${START} */`, 'a non-prefixed comment containing marker text'],
+    [`.x::before { content: "${START}"; }`, 'marker text in a string'],
+  ])('returns absent for %s', (source, _label) => {
+    expect(parseOwnedCssBlock(source)).toEqual({ status: 'absent' });
+  });
+
+  test('finds a valid LF block and its internal newline', () => {
+    const source = `${START}\n${RULE_A}\n.flm-${A} {\n  display: flex;\n}\n${END}`;
+
+    expect(parseOwnedCssBlock(source)).toEqual({
+      status: 'found',
+      range: { start: 0, end: source.length },
+      newline: '\n',
+    });
+  });
+
+  test('finds a valid CRLF block and permits an opening brace directly after the selector', () => {
+    const source = `${START}\r\n${RULE_A}\r\n.flm-${A}{\r\n  display: flex;\r\n}\r\n${END}`;
+
+    expect(parseOwnedCssBlock(source)).toEqual({
+      status: 'found',
+      range: { start: 0, end: source.length },
+      newline: '\r\n',
+    });
+  });
+
+  test('returns the exact marker range without claiming handwritten prefix or suffix bytes', () => {
+    const prefix = '.before {}\n\n';
+    const block = `${START}\n${END}`;
+    const suffix = '\n\n.after {}';
+    const source = prefix + block + suffix;
+
+    expect(parseOwnedCssBlock(source)).toEqual({
+      status: 'found',
+      range: { start: prefix.length, end: prefix.length + block.length },
+      newline: '\n',
+    });
+  });
+
+  test('uses the document newline for a same-line empty marker pair', () => {
+    const prefix = '.before {}\r\n';
+    const block = `${START}${END}`;
+
+    expect(parseOwnedCssBlock(prefix + block)).toEqual({
+      status: 'found',
+      range: { start: prefix.length, end: prefix.length + block.length },
+      newline: '\r\n',
+    });
+  });
+
+  test.each([
+    {
+      label: 'unsupported schema',
+      source: '/* flex-layout-codemod:start schema=2 *//* flex-layout-codemod:end */',
+      code: 'unsupported-ownership-schema',
+      reason: 'Unsupported flex-layout-codemod ownership schema: 2',
+    },
+    {
+      label: 'unknown prefixed marker',
+      source: '/* flex-layout-codemod:future */',
+      code: 'unknown-ownership-marker',
+      reason: 'Unknown flex-layout-codemod ownership marker',
+    },
+    {
+      label: 'duplicate start',
+      source: `${START}${END}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Duplicate flex-layout-codemod start marker',
+    },
+    {
+      label: 'duplicate end',
+      source: `${START}${END}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Duplicate flex-layout-codemod end marker',
+    },
+    {
+      label: 'end before start',
+      source: `${END}${START}`,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod end marker appears before start marker',
+    },
+    {
+      label: 'missing end mate',
+      source: START,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod start marker has no matching end marker',
+    },
+    {
+      label: 'missing start mate',
+      source: END,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod end marker has no matching start marker',
+    },
+    {
+      label: 'nested start',
+      source: `${START}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Nested flex-layout-codemod start marker',
+    },
+    {
+      label: 'rule marker outside the block',
+      source: `${RULE_A}\n.flm-${A} {}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod rule marker appears outside owned block',
+    },
+    {
+      label: 'malformed rule ID',
+      source: `${START}/* flex-layout-codemod:rule id=abc */.flm-abc {}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Malformed flex-layout-codemod rule marker',
+    },
+    {
+      label: 'rule ID and next selector mismatch',
+      source: `${START}${RULE_A}\n.flm-${B} {}${END}`,
+      code: 'ownership-rule-mismatch',
+      reason: 'Flex-layout-codemod rule ID does not match following selector',
+    },
+  ] as const)('returns a stable, path-free invalid result for $label', ({ source, code, reason }) => {
+    const result = parseOwnedCssBlock(source);
+
+    expect(result).toEqual({ status: 'invalid', code, reason });
+    expect(reason).not.toMatch(/[/\\]/);
+  });
+});

--- a/src/adapter/css/stylesheet/owned-css-block.parser.spec.ts
+++ b/src/adapter/css/stylesheet/owned-css-block.parser.spec.ts
@@ -17,6 +17,13 @@ describe('parseOwnedCssBlock', () => {
     expect(parseOwnedCssBlock(source)).toEqual({ status: 'absent' });
   });
 
+  test.each([
+    ['an escaped quote', String.raw`.escaped\"text"/* flex-layout-codemod:start schema=1 */"`],
+    ['an escaped comment opener', String.raw`.escaped\/* flex-layout-codemod:start schema=1 */`],
+  ])('returns absent when marker text follows %s in normal CSS', (_label, source) => {
+    expect(parseOwnedCssBlock(source)).toEqual({ status: 'absent' });
+  });
+
   test('finds a valid LF block and its internal newline', () => {
     const source = `${START}\n${RULE_A}\n.flm-${A} {\n  display: flex;\n}\n${END}`;
 

--- a/src/adapter/css/stylesheet/owned-css-block.parser.ts
+++ b/src/adapter/css/stylesheet/owned-css-block.parser.ts
@@ -1,0 +1,122 @@
+import type { CssStylesheetErrorCode } from './css-stylesheet.error';
+import { scanCssComments, type CssCommentToken, type CssSourceRange } from './css-comment.scanner';
+import type { CssNewline } from './owned-css-block.serializer';
+
+const MARKER_PREFIX = 'flex-layout-codemod:';
+const START_MARKER_PATTERN = /^flex-layout-codemod:start schema=([0-9]+)$/;
+const RULE_MARKER_PATTERN = /^flex-layout-codemod:rule id=([a-f0-9]{64})$/;
+const END_MARKER_PATTERN = /^flex-layout-codemod:end$/;
+
+interface OwnedRuleMarker {
+  readonly token: CssCommentToken;
+  readonly id: string;
+}
+
+export type OwnedCssBlockParseResult =
+  | { readonly status: 'absent' }
+  | { readonly status: 'found'; readonly range: CssSourceRange; readonly newline: CssNewline }
+  | { readonly status: 'invalid'; readonly code: CssStylesheetErrorCode; readonly reason: string };
+
+function invalid(code: CssStylesheetErrorCode, reason: string): OwnedCssBlockParseResult {
+  return { status: 'invalid', code, reason };
+}
+
+function firstNewline(source: string): CssNewline {
+  const match = /\r\n|\n/.exec(source);
+  return match?.[0] === '\r\n' ? '\r\n' : '\n';
+}
+
+function isCssWhitespace(codeUnit: string | undefined): boolean {
+  return codeUnit === ' ' || codeUnit === '\t' || codeUnit === '\n' || codeUnit === '\r' || codeUnit === '\f';
+}
+
+function ruleSelectorMatches(source: string, marker: OwnedRuleMarker): boolean {
+  let selectorStart = marker.token.end;
+  while (isCssWhitespace(source[selectorStart])) selectorStart += 1;
+
+  const selector = `.flm-${marker.id}`;
+  if (!source.startsWith(selector, selectorStart)) return false;
+
+  const boundary = source[selectorStart + selector.length];
+  return boundary === '{' || isCssWhitespace(boundary);
+}
+
+export function parseOwnedCssBlock(source: string): OwnedCssBlockParseResult {
+  let start: CssCommentToken | undefined;
+  let end: CssCommentToken | undefined;
+  let regionOpen = false;
+  const rules: OwnedRuleMarker[] = [];
+
+  for (const token of scanCssComments(source)) {
+    const marker = token.content.trim();
+    if (!marker.startsWith(MARKER_PREFIX)) continue;
+
+    const startMatch = START_MARKER_PATTERN.exec(marker);
+    if (startMatch !== null) {
+      const schema = startMatch[1];
+      if (schema !== '1') {
+        return invalid('unsupported-ownership-schema', `Unsupported flex-layout-codemod ownership schema: ${schema}`);
+      }
+      if (regionOpen) {
+        return invalid('malformed-ownership-block', 'Nested flex-layout-codemod start marker');
+      }
+      if (start !== undefined) {
+        return invalid('malformed-ownership-block', 'Duplicate flex-layout-codemod start marker');
+      }
+      if (end !== undefined) {
+        return invalid('malformed-ownership-block', 'Flex-layout-codemod end marker appears before start marker');
+      }
+
+      start = token;
+      regionOpen = true;
+      continue;
+    }
+
+    const ruleMatch = RULE_MARKER_PATTERN.exec(marker);
+    if (ruleMatch !== null) {
+      if (!regionOpen) {
+        return invalid('malformed-ownership-block', 'Flex-layout-codemod rule marker appears outside owned block');
+      }
+
+      rules.push({ token, id: ruleMatch[1] ?? '' });
+      continue;
+    }
+
+    if (END_MARKER_PATTERN.test(marker)) {
+      if (end !== undefined) {
+        return invalid('malformed-ownership-block', 'Duplicate flex-layout-codemod end marker');
+      }
+
+      end = token;
+      regionOpen = false;
+      continue;
+    }
+
+    if (marker === `${MARKER_PREFIX}rule` || marker.startsWith(`${MARKER_PREFIX}rule `)) {
+      return invalid('malformed-ownership-block', 'Malformed flex-layout-codemod rule marker');
+    }
+
+    return invalid('unknown-ownership-marker', 'Unknown flex-layout-codemod ownership marker');
+  }
+
+  if (start === undefined && end === undefined) return { status: 'absent' };
+  if (start === undefined) {
+    return invalid('malformed-ownership-block', 'Flex-layout-codemod end marker has no matching start marker');
+  }
+  if (end === undefined) {
+    return invalid('malformed-ownership-block', 'Flex-layout-codemod start marker has no matching end marker');
+  }
+
+  for (const rule of rules) {
+    if (!ruleSelectorMatches(source, rule)) {
+      return invalid('ownership-rule-mismatch', 'Flex-layout-codemod rule ID does not match following selector');
+    }
+  }
+
+  const internalSource = source.slice(start.end, end.start);
+  return {
+    status: 'found',
+    range: { start: start.start, end: end.end },
+    newline: /\r\n|\n/.test(internalSource) ? firstNewline(internalSource) : firstNewline(source),
+  };
+}

--- a/src/adapter/css/stylesheet/owned-css-block.serializer.spec.ts
+++ b/src/adapter/css/stylesheet/owned-css-block.serializer.spec.ts
@@ -1,0 +1,35 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { serializeOwnedCssBlock } from './owned-css-block.serializer';
+
+const ID = 'a'.repeat(64);
+
+function rule(): OwnedCssRule {
+  return {
+    owner: 'flex-layout-codemod',
+    id: ID,
+    className: `flm-${ID}`,
+    family: 'layout',
+    declarations: [{ property: 'display', value: 'flex' }],
+    context: { priority: 0 },
+  };
+}
+
+describe('serializeOwnedCssBlock', () => {
+  test.each(['\n', '\r\n'] as const)('wraps rules with markers using %j and no outer newline', newline => {
+    expect(serializeOwnedCssBlock([rule()], newline)).toBe(
+      `/* flex-layout-codemod:start schema=1 */${newline}/* flex-layout-codemod:rule id=${ID} */${newline}.flm-${ID} {${newline}  display: flex;${newline}}${newline}/* flex-layout-codemod:end */`,
+    );
+  });
+
+  test('serializes no rules as an empty string', () => {
+    expect(serializeOwnedCssBlock([], '\n')).toBe('');
+  });
+
+  test('validates every rule before producing a block', () => {
+    const unsafe = { ...rule(), declarations: [{ property: 'display', value: 'flex; color: red' }] };
+
+    expect(() => serializeOwnedCssBlock([rule(), unsafe], '\n')).toThrow(
+      expect.objectContaining({ code: 'invalid-css-lexeme' }),
+    );
+  });
+});

--- a/src/adapter/css/stylesheet/owned-css-block.serializer.ts
+++ b/src/adapter/css/stylesheet/owned-css-block.serializer.ts
@@ -1,0 +1,14 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { serializeCssRules, type CssNewline } from './css-rule.serializer';
+
+const START_MARKER = '/* flex-layout-codemod:start schema=1 */';
+const END_MARKER = '/* flex-layout-codemod:end */';
+
+export { type CssNewline } from './css-rule.serializer';
+
+export function serializeOwnedCssBlock(rules: readonly OwnedCssRule[], newline: CssNewline): string {
+  const serializedRules = serializeCssRules(rules, newline);
+  if (serializedRules === '') return '';
+
+  return [START_MARKER, serializedRules, END_MARKER].join(newline);
+}

--- a/src/adapter/css/stylesheet/owned-stylesheet.merger.spec.ts
+++ b/src/adapter/css/stylesheet/owned-stylesheet.merger.spec.ts
@@ -91,6 +91,16 @@ describe('mergeOwnedStylesheet', () => {
     expectMerge(existing, [], existing);
   });
 
+  test.each([
+    ['escaped quotes', String.raw`.before\"text"/* flex-layout-codemod:start schema=1 */".middle { color: red; }`],
+    [
+      'escaped comment openers',
+      String.raw`.before\/* flex-layout-codemod:start schema=1 */.middle { color: red; }\/* flex-layout-codemod:end */.after { color: blue; }`,
+    ],
+  ])('preserves every handwritten byte when ownership markers follow %s', (_label, existing) => {
+    expectMerge(existing, [], existing);
+  });
+
   test('replaces a smaller owned rule set with a larger one', () => {
     const prefix = '.before {}\n';
     const suffix = '\n.after {}';

--- a/src/adapter/css/stylesheet/owned-stylesheet.merger.spec.ts
+++ b/src/adapter/css/stylesheet/owned-stylesheet.merger.spec.ts
@@ -1,0 +1,188 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { mergeOwnedStylesheet } from './owned-stylesheet.merger';
+
+const A = 'a'.repeat(64);
+const B = 'b'.repeat(64);
+const C = 'c'.repeat(64);
+const START = '/* flex-layout-codemod:start schema=1 */';
+const END = '/* flex-layout-codemod:end */';
+
+function rule(id: string, property = 'display', value = 'flex'): OwnedCssRule {
+  return {
+    owner: 'flex-layout-codemod',
+    id,
+    className: `flm-${id}`,
+    family: 'layout',
+    declarations: [{ property, value }],
+    context: { priority: 0 },
+  };
+}
+
+function block(newline: '\n' | '\r\n', rules: readonly OwnedCssRule[]): string {
+  if (rules.length === 0) return '';
+
+  return [
+    START,
+    ...rules.flatMap(current => [
+      `/* flex-layout-codemod:rule id=${current.id} */`,
+      `.${current.className} {`,
+      ...current.declarations.map(declaration => `  ${declaration.property}: ${declaration.value};`),
+      '}',
+    ]),
+    END,
+  ].join(newline);
+}
+
+function expectMerge(existing: string, rules: readonly OwnedCssRule[], output: string): void {
+  const result = mergeOwnedStylesheet(existing, rules);
+
+  expect(result).toEqual({ changed: output !== existing, output });
+}
+
+describe('mergeOwnedStylesheet', () => {
+  test('appends an LF owned block to empty CSS', () => {
+    expectMerge('', [rule(A)], block('\n', [rule(A)]));
+  });
+
+  test('appends directly after handwritten CSS with no trailing newline', () => {
+    const existing = '.handwritten { display: block; }';
+
+    expectMerge(existing, [rule(A)], `${existing}${block('\n', [rule(A)])}`);
+  });
+
+  test.each([
+    ['LF', '.before {}\n.after {}', '\n'],
+    ['CRLF', '.before {}\r\n.after {}', '\r\n'],
+    ['mixed document newlines', '.before {}\r\n.after {}\n.last {}', '\r\n'],
+  ] as const)('uses the first document newline when appending to %s CSS', (_label, existing, newline) => {
+    expectMerge(existing, [rule(A)], `${existing}${block(newline, [rule(A)])}`);
+  });
+
+  test('replaces only the owned range and retains its internal newline over the document preference', () => {
+    const prefix = 'PREFIX-SENTINEL\r\n.handwritten { color: red; }\r\n';
+    const suffix = '\r\nSUFFIX-SENTINEL\n.after { color: blue; }';
+    const existing = `${prefix}${block('\n', [rule(A)])}${suffix}`;
+    const output = `${prefix}${block('\n', [rule(B)])}${suffix}`;
+
+    expectMerge(existing, [rule(B)], output);
+    expect(output.startsWith(prefix)).toBe(true);
+    expect(output.endsWith(suffix)).toBe(true);
+  });
+
+  test('removes only an owned block surrounded by handwritten bytes', () => {
+    const prefix = 'PREFIX-SENTINEL\n\n';
+    const suffix = '\n\nSUFFIX-SENTINEL';
+    const existing = `${prefix}${block('\r\n', [rule(A)])}${suffix}`;
+
+    expectMerge(existing, [], `${prefix}${suffix}`);
+  });
+
+  test('removes an owned-only stylesheet completely', () => {
+    const existing = block('\n', [rule(A)]);
+
+    expectMerge(existing, [], '');
+  });
+
+  test.each([
+    ['', 'empty CSS'],
+    ['.handwritten {}', 'handwritten-only CSS'],
+    ['.x::before { content: "/* flex-layout-codemod:start schema=1 */"; }', 'a marker-like string'],
+  ])('leaves absent ownership and no rules unchanged for %s', (existing, _label) => {
+    expectMerge(existing, [], existing);
+  });
+
+  test('replaces a smaller owned rule set with a larger one', () => {
+    const prefix = '.before {}\n';
+    const suffix = '\n.after {}';
+    const existing = `${prefix}${block('\n', [rule(A)])}${suffix}`;
+
+    expectMerge(existing, [rule(A), rule(B), rule(C)], `${prefix}${block('\n', [rule(A), rule(B), rule(C)])}${suffix}`);
+  });
+
+  test('replaces a larger owned rule set with a smaller one', () => {
+    const prefix = '.before {}\r\n';
+    const suffix = '\r\n.after {}';
+    const existing = `${prefix}${block('\r\n', [rule(A), rule(B), rule(C)])}${suffix}`;
+
+    expectMerge(existing, [rule(C)], `${prefix}${block('\r\n', [rule(C)])}${suffix}`);
+  });
+
+  test('is byte-idempotent when merging the same ordered rules again', () => {
+    const first = mergeOwnedStylesheet('.before {}\r\n', [rule(A), rule(B)]);
+
+    expect(mergeOwnedStylesheet(first.output, [rule(A), rule(B)])).toEqual({ changed: false, output: first.output });
+  });
+
+  test.each([
+    {
+      label: 'unsupported schema',
+      source: '/* flex-layout-codemod:start schema=2 *//* flex-layout-codemod:end */',
+      code: 'unsupported-ownership-schema',
+      reason: 'Unsupported flex-layout-codemod ownership schema: 2',
+    },
+    {
+      label: 'unknown prefixed marker',
+      source: '/* flex-layout-codemod:future */',
+      code: 'unknown-ownership-marker',
+      reason: 'Unknown flex-layout-codemod ownership marker',
+    },
+    {
+      label: 'duplicate start',
+      source: `${START}${END}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Duplicate flex-layout-codemod start marker',
+    },
+    {
+      label: 'duplicate end',
+      source: `${START}${END}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Duplicate flex-layout-codemod end marker',
+    },
+    {
+      label: 'end before start',
+      source: `${END}${START}`,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod end marker appears before start marker',
+    },
+    {
+      label: 'missing end mate',
+      source: START,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod start marker has no matching end marker',
+    },
+    {
+      label: 'missing start mate',
+      source: END,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod end marker has no matching start marker',
+    },
+    {
+      label: 'nested start',
+      source: `${START}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Nested flex-layout-codemod start marker',
+    },
+    {
+      label: 'rule marker outside the block',
+      source: `/* flex-layout-codemod:rule id=${A} */\n.flm-${A} {}${START}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Flex-layout-codemod rule marker appears outside owned block',
+    },
+    {
+      label: 'malformed rule ID',
+      source: `${START}/* flex-layout-codemod:rule id=abc */.flm-abc {}${END}`,
+      code: 'malformed-ownership-block',
+      reason: 'Malformed flex-layout-codemod rule marker',
+    },
+    {
+      label: 'rule ID and selector mismatch',
+      source: `${START}/* flex-layout-codemod:rule id=${A} */\n.flm-${B} {}${END}`,
+      code: 'ownership-rule-mismatch',
+      reason: 'Flex-layout-codemod rule ID does not match following selector',
+    },
+  ] as const)('throws the parser code and reason for $label', ({ source, code, reason }) => {
+    expect(() => mergeOwnedStylesheet(source, [rule(A)])).toThrow(
+      expect.objectContaining({ name: 'CssStylesheetError', code, message: reason }),
+    );
+  });
+});

--- a/src/adapter/css/stylesheet/owned-stylesheet.merger.ts
+++ b/src/adapter/css/stylesheet/owned-stylesheet.merger.ts
@@ -1,0 +1,27 @@
+import type { OwnedCssRule } from '../css-artifact.model';
+import { CssStylesheetError } from './css-stylesheet.error';
+import { parseOwnedCssBlock } from './owned-css-block.parser';
+import { serializeOwnedCssBlock, type CssNewline } from './owned-css-block.serializer';
+
+export interface OwnedStylesheetMergeResult {
+  readonly changed: boolean;
+  readonly output: string;
+}
+
+function firstDocumentNewline(source: string): CssNewline {
+  return /\r\n|\n/.exec(source)?.[0] === '\r\n' ? '\r\n' : '\n';
+}
+
+export function mergeOwnedStylesheet(existing: string, rules: readonly OwnedCssRule[]): OwnedStylesheetMergeResult {
+  const parsed = parseOwnedCssBlock(existing);
+  if (parsed.status === 'invalid') throw new CssStylesheetError(parsed.code, parsed.reason);
+
+  const newline = parsed.status === 'found' ? parsed.newline : firstDocumentNewline(existing);
+  const block = serializeOwnedCssBlock(rules, newline);
+  const output =
+    parsed.status === 'found'
+      ? existing.slice(0, parsed.range.start) + block + existing.slice(parsed.range.end)
+      : existing + block;
+
+  return Object.freeze({ changed: output !== existing, output });
+}

--- a/test/architecture/native-css-stylesheet-boundary.test.ts
+++ b/test/architecture/native-css-stylesheet-boundary.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import ts from 'typescript';
+
+import { inspectTypeScript, productionTypeScriptFiles, type TypeScriptInspection } from './typescript-boundary';
+
+const stylesheetRoot = join(process.cwd(), 'src', 'adapter', 'css', 'stylesheet');
+const fixturePath = join(stylesheetRoot, 'fixture.ts');
+
+const nodeIoModule = /^(?:node:)?(?:fs|path)(?:\/|$)/u;
+const forbiddenLayer = /(?:^|\/)(?:analyzer|cli|migrator|planner|tailwind|template)(?:\/|$)/u;
+const atomicFileWriterModule = /(?:^|\/)atomic-file\.writer(?:\.[cm]?[jt]s)?$/u;
+const absolutePath = /^(?:\/(?![*/])(?=.)|[a-z]:[\\/]|\\\\)/iu;
+const packageVersionIdentifier = /^(?:PACKAGE_VERSION|npm_package_version|packageVersion)$/u;
+const packageManifestModule = /(?:^|\/)package\.json$/u;
+const generatedMarkerForms = new Set([
+  '/* flex-layout-codemod:start schema=1 */',
+  '/* flex-layout-codemod:rule id=${} */',
+  '/* flex-layout-codemod:end */',
+]);
+
+function forbiddenDependency(inspection: TypeScriptInspection): string | undefined {
+  return (
+    inspection.moduleReferences.find(
+      reference =>
+        nodeIoModule.test(reference) || forbiddenLayer.test(reference) || atomicFileWriterModule.test(reference),
+    ) ?? inspection.identifiers.find(identifier => identifier === 'AtomicFileWriter')
+  );
+}
+
+function sourceFile(source: string, sourcePath: string): ts.SourceFile {
+  return ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+}
+
+function stringFragments(source: string, sourcePath: string): readonly string[] {
+  const fragments: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isStringLiteralLike(node) ||
+      ts.isTemplateHead(node) ||
+      ts.isTemplateMiddle(node) ||
+      ts.isTemplateTail(node)
+    ) {
+      fragments.push(node.text);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile(source, sourcePath));
+  return fragments;
+}
+
+function generatedMarkers(source: string, sourcePath: string): readonly string[] {
+  const markers: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isStringLiteralLike(node) && node.text.startsWith('/* flex-layout-codemod:')) {
+      markers.push(node.text);
+    } else if (ts.isTemplateExpression(node) && node.head.text.startsWith('/* flex-layout-codemod:')) {
+      markers.push(node.head.text + node.templateSpans.map(span => '${}' + span.literal.text).join(''));
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile(source, sourcePath));
+  return markers;
+}
+
+function absolutePathLiteral(source: string, sourcePath: string): string | undefined {
+  return stringFragments(source, sourcePath).find(fragment => absolutePath.test(fragment));
+}
+
+function packageVersionRead(inspection: TypeScriptInspection): string | undefined {
+  return (
+    inspection.moduleReferences.find(reference => packageManifestModule.test(reference)) ??
+    [...inspection.identifiers, ...inspection.literalTexts].find(token => packageVersionIdentifier.test(token))
+  );
+}
+
+function containsIdentifier(node: ts.Node, name: string): boolean {
+  let found = false;
+
+  function visit(current: ts.Node): void {
+    if (found) return;
+    if (ts.isIdentifier(current) && current.text === name) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  }
+
+  visit(node);
+  return found;
+}
+
+function composesExistingWithGeneratedOutput(source: string, sourcePath: string): boolean {
+  let serializesOwnedBlock = false;
+  let concatenatesExistingAndBlock = false;
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'serializeOwnedCssBlock'
+    ) {
+      serializesOwnedBlock = true;
+    }
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+      containsIdentifier(node, 'existing') &&
+      containsIdentifier(node, 'block')
+    ) {
+      concatenatesExistingAndBlock = true;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile(source, sourcePath));
+  return serializesOwnedBlock && concatenatesExistingAndBlock;
+}
+
+describe('native CSS stylesheet architecture boundary', () => {
+  test.each([
+    ['Node filesystem import', "import { readFileSync } from 'node:fs';"],
+    ['Node path re-export', "export { join } from 'node:path';"],
+    ['CLI dynamic import', "const cli = import('../../../cli/run-cli');"],
+    ['migrator require', "const migrator = require('../../../migrator/file.migrator');"],
+    ['planner import-equals', "import planner = require('../../../planner/native-css.planner');"],
+    ['template type import', "import type { Template } from '../../../template/template.model';"],
+    ['Tailwind side-effect import', "import '../../tailwind/tailwind.adapter';"],
+    ['analyzer re-export', "export * from '../../../analyzer/flex-layout-attribute.analyzer';"],
+    ['AtomicFileWriter import', "import { AtomicFileWriter } from '../../../lib/atomic-file.writer';"],
+  ])('rejects the %s dependency mutation', (_label, source) => {
+    expect(forbiddenDependency(inspectTypeScript(source, fixturePath))).toBeDefined();
+  });
+
+  test('recursively keeps stylesheet production modules independent from I/O and application layers', () => {
+    for (const path of productionTypeScriptFiles(stylesheetRoot)) {
+      expect(
+        forbiddenDependency(inspectTypeScript(readFileSync(path, 'utf8'), path)),
+        relative(process.cwd(), path),
+      ).toBeUndefined();
+    }
+  });
+
+  test.each([
+    ['POSIX', "const target = '/tmp/owned.css';"],
+    ['Windows drive', String.raw`const target = 'C:\\temp\\owned.css';`],
+    ['Windows UNC', String.raw`const target = '\\\\server\\share\\owned.css';`],
+  ])('rejects a %s absolute-path mutation', (_label, source) => {
+    expect(absolutePathLiteral(source, fixturePath)).toBeDefined();
+  });
+
+  test.each([
+    ['package manifest import', "import manifest from '../../../../package.json';"],
+    ['npm package environment read', 'const value = process.env.npm_package_version;'],
+    ['package-version identifier', "const packageVersion = '2.0.0';"],
+  ])('rejects a %s mutation', (_label, source) => {
+    expect(packageVersionRead(inspectTypeScript(source, fixturePath))).toBeDefined();
+  });
+
+  test('keeps absolute paths and package-version reads out of stylesheet production modules', () => {
+    for (const path of productionTypeScriptFiles(stylesheetRoot)) {
+      const source = readFileSync(path, 'utf8');
+      const inspection = inspectTypeScript(source, path);
+      const sourcePath = relative(process.cwd(), path);
+
+      expect(absolutePathLiteral(source, path), sourcePath).toBeUndefined();
+      expect(packageVersionRead(inspection), sourcePath).toBeUndefined();
+    }
+  });
+
+  test.each([
+    ['schema drift', "const marker = '/* flex-layout-codemod:start schema=2 */';"],
+    ['rule grammar drift', 'const marker = `/* flex-layout-codemod:rule id=${id} generated */`;'],
+    ['end-marker drift', "const marker = '/* flex-layout-codemod:end schema=1 */';"],
+  ])('rejects a %s mutation', (_label, source) => {
+    expect(generatedMarkers(source, fixturePath).some(marker => !generatedMarkerForms.has(marker))).toBe(true);
+  });
+
+  test('permits exactly the three schema-1 generated marker forms in production', () => {
+    const markers = productionTypeScriptFiles(stylesheetRoot).flatMap(path =>
+      generatedMarkers(readFileSync(path, 'utf8'), path),
+    );
+
+    expect([...new Set(markers)].sort()).toEqual([...generatedMarkerForms].sort());
+  });
+
+  test('detects a non-merger module composing handwritten input with a generated owned block', () => {
+    const source = `
+      import { serializeOwnedCssBlock } from './owned-css-block.serializer';
+      export function compose(existing: string, rules: readonly OwnedCssRule[]): string {
+        const block = serializeOwnedCssBlock(rules, '\\n');
+        return existing + block;
+      }
+    `;
+
+    expect(composesExistingWithGeneratedOutput(source, fixturePath)).toBe(true);
+  });
+
+  test('makes the merger the only stylesheet module that composes existing CSS with generated output', () => {
+    const composers = productionTypeScriptFiles(stylesheetRoot).flatMap(path => {
+      const source = readFileSync(path, 'utf8');
+      return composesExistingWithGeneratedOutput(source, path) ? [basename(path)] : [];
+    });
+
+    expect(composers).toEqual(['owned-stylesheet.merger.ts']);
+  });
+
+  test('ignores prohibited dependency, marker, path, version, and composition text in comments', () => {
+    const source = `
+      // import { readFileSync } from 'node:fs';
+      // export * from '../../../planner/native-css.planner';
+      // const target = '/tmp/owned.css';
+      // const packageVersion = process.env.npm_package_version;
+      // const marker = '/* flex-layout-codemod:start schema=2 */';
+      // const block = serializeOwnedCssBlock(rules, '\\n');
+      // return existing + block;
+      export const harmless = 'relative.css';
+    `;
+    const inspection = inspectTypeScript(source, fixturePath);
+
+    expect(forbiddenDependency(inspection)).toBeUndefined();
+    expect(absolutePathLiteral(source, fixturePath)).toBeUndefined();
+    expect(packageVersionRead(inspection)).toBeUndefined();
+    expect(generatedMarkers(source, fixturePath)).toEqual([]);
+    expect(composesExistingWithGeneratedOutput(source, fixturePath)).toBe(false);
+  });
+});

--- a/test/architecture/native-css-stylesheet-boundary.test.ts
+++ b/test/architecture/native-css-stylesheet-boundary.test.ts
@@ -13,6 +13,7 @@ const atomicFileWriterModule = /(?:^|\/)atomic-file\.writer(?:\.[cm]?[jt]s)?$/u;
 const absolutePath = /^(?:\/(?![*/])(?=.)|[a-z]:[\\/]|\\\\)/iu;
 const packageVersionIdentifier = /^(?:PACKAGE_VERSION|npm_package_version|packageVersion)$/u;
 const packageManifestModule = /(?:^|\/)package\.json$/u;
+const ownedBlockSerializerModule = /(?:^|\/)owned-css-block\.serializer(?:\.[cm]?[jt]s)?$/u;
 const generatedMarkerForms = new Set([
   '/* flex-layout-codemod:start schema=1 */',
   '/* flex-layout-codemod:rule id=${} */',
@@ -78,52 +79,17 @@ function packageVersionRead(inspection: TypeScriptInspection): string | undefine
   );
 }
 
-function containsIdentifier(node: ts.Node, name: string): boolean {
-  let found = false;
-
-  function visit(current: ts.Node): void {
-    if (found) return;
-    if (ts.isIdentifier(current) && current.text === name) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(current, visit);
-  }
-
-  visit(node);
-  return found;
-}
-
-function composesExistingWithGeneratedOutput(source: string, sourcePath: string): boolean {
-  let serializesOwnedBlock = false;
-  let concatenatesExistingAndBlock = false;
-
-  function visit(node: ts.Node): void {
-    if (
-      ts.isCallExpression(node) &&
-      ts.isIdentifier(node.expression) &&
-      node.expression.text === 'serializeOwnedCssBlock'
-    ) {
-      serializesOwnedBlock = true;
-    }
-    if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.PlusToken &&
-      containsIdentifier(node, 'existing') &&
-      containsIdentifier(node, 'block')
-    ) {
-      concatenatesExistingAndBlock = true;
-    }
-    ts.forEachChild(node, visit);
-  }
-
-  visit(sourceFile(source, sourcePath));
-  return serializesOwnedBlock && concatenatesExistingAndBlock;
+function usesOwnedBlockSerializer(inspection: TypeScriptInspection): boolean {
+  return (
+    inspection.moduleReferences.some(reference => ownedBlockSerializerModule.test(reference)) &&
+    inspection.identifiers.includes('serializeOwnedCssBlock')
+  );
 }
 
 describe('native CSS stylesheet architecture boundary', () => {
   test.each([
     ['Node filesystem import', "import { readFileSync } from 'node:fs';"],
+    ['Node filesystem import type', "type Path = import('node:fs').PathLike;"],
     ['Node path re-export', "export { join } from 'node:path';"],
     ['CLI dynamic import', "const cli = import('../../../cli/run-cli');"],
     ['migrator require', "const migrator = require('../../../migrator/file.migrator');"],
@@ -188,30 +154,44 @@ describe('native CSS stylesheet architecture boundary', () => {
     expect([...new Set(markers)].sort()).toEqual([...generatedMarkerForms].sort());
   });
 
-  test('detects a non-merger module composing handwritten input with a generated owned block', () => {
-    const source = `
-      import { serializeOwnedCssBlock } from './owned-css-block.serializer';
-      export function compose(existing: string, rules: readonly OwnedCssRule[]): string {
-        const block = serializeOwnedCssBlock(rules, '\\n');
-        return existing + block;
-      }
-    `;
-
-    expect(composesExistingWithGeneratedOutput(source, fixturePath)).toBe(true);
+  test.each([
+    [
+      'direct call and concatenation',
+      `
+        import { serializeOwnedCssBlock } from './owned-css-block.serializer';
+        export function compose(existing: string, rules: readonly OwnedCssRule[]): string {
+          const block = serializeOwnedCssBlock(rules, '\\n');
+          return existing + block;
+        }
+      `,
+    ],
+    [
+      'aliased call with renamed values and template interpolation',
+      `
+        import { serializeOwnedCssBlock as emitOwned } from './owned-css-block.serializer';
+        export function compose(original: string, artifacts: readonly OwnedCssRule[]): string {
+          const generated = emitOwned(artifacts, '\\n');
+          return \`\${original}\${generated}\`;
+        }
+      `,
+    ],
+  ])('detects a non-merger owned-block serializer import: %s', (_label, source) => {
+    expect(usesOwnedBlockSerializer(inspectTypeScript(source, fixturePath))).toBe(true);
   });
 
-  test('makes the merger the only stylesheet module that composes existing CSS with generated output', () => {
-    const composers = productionTypeScriptFiles(stylesheetRoot).flatMap(path => {
-      const source = readFileSync(path, 'utf8');
-      return composesExistingWithGeneratedOutput(source, path) ? [basename(path)] : [];
+  test('makes the merger the only stylesheet module that imports and uses the owned-block serializer', () => {
+    const consumers = productionTypeScriptFiles(stylesheetRoot).flatMap(path => {
+      const inspection = inspectTypeScript(readFileSync(path, 'utf8'), path);
+      return usesOwnedBlockSerializer(inspection) ? [basename(path)] : [];
     });
 
-    expect(composers).toEqual(['owned-stylesheet.merger.ts']);
+    expect(consumers).toEqual(['owned-stylesheet.merger.ts']);
   });
 
   test('ignores prohibited dependency, marker, path, version, and composition text in comments', () => {
     const source = `
       // import { readFileSync } from 'node:fs';
+      // import { serializeOwnedCssBlock } from './owned-css-block.serializer';
       // export * from '../../../planner/native-css.planner';
       // const target = '/tmp/owned.css';
       // const packageVersion = process.env.npm_package_version;
@@ -226,6 +206,6 @@ describe('native CSS stylesheet architecture boundary', () => {
     expect(absolutePathLiteral(source, fixturePath)).toBeUndefined();
     expect(packageVersionRead(inspection)).toBeUndefined();
     expect(generatedMarkers(source, fixturePath)).toEqual([]);
-    expect(composesExistingWithGeneratedOutput(source, fixturePath)).toBe(false);
+    expect(usesOwnedBlockSerializer(inspection)).toBe(false);
   });
 });

--- a/test/architecture/native-css-stylesheet-boundary.test.ts
+++ b/test/architecture/native-css-stylesheet-boundary.test.ts
@@ -10,7 +10,7 @@ const fixturePath = join(stylesheetRoot, 'fixture.ts');
 const nodeIoModule = /^(?:node:)?(?:fs|path)(?:\/|$)/u;
 const forbiddenLayer = /(?:^|\/)(?:analyzer|cli|migrator|planner|tailwind|template)(?:\/|$)/u;
 const atomicFileWriterModule = /(?:^|\/)atomic-file\.writer(?:\.[cm]?[jt]s)?$/u;
-const absolutePath = /^(?:\/(?![*/])(?=.)|[a-z]:[\\/]|\\\\)/iu;
+const absolutePath = /^(?:\/(?![*/])|[a-z]:[\\/]|\\\\)/iu;
 const packageVersionIdentifier = /^(?:PACKAGE_VERSION|npm_package_version|packageVersion)$/u;
 const packageManifestModule = /(?:^|\/)package\.json$/u;
 const ownedBlockSerializerModule = /(?:^|\/)owned-css-block\.serializer(?:\.[cm]?[jt]s)?$/u;
@@ -30,26 +30,25 @@ function forbiddenDependency(inspection: TypeScriptInspection): string | undefin
 }
 
 function sourceFile(source: string, sourcePath: string): ts.SourceFile {
-  return ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, false, ts.ScriptKind.TS);
+  return ts.createSourceFile(sourcePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 }
 
-function stringFragments(source: string, sourcePath: string): readonly string[] {
-  const fragments: string[] = [];
+function isCssDelimiterComparison(node: ts.Node): boolean {
+  if (!ts.isStringLiteralLike(node) || node.text !== '/' || !ts.isBinaryExpression(node.parent)) return false;
 
-  function visit(node: ts.Node): void {
-    if (
-      ts.isStringLiteralLike(node) ||
-      ts.isTemplateHead(node) ||
-      ts.isTemplateMiddle(node) ||
-      ts.isTemplateTail(node)
-    ) {
-      fragments.push(node.text);
-    }
-    ts.forEachChild(node, visit);
-  }
+  const parent = node.parent;
+  const isEqualityOperator = [
+    ts.SyntaxKind.EqualsEqualsToken,
+    ts.SyntaxKind.EqualsEqualsEqualsToken,
+    ts.SyntaxKind.ExclamationEqualsToken,
+    ts.SyntaxKind.ExclamationEqualsEqualsToken,
+  ].includes(parent.operatorToken.kind);
+  const compared = parent.left === node ? parent.right : parent.left;
 
-  visit(sourceFile(source, sourcePath));
-  return fragments;
+  return (
+    isEqualityOperator &&
+    ((ts.isIdentifier(compared) && compared.text === 'codeUnit') || ts.isElementAccessExpression(compared))
+  );
 }
 
 function generatedMarkers(source: string, sourcePath: string): readonly string[] {
@@ -69,7 +68,26 @@ function generatedMarkers(source: string, sourcePath: string): readonly string[]
 }
 
 function absolutePathLiteral(source: string, sourcePath: string): string | undefined {
-  return stringFragments(source, sourcePath).find(fragment => absolutePath.test(fragment));
+  let match: string | undefined;
+
+  function visit(node: ts.Node): void {
+    if (match !== undefined) return;
+    if (
+      (ts.isStringLiteralLike(node) ||
+        ts.isTemplateHead(node) ||
+        ts.isTemplateMiddle(node) ||
+        ts.isTemplateTail(node)) &&
+      absolutePath.test(node.text) &&
+      !isCssDelimiterComparison(node)
+    ) {
+      match = node.text;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile(source, sourcePath));
+  return match;
 }
 
 function packageVersionRead(inspection: TypeScriptInspection): string | undefined {
@@ -112,11 +130,21 @@ describe('native CSS stylesheet architecture boundary', () => {
   });
 
   test.each([
+    ['POSIX root', "const target = '/';"],
+    ['POSIX root comparison', "const isRoot = target === '/';"],
     ['POSIX', "const target = '/tmp/owned.css';"],
     ['Windows drive', String.raw`const target = 'C:\\temp\\owned.css';`],
     ['Windows UNC', String.raw`const target = '\\\\server\\share\\owned.css';`],
   ])('rejects a %s absolute-path mutation', (_label, source) => {
     expect(absolutePathLiteral(source, fixturePath)).toBeDefined();
+  });
+
+  test.each([
+    ['CSS slash delimiter comparison', "const isSlash = codeUnit === '/';"],
+    ['ownership comment prefix', "const marker = '/* flex-layout-codemod:start schema=1 */';"],
+    ['line-comment prefix', "const prefix = '//';"],
+  ])('does not mistake a %s for an absolute path', (_label, source) => {
+    expect(absolutePathLiteral(source, fixturePath)).toBeUndefined();
   });
 
   test.each([

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -59,7 +59,13 @@ export function inspectTypeScript(source: string, sourcePath: string): TypeScrip
       );
     }
 
-    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteralLike(node.argument.literal)
+    ) {
+      moduleReferences.push(node.argument.literal.text);
+    } else if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
       const reference = moduleText(node.moduleSpecifier);
       if (reference !== undefined) moduleReferences.push(reference);
     } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {

--- a/test/compatibility/native-css-stylesheet.test.ts
+++ b/test/compatibility/native-css-stylesheet.test.ts
@@ -1,0 +1,381 @@
+import { CssArtifactRegistry } from '../../src/adapter/css/css-artifact.registry';
+import type {
+  CssDeclaration,
+  CssRuleContext,
+  CssSemanticFamily,
+  OwnedCssRule,
+} from '../../src/adapter/css/css-artifact.model';
+import { cssRuleContext } from '../../src/adapter/css/css-breakpoint.context';
+import { renderFlexAlignCss } from '../../src/adapter/css/flex/flex-align.css-renderer';
+import { renderLayoutGapCss } from '../../src/adapter/css/flex/layout-gap.css-renderer';
+import { renderLayoutCss } from '../../src/adapter/css/flex/layout.css-renderer';
+import { parseOwnedCssBlock } from '../../src/adapter/css/stylesheet/owned-css-block.parser';
+import { serializeOwnedCssBlock } from '../../src/adapter/css/stylesheet/owned-css-block.serializer';
+import { mergeOwnedStylesheet } from '../../src/adapter/css/stylesheet/owned-stylesheet.merger';
+import { BreakpointCatalog, type BreakpointDefinition } from '../../src/breakpoint/breakpoint-catalog';
+import { planFlexAlignSemantics } from '../../src/flex/flex-align.semantic';
+import { planLayoutGapSemantics } from '../../src/flex/layout-gap.semantic';
+import { parseLayout } from '../../src/flex/layout.semantic';
+
+const standardAliases = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  'lt-sm',
+  'lt-md',
+  'lt-lg',
+  'lt-xl',
+  'gt-xs',
+  'gt-sm',
+  'gt-md',
+  'gt-lg',
+] as const;
+
+const expectedRuleIds = [
+  '6ae331818e3189b1bd4ceb90a8d7bc3b29b6f46b32ed0eea16fd2e0ff126dbd9',
+  'dd734cc26a3c6c947f23cd39b3659737b0384708eeb3ee57b0b828df93090c90',
+  'a0e5e9dd7330c10550dec6d418fdc28735d26f62f476b866383a6460cf6f2391',
+  '63a9a63be732726b9073b2108fd32f562e1352ba19a3e2f90b3a48efe530a7cc',
+  'ea87caa74386649cdf2b9ab42ba8f392ba16d6190fc3838d8438b333edecbf3c',
+  '415c9233ba1b7e91a83321ebeebf75d7f67872bd7e2ac1060d4b9cc0315aaa41',
+  'bd8c772ff3e0227febf73568da0bae5a29ff00f1ca61b4a3002e8675df9feeb9',
+  '83e28dfc2f65e4bd2791946071873d8dc5ccfd666687da2f31fb3c050bcc0e59',
+  'a0f5eac60e36b339300f6432e08209812dd2f33624e7bf84a1ef180c1b740631',
+  '6214ed08ab887f9bf96da06acfaf94b0b57c71c736700bcacd7c9b06d550c5fc',
+  '5db569964d7005fb7f43670e7b3717a9383141a116aa726650e687064263308e',
+  'b2da7c7d7c270a15fb6a23bb497458d693e0e1cc81b4c35dd004778d3d911d63',
+  '2943bb442fafabc50683021038fa1b94f758c725ca4093a83f9fc79aebcddba9',
+  'd931799d6cdf205a3ba45bbeefc6b29adaf93a6aab3cabdd17b794184df3653d',
+  'bc74dea29e0d48899caea3b580821fec03ffa1c075259a3c57908dff0ee8d802',
+] as const;
+
+const handwrittenPrefix = '/* handwritten prefix */\n.page { color: rebeccapurple; }\n\n';
+const handwrittenSuffix = '\n\n/* handwritten suffix */\n.note::before { content: "kept"; }\n';
+
+const goldenStylesheet = `/* handwritten prefix */
+.page { color: rebeccapurple; }
+
+/* flex-layout-codemod:start schema=1 */
+/* flex-layout-codemod:rule id=6ae331818e3189b1bd4ceb90a8d7bc3b29b6f46b32ed0eea16fd2e0ff126dbd9 */
+.flm-6ae331818e3189b1bd4ceb90a8d7bc3b29b6f46b32ed0eea16fd2e0ff126dbd9 {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+@media screen and (min-width: 0px) and (max-width: 599.98px) {
+  /* flex-layout-codemod:rule id=dd734cc26a3c6c947f23cd39b3659737b0384708eeb3ee57b0b828df93090c90 */
+  .flm-dd734cc26a3c6c947f23cd39b3659737b0384708eeb3ee57b0b828df93090c90 {
+    gap: 8px;
+  }
+}
+@media screen and (max-width: 599.98px) {
+  /* flex-layout-codemod:rule id=a0e5e9dd7330c10550dec6d418fdc28735d26f62f476b866383a6460cf6f2391 */
+  .flm-a0e5e9dd7330c10550dec6d418fdc28735d26f62f476b866383a6460cf6f2391 {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 600px) and (max-width: 959.98px) {
+  /* flex-layout-codemod:rule id=63a9a63be732726b9073b2108fd32f562e1352ba19a3e2f90b3a48efe530a7cc */
+  .flm-63a9a63be732726b9073b2108fd32f562e1352ba19a3e2f90b3a48efe530a7cc {
+    gap: 8px;
+  }
+  /* flex-layout-codemod:rule id=ea87caa74386649cdf2b9ab42ba8f392ba16d6190fc3838d8438b333edecbf3c */
+  .flm-ea87caa74386649cdf2b9ab42ba8f392ba16d6190fc3838d8438b333edecbf3c {
+    align-self: center;
+  }
+}
+@media screen and (max-width: 959.98px) {
+  /* flex-layout-codemod:rule id=415c9233ba1b7e91a83321ebeebf75d7f67872bd7e2ac1060d4b9cc0315aaa41 */
+  .flm-415c9233ba1b7e91a83321ebeebf75d7f67872bd7e2ac1060d4b9cc0315aaa41 {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 960px) and (max-width: 1279.98px) {
+  /* flex-layout-codemod:rule id=bd8c772ff3e0227febf73568da0bae5a29ff00f1ca61b4a3002e8675df9feeb9 */
+  .flm-bd8c772ff3e0227febf73568da0bae5a29ff00f1ca61b4a3002e8675df9feeb9 {
+    gap: 8px;
+  }
+}
+@media screen and (max-width: 1279.98px) {
+  /* flex-layout-codemod:rule id=83e28dfc2f65e4bd2791946071873d8dc5ccfd666687da2f31fb3c050bcc0e59 */
+  .flm-83e28dfc2f65e4bd2791946071873d8dc5ccfd666687da2f31fb3c050bcc0e59 {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 1280px) and (max-width: 1919.98px) {
+  /* flex-layout-codemod:rule id=a0f5eac60e36b339300f6432e08209812dd2f33624e7bf84a1ef180c1b740631 */
+  .flm-a0f5eac60e36b339300f6432e08209812dd2f33624e7bf84a1ef180c1b740631 {
+    gap: 8px;
+  }
+}
+@media screen and (max-width: 1919.98px) {
+  /* flex-layout-codemod:rule id=6214ed08ab887f9bf96da06acfaf94b0b57c71c736700bcacd7c9b06d550c5fc */
+  .flm-6214ed08ab887f9bf96da06acfaf94b0b57c71c736700bcacd7c9b06d550c5fc {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 1920px) and (max-width: 4999.98px) {
+  /* flex-layout-codemod:rule id=5db569964d7005fb7f43670e7b3717a9383141a116aa726650e687064263308e */
+  .flm-5db569964d7005fb7f43670e7b3717a9383141a116aa726650e687064263308e {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 1920px) {
+  /* flex-layout-codemod:rule id=b2da7c7d7c270a15fb6a23bb497458d693e0e1cc81b4c35dd004778d3d911d63 */
+  .flm-b2da7c7d7c270a15fb6a23bb497458d693e0e1cc81b4c35dd004778d3d911d63 {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 1280px) {
+  /* flex-layout-codemod:rule id=2943bb442fafabc50683021038fa1b94f758c725ca4093a83f9fc79aebcddba9 */
+  .flm-2943bb442fafabc50683021038fa1b94f758c725ca4093a83f9fc79aebcddba9 {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 960px) {
+  /* flex-layout-codemod:rule id=d931799d6cdf205a3ba45bbeefc6b29adaf93a6aab3cabdd17b794184df3653d */
+  .flm-d931799d6cdf205a3ba45bbeefc6b29adaf93a6aab3cabdd17b794184df3653d {
+    gap: 8px;
+  }
+}
+@media screen and (min-width: 600px) {
+  /* flex-layout-codemod:rule id=bc74dea29e0d48899caea3b580821fec03ffa1c075259a3c57908dff0ee8d802 */
+  .flm-bc74dea29e0d48899caea3b580821fec03ffa1c075259a3c57908dff0ee8d802 {
+    gap: 8px;
+  }
+}
+/* flex-layout-codemod:end */
+
+/* handwritten suffix */
+.note::before { content: "kept"; }
+`;
+
+const smallerGoldenStylesheet = `/* handwritten prefix */
+.page { color: rebeccapurple; }
+
+/* flex-layout-codemod:start schema=1 */
+/* flex-layout-codemod:rule id=6ae331818e3189b1bd4ceb90a8d7bc3b29b6f46b32ed0eea16fd2e0ff126dbd9 */
+.flm-6ae331818e3189b1bd4ceb90a8d7bc3b29b6f46b32ed0eea16fd2e0ff126dbd9 {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+@media screen and (min-width: 600px) and (max-width: 959.98px) {
+  /* flex-layout-codemod:rule id=63a9a63be732726b9073b2108fd32f562e1352ba19a3e2f90b3a48efe530a7cc */
+  .flm-63a9a63be732726b9073b2108fd32f562e1352ba19a3e2f90b3a48efe530a7cc {
+    gap: 8px;
+  }
+  /* flex-layout-codemod:rule id=ea87caa74386649cdf2b9ab42ba8f392ba16d6190fc3838d8438b333edecbf3c */
+  .flm-ea87caa74386649cdf2b9ab42ba8f392ba16d6190fc3838d8438b333edecbf3c {
+    align-self: center;
+  }
+}
+/* flex-layout-codemod:end */
+
+/* handwritten suffix */
+.note::before { content: "kept"; }
+`;
+
+interface ScenarioArtifact {
+  readonly label: string;
+  readonly family: CssSemanticFamily;
+  readonly declarations: readonly CssDeclaration[];
+  readonly context: CssRuleContext;
+}
+
+function plannedLayoutDeclarations(): readonly CssDeclaration[] {
+  const planned = parseLayout('row wrap');
+  if (!planned.ok) throw new Error('Expected planned layout semantics');
+  return renderLayoutCss(planned.value);
+}
+
+function plannedGapDeclarations(): readonly CssDeclaration[] {
+  const planned = planLayoutGapSemantics('8px', 'row');
+  if (planned.status !== 'planned') throw new Error('Expected planned layout gap semantics');
+  return renderLayoutGapCss(planned.value);
+}
+
+function plannedAlignmentDeclarations(): readonly CssDeclaration[] {
+  const planned = planFlexAlignSemantics('center');
+  if (planned.status !== 'planned') throw new Error('Expected planned flex alignment semantics');
+  return renderFlexAlignCss(planned.value);
+}
+
+function verifiedDefinition(catalog: BreakpointCatalog, alias: string): BreakpointDefinition {
+  const classification = catalog.classify(alias);
+  if (classification.kind !== 'verified') throw new Error(`Expected ${alias} to be a verified breakpoint`);
+  return classification.definition;
+}
+
+function scenarioArtifacts(): readonly ScenarioArtifact[] {
+  const catalog = new BreakpointCatalog();
+  const gap = plannedGapDeclarations();
+  const responsive = standardAliases.map(alias => ({
+    label: alias,
+    family: 'layout-gap' as const,
+    declarations: gap,
+    context: cssRuleContext(verifiedDefinition(catalog, alias)),
+  }));
+  const smContext = cssRuleContext(verifiedDefinition(catalog, 'sm'));
+
+  return [
+    { label: 'base', family: 'layout', declarations: plannedLayoutDeclarations(), context: cssRuleContext() },
+    ...responsive,
+    {
+      label: 'sm-align',
+      family: 'flex-align',
+      declarations: plannedAlignmentDeclarations(),
+      context: smContext,
+    },
+  ];
+}
+
+function buildScenario(
+  direction: 'forward' | 'reverse' = 'forward',
+  includedLabels?: ReadonlySet<string>,
+): {
+  readonly registry: CssArtifactRegistry;
+  readonly labelById: ReadonlyMap<string, string>;
+} {
+  const registry = new CssArtifactRegistry();
+  const labelById = new Map<string, string>();
+  const selected = scenarioArtifacts().filter(artifact => includedLabels?.has(artifact.label) ?? true);
+  const artifacts = direction === 'reverse' ? [...selected].reverse() : selected;
+
+  for (const artifact of artifacts) {
+    const rule = registry.register(artifact.family, artifact.declarations, artifact.context);
+    labelById.set(rule.id, artifact.label);
+  }
+
+  return { registry, labelById };
+}
+
+function orderedLabels(rules: readonly OwnedCssRule[], labelById: ReadonlyMap<string, string>): readonly string[] {
+  return rules.map(rule => labelById.get(rule.id) ?? 'missing');
+}
+
+describe('native CSS stylesheet end-to-end compatibility', () => {
+  test('keeps all 14 catalog contexts, stable IDs, and registry order independent of registration order', () => {
+    const forward = buildScenario();
+    const reverse = buildScenario('reverse');
+    const forwardRules = forward.registry.rules();
+    const reverseRules = reverse.registry.rules();
+    const expectedLabels = [
+      'base',
+      'xs',
+      'lt-sm',
+      'sm',
+      'sm-align',
+      'lt-md',
+      'md',
+      'lt-lg',
+      'lg',
+      'lt-xl',
+      'xl',
+      'gt-lg',
+      'gt-md',
+      'gt-sm',
+      'gt-xs',
+    ];
+
+    expect(forwardRules.map(rule => rule.id)).toEqual(expectedRuleIds);
+    expect(reverseRules.map(rule => rule.id)).toEqual(expectedRuleIds);
+    expect(orderedLabels(forwardRules, forward.labelById)).toEqual(expectedLabels);
+    expect(orderedLabels(reverseRules, reverse.labelById)).toEqual(expectedLabels);
+    expect(forwardRules.map(rule => rule.context)).toEqual([
+      { priority: 0 },
+      { priority: 1000, media: { type: 'screen', clauses: [{ min: 0, max: 599.98 }] } },
+      { priority: 950, media: { type: 'screen', clauses: [{ max: 599.98 }] } },
+      { priority: 900, media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] } },
+      { priority: 900, media: { type: 'screen', clauses: [{ min: 600, max: 959.98 }] } },
+      { priority: 850, media: { type: 'screen', clauses: [{ max: 959.98 }] } },
+      { priority: 800, media: { type: 'screen', clauses: [{ min: 960, max: 1279.98 }] } },
+      { priority: 750, media: { type: 'screen', clauses: [{ max: 1279.98 }] } },
+      { priority: 700, media: { type: 'screen', clauses: [{ min: 1280, max: 1919.98 }] } },
+      { priority: 650, media: { type: 'screen', clauses: [{ max: 1919.98 }] } },
+      { priority: 600, media: { type: 'screen', clauses: [{ min: 1920, max: 4999.98 }] } },
+      { priority: -650, media: { type: 'screen', clauses: [{ min: 1920 }] } },
+      { priority: -750, media: { type: 'screen', clauses: [{ min: 1280 }] } },
+      { priority: -850, media: { type: 'screen', clauses: [{ min: 960 }] } },
+      { priority: -950, media: { type: 'screen', clauses: [{ min: 600 }] } },
+    ]);
+  });
+
+  test('merges one exact grouped golden stylesheet, preserves bytes, parses its range, and is idempotent', () => {
+    const full = buildScenario();
+    const previous = buildScenario('forward', new Set(['base']));
+    const existing = handwrittenPrefix + serializeOwnedCssBlock(previous.registry.rules(), '\n') + handwrittenSuffix;
+    const merged = mergeOwnedStylesheet(existing, full.registry.rules());
+
+    expect(merged).toEqual({ changed: true, output: goldenStylesheet });
+    expect(merged.output.startsWith(handwrittenPrefix)).toBe(true);
+    expect(merged.output.endsWith(handwrittenSuffix)).toBe(true);
+    expect(merged.output.match(/^@media /gmu)).toHaveLength(13);
+    expect(
+      merged.output.match(/^@media screen and \(min-width: 600px\) and \(max-width: 959\.98px\) \{/gmu),
+    ).toHaveLength(1);
+    expect(parseOwnedCssBlock(merged.output)).toEqual({
+      status: 'found',
+      range: { start: handwrittenPrefix.length, end: goldenStylesheet.length - handwrittenSuffix.length },
+      newline: '\n',
+    });
+    expect(mergeOwnedStylesheet(merged.output, full.registry.rules())).toEqual({
+      changed: false,
+      output: goldenStylesheet,
+    });
+  });
+
+  test('replaces the golden block with a smaller registry and removes ownership without changing surrounding bytes', () => {
+    const smaller = buildScenario('forward', new Set(['base', 'sm', 'sm-align']));
+    const shrunk = mergeOwnedStylesheet(goldenStylesheet, smaller.registry.rules());
+
+    expect(shrunk).toEqual({ changed: true, output: smallerGoldenStylesheet });
+    expect(shrunk.output.startsWith(handwrittenPrefix)).toBe(true);
+    expect(shrunk.output.endsWith(handwrittenSuffix)).toBe(true);
+    expect(mergeOwnedStylesheet(shrunk.output, [])).toEqual({
+      changed: true,
+      output: handwrittenPrefix + handwrittenSuffix,
+    });
+  });
+
+  test('emits the same golden bytes when all artifacts are registered in reverse order', () => {
+    const reverse = buildScenario('reverse');
+    const previous = buildScenario('forward', new Set(['base']));
+    const existing = handwrittenPrefix + serializeOwnedCssBlock(previous.registry.rules(), '\n') + handwrittenSuffix;
+
+    expect(mergeOwnedStylesheet(existing, reverse.registry.rules())).toEqual({
+      changed: true,
+      output: goldenStylesheet,
+    });
+  });
+
+  test.each([
+    {
+      label: 'unsupported schema',
+      source: '/* flex-layout-codemod:start schema=2 *//* flex-layout-codemod:end */',
+      code: 'unsupported-ownership-schema',
+    },
+    {
+      label: 'different rule selector ID',
+      source: `/* flex-layout-codemod:start schema=1 */
+/* flex-layout-codemod:rule id=${'a'.repeat(64)} */
+.flm-${'b'.repeat(64)} {}
+/* flex-layout-codemod:end */`,
+      code: 'ownership-rule-mismatch',
+    },
+    {
+      label: 'rule ID used only as a selector prefix',
+      source: `/* flex-layout-codemod:start schema=1 */
+/* flex-layout-codemod:rule id=${'a'.repeat(64)} */
+.flm-${'a'.repeat(64)}0 {}
+/* flex-layout-codemod:end */`,
+      code: 'ownership-rule-mismatch',
+    },
+  ] as const)('rejects $label in the final ownership corruption matrix', ({ source, code }) => {
+    expect(parseOwnedCssBlock(source)).toEqual(expect.objectContaining({ status: 'invalid', code }));
+  });
+});


### PR DESCRIPTION
## Summary

- Add deterministic validation and serialization for owned native CSS rules and media queries.
- Define exact schema-1 ownership markers and parse them with a string- and escape-aware CSS comment scanner.
- Add fail-closed corruption detection and a pure append/replace/remove stylesheet merger that preserves all unowned bytes.
- Add architecture coverage and golden registry-to-stylesheet tests across all 13 aliases.
- Keep this slice internal: CLI and filesystem integration remain intentionally out of scope.

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally (102 files, 2,674 tests).
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

## Migration example

Not applicable — this is internal infrastructure that is not yet reachable through the CLI.

## Dependencies and compatibility

None.