### PR TITLE
refactor: introduce enterprise migration pipeline shell

### DIFF
--- a/docs/architecture/enterprise-architecture-rewrite.md
+++ b/docs/architecture/enterprise-architecture-rewrite.md
@@ -147,6 +147,8 @@ Add the benchmark corpus, structural counters, output snapshots, architectural d
 
 Introduce immutable manifest, analyzed-project, rendered-project, and validated-plan contracts plus the pipeline coordinator. Adapt the existing migrator behind these contracts without duplicating migration policy.
 
+`CurrentMigrationPipeline` is the single temporary compatibility façade over `Migrator`. Slices 3–6 replace its delegated responsibilities with concrete stages; Slice 7 removes the façade after the CLI-facing `MigrationRunner` is backed by `MigrationPipeline`.
+
 ### 3. Discovery and analysis
 
 Move file topology, reads, Angular parsing, and input analysis into their dedicated stages. Remove repeated construction and parsing while retaining deterministic ordering and current diagnostics.

--- a/docs/superpowers/plans/2026-09-03-enterprise-pipeline-shell.md
+++ b/docs/superpowers/plans/2026-09-03-enterprise-pipeline-shell.md
@@ -1,0 +1,410 @@
+# Enterprise Pipeline Shell Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce immutable Discover → Analyze → Render → Validate → Apply contracts and a fail-closed coordinator, while routing production through one temporary compatibility façade over the existing migrator.
+
+**Architecture:** New `src/pipeline` modules define readonly handoff models, narrow stage ports, and a coordinator that passes each completed result exactly once to the next stage. A temporary `CurrentMigrationPipeline` implements the CLI-facing runner by delegating to the existing `Migrator`; it is the only production route until later slices replace its internals stage by stage, and its removal is explicitly reserved for Slice 7.
+
+**Tech Stack:** TypeScript 6, Node.js 24, Vitest 4, existing migration models and adapters.
+
+**Spec:** `docs/architecture/enterprise-architecture-rewrite.md`
+
+## Global Constraints
+
+- Preserve discovered template order, source bytes, generated output, diagnostics, plan/write behavior, reports, exit codes, transaction recovery, interruption behavior, and packaged CLI entry points.
+- Add no runtime dependency, plugin framework, reflection framework, service locator, or general dependency-injection container.
+- Every handoff factory recursively freezes its owned arrays, records, and artifact states; it does not freeze opaque Angular compiler nodes or mutate caller-owned values.
+- Expected source limitations remain data; thrown stage failures are I/O or internal invariants and identify the failing stage internally without changing public JSON schema.
+- Only the existing transaction/atomic-writer boundary may mutate project files.
+- The compatibility façade contains no conversion, breakpoint, rendering, validation, transaction, reporting, or exit policy. It is removed in delivery Slice 7 after real stages own the complete production flow.
+- Add no Changeset because public behavior is unchanged.
+- Retain the exact known undeclared `ignore` baseline; do not add or remove dependencies in this slice.
+- Preserve or improve deterministic workload counters and benchmark report schemas; timing values remain observational.
+- Every task follows TDD, ends with focused verification and `git diff --check`, and produces an independently reviewable commit.
+
+---
+
+### Task 1: Define immutable pipeline handoff models
+
+**Files:**
+
+- Create: `src/pipeline/project-manifest.ts`
+- Create: `src/pipeline/analyzed-project.ts`
+- Create: `src/pipeline/rendered-project.ts`
+- Create: `src/pipeline/validated-project-plan.ts`
+- Create: `src/pipeline/pipeline-handoffs.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `MigrationOptions`, `TemplateParseResult`, `LocatedFlexLayoutInput`, `FileMigrationPlan`, `AdapterSessionResult`, `MigrationPlan`, and `StylesheetMigrationResult`.
+- Produces:
+
+```ts
+export interface MigrationInvocation {
+  readonly inputPath: string;
+  readonly outputPath: string;
+  readonly options: Readonly<MigrationOptions>;
+}
+
+export interface ManifestTemplate {
+  readonly inputPath: string;
+  readonly outputPath: string;
+}
+
+export interface ProjectManifest {
+  readonly invocation: MigrationInvocation;
+  readonly templates: readonly ManifestTemplate[];
+}
+
+export type AnalyzedTemplate =
+  | {
+      readonly status: 'parsed';
+      readonly file: ManifestTemplate;
+      readonly source: string;
+      readonly parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }>;
+      readonly inputs: readonly LocatedFlexLayoutInput[];
+    }
+  | {
+      readonly status: 'parse-error';
+      readonly file: ManifestTemplate;
+      readonly source: string;
+      readonly parseResult: Extract<TemplateParseResult, { readonly status: 'parse-error' }>;
+    };
+
+export interface AnalyzedProject {
+  readonly manifest: ProjectManifest;
+  readonly templates: readonly AnalyzedTemplate[];
+}
+
+export interface RenderedProject {
+  readonly analyzed: AnalyzedProject;
+  readonly files: readonly FileMigrationPlan[];
+  readonly session: AdapterSessionResult;
+}
+
+export interface ValidatedProjectPlan {
+  readonly rendered: RenderedProject;
+  readonly plan: MigrationPlan;
+  readonly stylesheet?: StylesheetMigrationResult;
+}
+```
+
+Each module exports a same-named camel-case factory: `migrationInvocation`, `projectManifest`, `analyzedProject`, `renderedProject`, and `validatedProjectPlan`.
+
+- [ ] **Step 1: Write failing factory tests**
+
+Test exact normalization and ownership rules:
+
+- invocation paths become normalized absolute paths;
+- invocation options are copied and frozen;
+- manifest templates preserve input order and contain normalized absolute paths;
+- analyzed templates preserve the manifest identities and source bytes;
+- input arrays, rendered file plans, session rule arrays, migration plan contents, and stylesheet records are copied/frozen through their existing factories where available;
+- mutating any caller-owned top-level array or plain options/stylesheet record after construction cannot change a handoff;
+- malformed membership (an analyzed template not present in its manifest, a rendered file not represented by an analyzed template, or a validated plan target differing from its finalized session target) throws an internal invariant error;
+- opaque Angular parse nodes remain usable and are not recursively frozen.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/pipeline-handoffs.spec.ts
+```
+
+Expected: FAIL because the handoff modules do not exist.
+
+- [ ] **Step 3: Implement minimal factories**
+
+Use `Object.freeze`, copied arrays, existing `fileMigrationPlan`/`migrationPlan` factories, and normalized absolute paths. Add a private invariant helper in the owning module rather than a cross-project error framework. Membership comparisons use normalized absolute input/output pairs and code-unit equality; do not compare opaque Angular nodes structurally.
+
+- [ ] **Step 4: Verify models and type boundaries**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/pipeline-handoffs.spec.ts src/migrator/file.migrator.spec.ts src/migrator/migrator.spec.ts
+npx tsc --noEmit
+npx eslint src/pipeline
+git diff --check
+```
+
+Expected: all selected tests, type-checking, lint, and diff checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline
+git commit -m "refactor: define immutable migration handoffs"
+```
+
+---
+
+### Task 2: Implement the five-stage coordinator
+
+**Files:**
+
+- Create: `src/pipeline/migration-pipeline.ts`
+- Create: `src/pipeline/migration-pipeline.spec.ts`
+- Create: `src/pipeline/pipeline-stage.error.ts`
+
+**Interfaces:**
+
+- Consumes: factories and interfaces from Task 1.
+- Produces:
+
+```ts
+export type PipelineStageName = 'discover' | 'analyze' | 'render' | 'validate' | 'apply';
+
+export interface DiscoverStage {
+  run(invocation: MigrationInvocation): Promise<ProjectManifest>;
+}
+export interface AnalyzeStage {
+  run(manifest: ProjectManifest): Promise<AnalyzedProject>;
+}
+export interface RenderStage {
+  run(analyzed: AnalyzedProject): Promise<RenderedProject>;
+}
+export interface ValidateStage {
+  run(rendered: RenderedProject): Promise<ValidatedProjectPlan>;
+}
+export interface ApplyStageResult {
+  readonly application: MigrationApplication;
+}
+export interface ApplyStage {
+  run(plan: ValidatedProjectPlan): Promise<ApplyStageResult>;
+}
+export interface MigrationPipelineResult {
+  readonly validated: ValidatedProjectPlan;
+  readonly application: MigrationApplication;
+}
+
+export class MigrationPipeline {
+  constructor(
+    discover: DiscoverStage,
+    analyze: AnalyzeStage,
+    render: RenderStage,
+    validate: ValidateStage,
+    apply: ApplyStage,
+  );
+  run(invocation: MigrationInvocation): Promise<MigrationPipelineResult>;
+}
+```
+
+`PipelineStageError` exposes readonly `stage: PipelineStageName` and `cause: unknown`; its message is `Migration pipeline <stage> stage failed.`.
+
+- [ ] **Step 1: Write failing coordinator tests**
+
+Use recording fake stages with real Task 1 handoffs. Assert exact call order, one call per stage, referential identity between one stage output and the next input, frozen final result/application, and no stage call after a predecessor throws.
+
+Add a parameterized failure test for all five stages. Existing `PipelineStageError` values pass through unchanged; any other thrown value is wrapped once with the exact stage and original cause. A stage that returns a promise rejection is handled identically to a synchronous throw.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/migration-pipeline.spec.ts
+```
+
+Expected: FAIL because the coordinator and error do not exist.
+
+- [ ] **Step 3: Implement the coordinator**
+
+Keep the coordinator linear and explicit:
+
+```ts
+const manifest = await runStage('discover', () => this.discover.run(invocation));
+const analyzed = await runStage('analyze', () => this.analyze.run(manifest));
+const rendered = await runStage('render', () => this.render.run(analyzed));
+const validated = await runStage('validate', () => this.validate.run(rendered));
+const applied = await runStage('apply', () => this.apply.run(validated));
+return Object.freeze({ validated, application: Object.freeze({ ...applied.application }) });
+```
+
+Do not add middleware, event buses, retries, parallel execution, generic stage graphs, or a DI container.
+
+- [ ] **Step 4: Verify coordinator behavior**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/migration-pipeline.spec.ts src/pipeline/pipeline-handoffs.spec.ts
+npx tsc --noEmit
+npx eslint src/pipeline
+git diff --check
+```
+
+Expected: all selected tests and static checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/migration-pipeline.ts src/pipeline/migration-pipeline.spec.ts src/pipeline/pipeline-stage.error.ts
+git commit -m "refactor: add staged migration coordinator"
+```
+
+---
+
+### Task 3: Route the CLI through the current-pipeline façade
+
+**Files:**
+
+- Create: `src/pipeline/current-migration.pipeline.ts`
+- Create: `src/pipeline/current-migration.pipeline.spec.ts`
+- Modify: `src/cli/run-cli.ts`
+- Modify: `src/cli/run-cli.spec.ts`
+- Modify: `test/architecture/migration-transaction-boundary.test.ts`
+
+**Interfaces:**
+
+- Consumes: current `Migrator`, `ConversionAdapterSession`, `MigrationOptions`, and `MigrationReport`.
+- Produces:
+
+```ts
+export interface MigrationRunner {
+  run(invocation: MigrationInvocation): Promise<MigrationReport>;
+}
+
+export type MigratorFactory = (
+  session: ConversionAdapterSession,
+  inputPath: string,
+  outputPath: string,
+) => Pick<Migrator, 'migrate'>;
+
+export class CurrentMigrationPipeline implements MigrationRunner {
+  constructor(session: ConversionAdapterSession, createMigrator?: MigratorFactory);
+  run(invocation: MigrationInvocation): Promise<MigrationReport>;
+}
+```
+
+- [ ] **Step 1: Write failing façade tests**
+
+Assert that `CurrentMigrationPipeline.run()` constructs exactly one migrator with the invocation's normalized paths, passes the exact copied options to `migrate`, returns the same report identity, and adds no exception translation. Assert the factory is called once per invocation and stores no completed invocation state.
+
+In the CLI unit test, inject a `MigrationRunner` factory and assert CLI argument validation creates one immutable invocation and calls `run()` once. Preserve existing adapter-session construction and presenter/report-writer assertions.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/current-migration.pipeline.spec.ts src/cli/run-cli.spec.ts test/architecture/migration-transaction-boundary.test.ts
+```
+
+Expected: FAIL because the façade/runner seam does not exist and CLI still constructs `Migrator` directly.
+
+- [ ] **Step 3: Implement the thin façade and CLI seam**
+
+The façade body contains only construction and delegation:
+
+```ts
+run(invocation: MigrationInvocation): Promise<MigrationReport> {
+  return this.createMigrator(this.session, invocation.inputPath, invocation.outputPath).migrate(invocation.options);
+}
+```
+
+Change `runCli` dependencies to accept an optional `createMigrationRunner(session)` defaulting to `new CurrentMigrationPipeline(session)`. After current argument/path validation, create the invocation through `migrationInvocation(...)`, call the runner once, and leave presentation, report writing, and exit policy in their existing order.
+
+Update the transaction authority contract so the exact production call graph is CLI → `CurrentMigrationPipeline.run` → `Migrator.migrate` → `MigrationTransaction.apply`. Preserve fail-closed detection of indirect/dynamic write authority.
+
+- [ ] **Step 4: Verify packaged parity and workload stability**
+
+Run:
+
+```bash
+npx vitest run src/pipeline/current-migration.pipeline.spec.ts src/cli/run-cli.spec.ts test/architecture/migration-transaction-boundary.test.ts test/compatibility/enterprise-rewrite-parity.test.ts test/performance/migration-workload-counter.test.ts
+npm run build
+npx vitest run test/cli/cli.test.ts
+npx tsc --noEmit
+npx eslint src/pipeline/current-migration.pipeline.ts src/pipeline/current-migration.pipeline.spec.ts src/cli/run-cli.ts src/cli/run-cli.spec.ts test/architecture/migration-transaction-boundary.test.ts
+git diff --check
+```
+
+Expected: exact public parity, workload counters, packaged CLI behavior, authority graph, type-checking, lint, and diff checks pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pipeline/current-migration.pipeline.ts src/pipeline/current-migration.pipeline.spec.ts src/cli/run-cli.ts src/cli/run-cli.spec.ts test/architecture/migration-transaction-boundary.test.ts
+git commit -m "refactor: route CLI through migration pipeline"
+```
+
+---
+
+### Task 4: Enforce pipeline ownership and document the transition
+
+**Files:**
+
+- Create: `test/architecture/enterprise-pipeline-shell-boundary.test.ts`
+- Modify: `test/architecture/enterprise-pipeline-boundary.test.ts`
+- Modify: `test/package/test-discovery.test.ts`
+- Modify: `docs/architecture/enterprise-architecture-rewrite.md`
+
+**Interfaces:**
+
+- Consumes: pipeline modules from Tasks 1–3 and existing architecture inspection utilities.
+- Produces: executable dependency-direction contracts and the named removal point for `CurrentMigrationPipeline`.
+
+- [ ] **Step 1: Write failing architecture tests**
+
+Require:
+
+- `src/pipeline` handoff models import only target-neutral analyzer/template/migrator/report model types and Node path normalization; they import no concrete adapter, filesystem, CLI, presenter, logger, transaction, or writer;
+- `migration-pipeline.ts` imports only handoff models, stage error, and `MigrationApplication` type;
+- `current-migration.pipeline.ts` is the sole pipeline module allowed to import concrete `Migrator` and adapter session, and its production AST contains exactly one call to `migrate` and no directive, breakpoint, render, validation, report-building, filesystem, transaction, or exit-policy symbols;
+- `run-cli.ts` imports `MigrationRunner`/`CurrentMigrationPipeline` and does not import `Migrator` directly;
+- no production module outside `run-cli.ts` imports `CurrentMigrationPipeline`;
+- new handoff arrays and result objects are readonly/frozen under mutation attempts; and
+- every `src/pipeline/*.spec.ts` file is discovered by Vitest policy.
+
+- [ ] **Step 2: Run architecture tests to verify RED**
+
+Run:
+
+```bash
+npx vitest run test/architecture/enterprise-pipeline-shell-boundary.test.ts test/package/test-discovery.test.ts
+```
+
+Expected: FAIL until the new pipeline ownership constraints are implemented and discovered.
+
+- [ ] **Step 3: Complete the boundaries and transition documentation**
+
+Use the existing TypeScript AST helpers, not regex over source comments/strings, for import and call assertions. Tighten `enterprise-pipeline-boundary.test.ts` so pipeline modules are included in the no-mutation production scan.
+
+Under delivery Slice 2 in the architecture document, add this transition statement:
+
+```text
+`CurrentMigrationPipeline` is the single temporary compatibility façade over `Migrator`. Slices 3–6 replace its delegated responsibilities with concrete stages; Slice 7 removes the façade after the CLI-facing `MigrationRunner` is backed by `MigrationPipeline`.
+```
+
+Do not update user-facing README/compatibility docs or add a Changeset.
+
+- [ ] **Step 4: Run complete slice verification**
+
+Run:
+
+```bash
+npm run clean
+npm run verify
+npx vitest run test/compatibility/enterprise-rewrite-parity.test.ts test/performance/migration-workload-counter.test.ts test/architecture/enterprise-pipeline-shell-boundary.test.ts
+npm run architecture:inventory -- --json "$(mktemp -d)/pipeline-shell-inventory.json"
+git diff --check
+git status --short
+```
+
+Expected: format, lint, type-check, 3,230-or-more tests, coverage, build, package checks, parity, workload counters, inventory, and diff checks pass. Only intended tracked changes are present.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/architecture/enterprise-pipeline-shell-boundary.test.ts test/architecture/enterprise-pipeline-boundary.test.ts test/package/test-discovery.test.ts docs/architecture/enterprise-architecture-rewrite.md
+git commit -m "test: enforce migration pipeline shell"
+```
+
+---
+
+## Slice completion gate
+
+After Task 4, request independent spec-compliance and code-quality review of the complete slice. Address findings through focused fix commits, rerun `npm run clean && npm run verify`, and open a pull request containing only Slice 2. Do not begin discovery/analysis ownership work until this pull request is merged; write the Slice 3 plan against the merged pipeline contracts.

--- a/src/cli/run-cli.spec.ts
+++ b/src/cli/run-cli.spec.ts
@@ -41,7 +41,7 @@ describe('runCli', () => {
     return { exitCode, stdout: stdout.text, stderr: stderr.text };
   }
 
-  test('runs one normalized immutable invocation through the injected migration runner', async () => {
+  test('runs one immutable invocation with raw execution paths and canonical identities through the injected runner', async () => {
     const input = `${join(temporaryDirectory, 'templates')}${sep}..${sep}input.html`;
     const outputPath = `${join(temporaryDirectory, 'generated')}${sep}..${sep}output.html`;
     const reportPath = join(temporaryDirectory, 'migration.json');
@@ -89,8 +89,10 @@ describe('runCli', () => {
     expect(sessions[0]?.adapter.name).toBe('tailwind');
     expect(invocations).toHaveLength(1);
     expect(invocations[0]).toEqual({
-      inputPath: resolve(input),
-      outputPath: resolve(outputPath),
+      inputPath: input,
+      outputPath,
+      canonicalInputPath: resolve(input),
+      canonicalOutputPath: resolve(outputPath),
       options: {
         mode: 'plan',
         responsiveImages: true,

--- a/src/cli/run-cli.spec.ts
+++ b/src/cli/run-cli.spec.ts
@@ -1,6 +1,10 @@
 import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
+import type { ConversionAdapterSession } from '../adapter/conversion-adapter.session';
+import type { MigrationRunner } from '../pipeline/current-migration.pipeline';
+import type { MigrationInvocation } from '../pipeline/project-manifest';
+import type { MigrationReport } from '../report/migration-report';
 import type { TextOutput } from '../report/terminal.presenter';
 import { runCli, type CliOutput } from './run-cli';
 
@@ -36,6 +40,73 @@ describe('runCli', () => {
     const exitCode = await runCli(['node', 'flex-layout-codemod', ...arguments_], output);
     return { exitCode, stdout: stdout.text, stderr: stderr.text };
   }
+
+  test('runs one normalized immutable invocation through the injected migration runner', async () => {
+    const input = `${join(temporaryDirectory, 'templates')}${sep}..${sep}input.html`;
+    const outputPath = `${join(temporaryDirectory, 'generated')}${sep}..${sep}output.html`;
+    const reportPath = join(temporaryDirectory, 'migration.json');
+    const expectedReport: MigrationReport = {
+      schemaVersion: 2,
+      mode: 'plan',
+      target: 'tailwind',
+      application: { status: 'skipped', reason: 'plan-only' },
+      input: 'validated-input',
+      output: 'validated-output',
+      durationMs: 7,
+      summary: {
+        filesScanned: 1,
+        filesChanged: 0,
+        converted: 0,
+        review: 1,
+        unsupported: 0,
+        invalid: 0,
+        parseErrors: 0,
+      },
+      files: [],
+    };
+    const sessions: ConversionAdapterSession[] = [];
+    const invocations: MigrationInvocation[] = [];
+    const stdout = new MemoryOutput();
+    const stderr = new MemoryOutput();
+
+    const exitCode = await runCli(
+      ['node', 'flex-layout-codemod', input, '--output', outputPath, '--responsive-images', '--report', reportPath],
+      { stdout, stderr },
+      {
+        createMigrationRunner(session): MigrationRunner {
+          sessions.push(session);
+          return {
+            run(invocation) {
+              invocations.push(invocation);
+              return Promise.resolve(expectedReport);
+            },
+          };
+        },
+      },
+    );
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.adapter.name).toBe('tailwind');
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toEqual({
+      inputPath: resolve(input),
+      outputPath: resolve(outputPath),
+      options: {
+        mode: 'plan',
+        responsiveImages: true,
+        stylesheetPath: undefined,
+        reportPath,
+      },
+    });
+    expect(Object.isFrozen(invocations[0])).toBe(true);
+    expect(Object.isFrozen(invocations[0]?.options)).toBe(true);
+    expect(exitCode).toBe(2);
+    expect(stdout.text).toBe(
+      'Plan: 1 files scanned, 0 would change\nConverted 0 | Review 1 | Unsupported 0 | Invalid 0 | Parse errors 0\nNo project files were written. Run again with --write to apply this plan.\n',
+    );
+    expect(stderr.text).toBe('');
+    expect(JSON.parse(await readFile(reportPath, 'utf8'))).toEqual(expectedReport);
+  });
 
   test('defaults a clean Tailwind migration to a plan without creating its output', async () => {
     const input = join(temporaryDirectory, 'input.html');

--- a/src/cli/run-cli.ts
+++ b/src/cli/run-cli.ts
@@ -2,8 +2,10 @@ import { Command, CommanderError, InvalidArgumentError, Option } from 'commander
 import * as path from 'node:path';
 import packageJson from '../../package.json' with { type: 'json' };
 import { AdapterFactory } from '../adapter/adapter.factory';
+import type { ConversionAdapterSession } from '../adapter/conversion-adapter.session';
 import { logger } from '../logger';
-import { Migrator } from '../migrator/migrator';
+import { CurrentMigrationPipeline, type MigrationRunner } from '../pipeline/current-migration.pipeline';
+import { migrationInvocation } from '../pipeline/project-manifest';
 import { JsonReportWriter } from '../report/json-report.writer';
 import { TerminalPresenter, type TextOutput } from '../report/terminal.presenter';
 import { getErrorMessage } from '../util/error.util';
@@ -31,6 +33,10 @@ export interface CliOutput {
   readonly stderr: TextOutput;
 }
 
+export interface RunCliDependencies {
+  readonly createMigrationRunner?: (session: ConversionAdapterSession) => MigrationRunner;
+}
+
 const processOutput: CliOutput = {
   stdout: process.stdout,
   stderr: process.stderr,
@@ -41,7 +47,11 @@ function parseSingleStylesheet(value: string, previous: string | undefined): str
   return value;
 }
 
-export async function runCli(argv: readonly string[], output: CliOutput = processOutput): Promise<0 | 1 | 2> {
+export async function runCli(
+  argv: readonly string[],
+  output: CliOutput = processOutput,
+  dependencies: RunCliDependencies = {},
+): Promise<0 | 1 | 2> {
   let exitCode: 0 | 1 | 2 = 0;
   let debug = false;
   const program = new Command();
@@ -110,12 +120,22 @@ export async function runCli(argv: readonly string[], output: CliOutput = proces
         orientationBreakpoints: options.orientationBreakpoints,
         printWithBreakpoints,
       });
-      const report = await new Migrator(session, input, destination).migrate({
-        mode,
-        responsiveImages: options.responsiveImages,
-        stylesheetPath,
-        reportPath,
-      });
+      const migrationRunner =
+        dependencies.createMigrationRunner === undefined
+          ? new CurrentMigrationPipeline(session)
+          : dependencies.createMigrationRunner(session);
+      const report = await migrationRunner.run(
+        migrationInvocation({
+          inputPath: input,
+          outputPath: destination,
+          options: {
+            mode,
+            responsiveImages: options.responsiveImages,
+            stylesheetPath,
+            reportPath,
+          },
+        }),
+      );
       const reportOutput = report.summary.parseErrors > 0 ? output.stderr : output.stdout;
 
       new TerminalPresenter().present(report, reportOutput);

--- a/src/pipeline/analyzed-project.ts
+++ b/src/pipeline/analyzed-project.ts
@@ -1,7 +1,7 @@
 import * as path from 'node:path';
 import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
 import { MigrationApplicationError } from '../migrator/migration-application.error';
-import type { TemplateParseResult } from '../template/template.model';
+import type { SourceRange, TemplateAttribute, TemplateElement, TemplateParseResult } from '../template/template.model';
 import { projectManifest, type ManifestTemplate, type ProjectManifest } from './project-manifest';
 
 export type AnalyzedTemplate =
@@ -26,8 +26,11 @@ export interface AnalyzedProject {
 
 export function analyzedProject(project: AnalyzedProject): AnalyzedProject {
   const manifest = projectManifest(project.manifest);
-  const templates = project.templates.map(template => {
-    const file = manifestTemplate(manifest, template.file);
+  if (project.templates.length !== manifest.templates.length) {
+    throw sequenceInvariant();
+  }
+  const templates = project.templates.map((template, index) => {
+    const file = manifestTemplateAt(manifest, template.file, index);
     if (template.status === 'parse-error') {
       return Object.freeze({
         status: template.status,
@@ -54,8 +57,39 @@ function freezeParsedResult(
 ): Extract<TemplateParseResult, { readonly status: 'parsed' }> {
   return Object.freeze({
     status: result.status,
-    elements: Object.freeze([...result.elements]),
+    elements: Object.freeze(result.elements.map(element => freezeTemplateElement(element))),
   });
+}
+
+function freezeTemplateElement(element: TemplateElement): TemplateElement {
+  return Object.freeze({
+    id: element.id,
+    name: element.name,
+    source: freezeSourceRange(element.source),
+    startTag: freezeSourceRange(element.startTag),
+    ...(element.endTag === undefined ? {} : { endTag: freezeSourceRange(element.endTag) }),
+    structural: element.structural,
+    attributes: Object.freeze(element.attributes.map(attribute => freezeTemplateAttribute(attribute))),
+    ...(element.parentId === undefined ? {} : { parentId: element.parentId }),
+  });
+}
+
+function freezeTemplateAttribute(attribute: TemplateAttribute): TemplateAttribute {
+  return Object.freeze({
+    name: attribute.name,
+    rawName: attribute.rawName,
+    rawValue: attribute.rawValue,
+    value: attribute.value,
+    binding: attribute.binding,
+    ...(attribute.bindingTarget === undefined ? {} : { bindingTarget: attribute.bindingTarget }),
+    source: freezeSourceRange(attribute.source),
+    nameSource: freezeSourceRange(attribute.nameSource),
+    ...(attribute.valueSource === undefined ? {} : { valueSource: freezeSourceRange(attribute.valueSource) }),
+  });
+}
+
+function freezeSourceRange(source: SourceRange): SourceRange {
+  return Object.freeze({ start: source.start, end: source.end });
 }
 
 function freezeParseErrorResult(
@@ -74,15 +108,12 @@ function freezeParseErrorResult(
   });
 }
 
-function manifestTemplate(manifest: ProjectManifest, candidate: ManifestTemplate): ManifestTemplate {
-  const match = manifest.templates.find(template => samePathPair(template, candidate));
-  if (match === undefined) {
-    throw internalInvariant('Analyzed template is not present in its project manifest.', [
-      candidate.inputPath,
-      candidate.outputPath,
-    ]);
+function manifestTemplateAt(manifest: ProjectManifest, candidate: ManifestTemplate, index: number): ManifestTemplate {
+  const expected = manifest.templates[index];
+  if (expected === undefined || !samePathPair(expected, candidate)) {
+    throw sequenceInvariant([candidate.inputPath, candidate.outputPath]);
   }
-  return match;
+  return expected;
 }
 
 function samePathPair(left: ManifestTemplate, right: ManifestTemplate): boolean {
@@ -105,6 +136,13 @@ function normalizedAbsolutePath(value: string): string {
   return path.normalize(path.resolve(value));
 }
 
-function internalInvariant(message: string, paths: readonly string[]): MigrationApplicationError {
+function sequenceInvariant(paths: readonly string[] = []): MigrationApplicationError {
+  return internalInvariant(
+    'Analyzed project templates must match its manifest one-to-one and in the same order.',
+    paths,
+  );
+}
+
+function internalInvariant(message: string, paths: readonly string[] = []): MigrationApplicationError {
   return new MigrationApplicationError('internal-invariant', message, paths);
 }

--- a/src/pipeline/analyzed-project.ts
+++ b/src/pipeline/analyzed-project.ts
@@ -1,0 +1,85 @@
+import * as path from 'node:path';
+import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import { MigrationApplicationError } from '../migrator/migration-application.error';
+import type { TemplateParseResult } from '../template/template.model';
+import { projectManifest, type ManifestTemplate, type ProjectManifest } from './project-manifest';
+
+export type AnalyzedTemplate =
+  | {
+      readonly status: 'parsed';
+      readonly file: ManifestTemplate;
+      readonly source: string;
+      readonly parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }>;
+      readonly inputs: readonly LocatedFlexLayoutInput[];
+    }
+  | {
+      readonly status: 'parse-error';
+      readonly file: ManifestTemplate;
+      readonly source: string;
+      readonly parseResult: Extract<TemplateParseResult, { readonly status: 'parse-error' }>;
+    };
+
+export interface AnalyzedProject {
+  readonly manifest: ProjectManifest;
+  readonly templates: readonly AnalyzedTemplate[];
+}
+
+export function analyzedProject(project: AnalyzedProject): AnalyzedProject {
+  const manifest = projectManifest(project.manifest);
+  const templates = project.templates.map(template => {
+    const file = manifestTemplate(manifest, template.file);
+    if (template.status === 'parse-error') {
+      return Object.freeze({
+        status: template.status,
+        file,
+        source: template.source,
+        parseResult: template.parseResult,
+      });
+    }
+
+    return Object.freeze({
+      status: template.status,
+      file,
+      source: template.source,
+      parseResult: template.parseResult,
+      inputs: Object.freeze(template.inputs.map(input => freezeLocatedInput(input))),
+    });
+  });
+
+  return Object.freeze({ manifest, templates: Object.freeze(templates) });
+}
+
+function manifestTemplate(manifest: ProjectManifest, candidate: ManifestTemplate): ManifestTemplate {
+  const match = manifest.templates.find(template => samePathPair(template, candidate));
+  if (match === undefined) {
+    throw internalInvariant('Analyzed template is not present in its project manifest.', [
+      candidate.inputPath,
+      candidate.outputPath,
+    ]);
+  }
+  return match;
+}
+
+function samePathPair(left: ManifestTemplate, right: ManifestTemplate): boolean {
+  return (
+    normalizedAbsolutePath(left.inputPath) === normalizedAbsolutePath(right.inputPath) &&
+    normalizedAbsolutePath(left.outputPath) === normalizedAbsolutePath(right.outputPath)
+  );
+}
+
+function freezeLocatedInput(input: LocatedFlexLayoutInput): LocatedFlexLayoutInput {
+  return Object.freeze({
+    ...input,
+    source: Object.freeze({ ...input.source }),
+    nameSource: Object.freeze({ ...input.nameSource }),
+    ...(input.valueSource === undefined ? {} : { valueSource: Object.freeze({ ...input.valueSource }) }),
+  });
+}
+
+function normalizedAbsolutePath(value: string): string {
+  return path.normalize(path.resolve(value));
+}
+
+function internalInvariant(message: string, paths: readonly string[]): MigrationApplicationError {
+  return new MigrationApplicationError('internal-invariant', message, paths);
+}

--- a/src/pipeline/analyzed-project.ts
+++ b/src/pipeline/analyzed-project.ts
@@ -33,7 +33,7 @@ export function analyzedProject(project: AnalyzedProject): AnalyzedProject {
         status: template.status,
         file,
         source: template.source,
-        parseResult: template.parseResult,
+        parseResult: freezeParseErrorResult(template.parseResult),
       });
     }
 
@@ -41,12 +41,37 @@ export function analyzedProject(project: AnalyzedProject): AnalyzedProject {
       status: template.status,
       file,
       source: template.source,
-      parseResult: template.parseResult,
+      parseResult: freezeParsedResult(template.parseResult),
       inputs: Object.freeze(template.inputs.map(input => freezeLocatedInput(input))),
     });
   });
 
   return Object.freeze({ manifest, templates: Object.freeze(templates) });
+}
+
+function freezeParsedResult(
+  result: Extract<TemplateParseResult, { readonly status: 'parsed' }>,
+): Extract<TemplateParseResult, { readonly status: 'parsed' }> {
+  return Object.freeze({
+    status: result.status,
+    elements: Object.freeze([...result.elements]),
+  });
+}
+
+function freezeParseErrorResult(
+  result: Extract<TemplateParseResult, { readonly status: 'parse-error' }>,
+): Extract<TemplateParseResult, { readonly status: 'parse-error' }> {
+  return Object.freeze({
+    status: result.status,
+    diagnostics: Object.freeze(
+      result.diagnostics.map(diagnostic =>
+        Object.freeze({
+          ...diagnostic,
+          source: Object.freeze({ ...diagnostic.source }),
+        }),
+      ),
+    ),
+  });
 }
 
 function manifestTemplate(manifest: ProjectManifest, candidate: ManifestTemplate): ManifestTemplate {

--- a/src/pipeline/current-migration.pipeline.spec.ts
+++ b/src/pipeline/current-migration.pipeline.spec.ts
@@ -1,0 +1,128 @@
+import { AdapterFactory } from '../adapter/adapter.factory';
+import type { MigrationOptions } from '../migrator/migrator';
+import type { MigrationReport } from '../report/migration-report';
+import { CurrentMigrationPipeline, type MigratorFactory } from './current-migration.pipeline';
+import { migrationInvocation } from './project-manifest';
+
+describe('CurrentMigrationPipeline', () => {
+  test('constructs one migrator from normalized paths and forwards the copied options', async () => {
+    const session = AdapterFactory.createSession('tailwind');
+    const callerOptions: MigrationOptions = {
+      mode: 'write',
+      responsiveImages: true,
+      stylesheetPath: 'styles/flex-layout.css',
+      reportPath: 'reports/migration.json',
+    };
+    const invocation = migrationInvocation({
+      inputPath: 'templates/../input.html',
+      outputPath: 'generated/../output.html',
+      options: callerOptions,
+    });
+    const factoryArguments: Parameters<MigratorFactory>[] = [];
+    const migratedOptions: Readonly<MigrationOptions>[] = [];
+    const expectedReport = report('delegated');
+    const createMigrator: MigratorFactory = (...arguments_) => {
+      factoryArguments.push(arguments_);
+      return {
+        migrate(options) {
+          if (options === undefined) throw new Error('Expected migration options.');
+          migratedOptions.push(options);
+          return Promise.resolve(expectedReport);
+        },
+      };
+    };
+
+    await new CurrentMigrationPipeline(session, createMigrator).run(invocation);
+
+    expect(invocation.options).not.toBe(callerOptions);
+    expect(Object.isFrozen(invocation.options)).toBe(true);
+    expect(factoryArguments).toEqual([[session, invocation.inputPath, invocation.outputPath]]);
+    expect(migratedOptions).toEqual([invocation.options]);
+    expect(migratedOptions[0]).toBe(invocation.options);
+  });
+
+  test('returns the exact report produced by the migrator', async () => {
+    const expectedReport = report('same-report');
+    const invocation = migrationInvocation({
+      inputPath: 'input.html',
+      outputPath: 'output.html',
+      options: { mode: 'plan' },
+    });
+    const createMigrator: MigratorFactory = () => ({ migrate: () => Promise.resolve(expectedReport) });
+
+    const actualReport = await new CurrentMigrationPipeline(
+      AdapterFactory.createSession('tailwind'),
+      createMigrator,
+    ).run(invocation);
+
+    expect(actualReport).toBe(expectedReport);
+  });
+
+  test('constructs a fresh migrator whenever the same invocation runs again', async () => {
+    const reports = [report('first'), report('second')];
+    const invocation = migrationInvocation({
+      inputPath: 'input.html',
+      outputPath: 'output.html',
+      options: { mode: 'plan' },
+    });
+    const migratedOptions: Readonly<MigrationOptions>[] = [];
+    let factoryCalls = 0;
+    const createMigrator: MigratorFactory = () => {
+      const expectedReport = reports[factoryCalls];
+      factoryCalls++;
+      if (expectedReport === undefined) throw new Error('Unexpected migrator construction.');
+      return {
+        migrate(options) {
+          if (options === undefined) throw new Error('Expected migration options.');
+          migratedOptions.push(options);
+          return Promise.resolve(expectedReport);
+        },
+      };
+    };
+    const pipeline = new CurrentMigrationPipeline(AdapterFactory.createSession('tailwind'), createMigrator);
+
+    const first = await pipeline.run(invocation);
+    const second = await pipeline.run(invocation);
+
+    expect(factoryCalls).toBe(2);
+    expect(migratedOptions).toEqual([invocation.options, invocation.options]);
+    expect(first).toBe(reports[0]);
+    expect(second).toBe(reports[1]);
+  });
+
+  test('preserves the exact migrator rejection', async () => {
+    const error = new Error('migration failed');
+    const invocation = migrationInvocation({
+      inputPath: 'input.html',
+      outputPath: 'output.html',
+      options: { mode: 'write' },
+    });
+    const createMigrator: MigratorFactory = () => ({ migrate: () => Promise.reject(error) });
+
+    await expect(
+      new CurrentMigrationPipeline(AdapterFactory.createSession('tailwind'), createMigrator).run(invocation),
+    ).rejects.toBe(error);
+  });
+});
+
+function report(input: string): MigrationReport {
+  return {
+    schemaVersion: 2,
+    mode: 'plan',
+    target: 'tailwind',
+    application: { status: 'skipped', reason: 'plan-only' },
+    input,
+    output: 'output.html',
+    durationMs: 0,
+    summary: {
+      filesScanned: 1,
+      filesChanged: 0,
+      converted: 0,
+      review: 0,
+      unsupported: 0,
+      invalid: 0,
+      parseErrors: 0,
+    },
+    files: [],
+  };
+}

--- a/src/pipeline/current-migration.pipeline.spec.ts
+++ b/src/pipeline/current-migration.pipeline.spec.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import { AdapterFactory } from '../adapter/adapter.factory';
 import type { MigrationOptions } from '../migrator/migrator';
 import type { MigrationReport } from '../report/migration-report';
@@ -5,7 +6,7 @@ import { CurrentMigrationPipeline, type MigratorFactory } from './current-migrat
 import { migrationInvocation } from './project-manifest';
 
 describe('CurrentMigrationPipeline', () => {
-  test('constructs one migrator from normalized paths and forwards the copied options', async () => {
+  test('constructs one migrator from raw legacy paths and forwards the copied options', async () => {
     const session = AdapterFactory.createSession('tailwind');
     const callerOptions: MigrationOptions = {
       mode: 'write',
@@ -36,7 +37,9 @@ describe('CurrentMigrationPipeline', () => {
 
     expect(invocation.options).not.toBe(callerOptions);
     expect(Object.isFrozen(invocation.options)).toBe(true);
-    expect(factoryArguments).toEqual([[session, invocation.inputPath, invocation.outputPath]]);
+    expect(factoryArguments).toEqual([[session, 'templates/../input.html', 'generated/../output.html']]);
+    expect(invocation.canonicalInputPath).toBe(path.resolve('input.html'));
+    expect(invocation.canonicalOutputPath).toBe(path.resolve('output.html'));
     expect(migratedOptions).toEqual([invocation.options]);
     expect(migratedOptions[0]).toBe(invocation.options);
   });

--- a/src/pipeline/current-migration.pipeline.ts
+++ b/src/pipeline/current-migration.pipeline.ts
@@ -1,0 +1,28 @@
+import type { ConversionAdapterSession } from '../adapter/conversion-adapter.session';
+import { Migrator } from '../migrator/migrator';
+import type { MigrationReport } from '../report/migration-report';
+import type { MigrationInvocation } from './project-manifest';
+
+export interface MigrationRunner {
+  run(invocation: MigrationInvocation): Promise<MigrationReport>;
+}
+
+export type MigratorFactory = (
+  session: ConversionAdapterSession,
+  inputPath: string,
+  outputPath: string,
+) => Pick<Migrator, 'migrate'>;
+
+const defaultMigratorFactory: MigratorFactory = (session, inputPath, outputPath) =>
+  new Migrator(session, inputPath, outputPath);
+
+export class CurrentMigrationPipeline implements MigrationRunner {
+  constructor(
+    private readonly session: ConversionAdapterSession,
+    private readonly createMigrator: MigratorFactory = defaultMigratorFactory,
+  ) {}
+
+  public run(invocation: MigrationInvocation): Promise<MigrationReport> {
+    return this.createMigrator(this.session, invocation.inputPath, invocation.outputPath).migrate(invocation.options);
+  }
+}

--- a/src/pipeline/migration-pipeline.spec.ts
+++ b/src/pipeline/migration-pipeline.spec.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from 'vitest';
+import type { MigrationApplication } from '../report/migration-report';
+import { analyzedProject, type AnalyzedProject } from './analyzed-project';
+import {
+  MigrationPipeline,
+  type AnalyzeStage,
+  type ApplyStage,
+  type DiscoverStage,
+  type RenderStage,
+  type ValidateStage,
+} from './migration-pipeline';
+import { PipelineStageError, type PipelineStageName } from './pipeline-stage.error';
+import {
+  migrationInvocation,
+  projectManifest,
+  type MigrationInvocation,
+  type ProjectManifest,
+} from './project-manifest';
+import { renderedProject, type RenderedProject } from './rendered-project';
+import { validatedProjectPlan, type ValidatedProjectPlan } from './validated-project-plan';
+
+interface PipelineFixtures {
+  readonly invocation: MigrationInvocation;
+  readonly manifest: ProjectManifest;
+  readonly analyzed: AnalyzedProject;
+  readonly rendered: RenderedProject;
+  readonly validated: ValidatedProjectPlan;
+  readonly application: MigrationApplication;
+}
+
+function fixtures(): PipelineFixtures {
+  const invocation = migrationInvocation({
+    inputPath: 'fixtures/source',
+    outputPath: 'fixtures/output',
+    options: { mode: 'plan' },
+  });
+  const manifest = projectManifest({ invocation, templates: [] });
+  const analyzed = analyzedProject({ manifest, templates: [] });
+  const rendered = renderedProject({ analyzed, files: [], session: { target: 'tailwind' } });
+  const validated = validatedProjectPlan({ rendered, plan: { target: 'tailwind', files: [], artifacts: [] } });
+  const application: MigrationApplication = { status: 'applied' };
+
+  return { invocation, manifest, analyzed, rendered, validated, application };
+}
+
+interface RecordingStages {
+  readonly calls: string[];
+  discover: DiscoverStage;
+  analyze: AnalyzeStage;
+  render: RenderStage;
+  validate: ValidateStage;
+  apply: ApplyStage;
+}
+
+function recordingStages(values: PipelineFixtures): RecordingStages {
+  const calls: string[] = [];
+
+  return {
+    calls,
+    discover: {
+      run(invocation) {
+        calls.push('discover');
+        expect(invocation).toBe(values.invocation);
+        return Promise.resolve(values.manifest);
+      },
+    },
+    analyze: {
+      run(manifest) {
+        calls.push('analyze');
+        expect(manifest).toBe(values.manifest);
+        return Promise.resolve(values.analyzed);
+      },
+    },
+    render: {
+      run(analyzed) {
+        calls.push('render');
+        expect(analyzed).toBe(values.analyzed);
+        return Promise.resolve(values.rendered);
+      },
+    },
+    validate: {
+      run(rendered) {
+        calls.push('validate');
+        expect(rendered).toBe(values.rendered);
+        return Promise.resolve(values.validated);
+      },
+    },
+    apply: {
+      run(validated) {
+        calls.push('apply');
+        expect(validated).toBe(values.validated);
+        return Promise.resolve({ application: values.application });
+      },
+    },
+  };
+}
+
+function pipeline(stages: RecordingStages): MigrationPipeline {
+  return new MigrationPipeline(stages.discover, stages.analyze, stages.render, stages.validate, stages.apply);
+}
+
+describe('MigrationPipeline', () => {
+  test('runs every stage once in order, hands off exact stage values, and freezes the result', async () => {
+    const values = fixtures();
+    const stages = recordingStages(values);
+
+    const result = await pipeline(stages).run(values.invocation);
+
+    expect(stages.calls).toEqual(['discover', 'analyze', 'render', 'validate', 'apply']);
+    expect(result.validated).toBe(values.validated);
+    expect(result.application).toEqual(values.application);
+    expect(result.application).not.toBe(values.application);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.application)).toBe(true);
+  });
+
+  test.each([
+    ['discover', 'synchronous throw'],
+    ['analyze', 'synchronous throw'],
+    ['render', 'synchronous throw'],
+    ['validate', 'synchronous throw'],
+    ['apply', 'synchronous throw'],
+    ['discover', 'promise rejection'],
+    ['analyze', 'promise rejection'],
+    ['render', 'promise rejection'],
+    ['validate', 'promise rejection'],
+    ['apply', 'promise rejection'],
+  ] as const)('wraps a %s %s once and skips all following stages', async (stage, failureMode) => {
+    const values = fixtures();
+    const stages = recordingStages(values);
+    const cause = { stage, failureMode };
+    replaceWithFailingStage(stages, stage, cause, failureMode);
+
+    await expect(pipeline(stages).run(values.invocation)).rejects.toMatchObject({
+      name: 'PipelineStageError',
+      message: `Migration pipeline ${stage} stage failed.`,
+      stage,
+      cause,
+    });
+    expect(stages.calls).toEqual(
+      ['discover', 'analyze', 'render', 'validate', 'apply'].slice(0, stageIndex(stage) + 1),
+    );
+  });
+
+  test('passes through an existing PipelineStageError without wrapping it again', async () => {
+    const values = fixtures();
+    const stages = recordingStages(values);
+    const error = new PipelineStageError('render', new Error('original failure'));
+    stages.render = {
+      run() {
+        stages.calls.push('render');
+        throw error;
+      },
+    };
+
+    await expect(pipeline(stages).run(values.invocation)).rejects.toBe(error);
+    expect(stages.calls).toEqual(['discover', 'analyze', 'render']);
+  });
+});
+
+function stageIndex(stage: PipelineStageName): number {
+  return ['discover', 'analyze', 'render', 'validate', 'apply'].indexOf(stage);
+}
+
+function replaceWithFailingStage(
+  stages: RecordingStages,
+  stage: PipelineStageName,
+  cause: unknown,
+  failureMode: 'synchronous throw' | 'promise rejection',
+): void {
+  const failingStage = {
+    run() {
+      stages.calls.push(stage);
+      if (failureMode === 'synchronous throw') throw cause;
+      return Promise.reject(cause);
+    },
+  };
+
+  switch (stage) {
+    case 'discover':
+      stages.discover = failingStage;
+      return;
+    case 'analyze':
+      stages.analyze = failingStage;
+      return;
+    case 'render':
+      stages.render = failingStage;
+      return;
+    case 'validate':
+      stages.validate = failingStage;
+      return;
+    case 'apply':
+      stages.apply = failingStage;
+      return;
+  }
+}

--- a/src/pipeline/migration-pipeline.ts
+++ b/src/pipeline/migration-pipeline.ts
@@ -1,0 +1,66 @@
+import type { MigrationApplication } from '../report/migration-report';
+import type { AnalyzedProject } from './analyzed-project';
+import { PipelineStageError } from './pipeline-stage.error';
+import type { MigrationInvocation, ProjectManifest } from './project-manifest';
+import type { RenderedProject } from './rendered-project';
+import type { ValidatedProjectPlan } from './validated-project-plan';
+
+export type PipelineStageName = 'discover' | 'analyze' | 'render' | 'validate' | 'apply';
+
+export interface DiscoverStage {
+  run(invocation: MigrationInvocation): Promise<ProjectManifest>;
+}
+
+export interface AnalyzeStage {
+  run(manifest: ProjectManifest): Promise<AnalyzedProject>;
+}
+
+export interface RenderStage {
+  run(analyzed: AnalyzedProject): Promise<RenderedProject>;
+}
+
+export interface ValidateStage {
+  run(rendered: RenderedProject): Promise<ValidatedProjectPlan>;
+}
+
+export interface ApplyStageResult {
+  readonly application: MigrationApplication;
+}
+
+export interface ApplyStage {
+  run(plan: ValidatedProjectPlan): Promise<ApplyStageResult>;
+}
+
+export interface MigrationPipelineResult {
+  readonly validated: ValidatedProjectPlan;
+  readonly application: MigrationApplication;
+}
+
+export class MigrationPipeline {
+  constructor(
+    private readonly discover: DiscoverStage,
+    private readonly analyze: AnalyzeStage,
+    private readonly render: RenderStage,
+    private readonly validate: ValidateStage,
+    private readonly apply: ApplyStage,
+  ) {}
+
+  public async run(invocation: MigrationInvocation): Promise<MigrationPipelineResult> {
+    const manifest = await runStage('discover', () => this.discover.run(invocation));
+    const analyzed = await runStage('analyze', () => this.analyze.run(manifest));
+    const rendered = await runStage('render', () => this.render.run(analyzed));
+    const validated = await runStage('validate', () => this.validate.run(rendered));
+    const applied = await runStage('apply', () => this.apply.run(validated));
+
+    return Object.freeze({ validated, application: Object.freeze({ ...applied.application }) });
+  }
+}
+
+async function runStage<T>(stage: PipelineStageName, action: () => Promise<T>): Promise<T> {
+  try {
+    return await action();
+  } catch (error: unknown) {
+    if (error instanceof PipelineStageError) throw error;
+    throw new PipelineStageError(stage, error);
+  }
+}

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -1,0 +1,350 @@
+import * as path from 'node:path';
+import type { AdapterSessionResult } from '../adapter/conversion-adapter.session';
+import type { OwnedCssRule } from '../adapter/css/css-artifact.model';
+import type { LocatedFlexLayoutInput } from '../analyzer/flex-layout-attribute.analyzer';
+import type { FileMigrationPlan, MigrationPlan } from '../migrator/migration-plan';
+import { MigrationApplicationError } from '../migrator/migration-application.error';
+import type { MigrationOptions } from '../migrator/migrator';
+import type { StylesheetMigrationResult } from '../report/migration-report.builder';
+import type { TemplateElement, TemplateParseResult } from '../template/template.model';
+import { analyzedProject, type AnalyzedProject } from './analyzed-project';
+import { migrationInvocation, projectManifest, type ProjectManifest } from './project-manifest';
+import { renderedProject, type RenderedProject } from './rendered-project';
+import { validatedProjectPlan } from './validated-project-plan';
+
+class OpaqueTemplateElement implements TemplateElement {
+  readonly id = '0';
+  readonly name = 'div';
+  readonly source = { start: 0, end: 26 };
+  readonly startTag = { start: 0, end: 20 };
+  readonly endTag = { start: 20, end: 26 };
+  readonly structural = false;
+  readonly attributes = [];
+  touched = false;
+
+  touch(): void {
+    this.touched = true;
+  }
+}
+
+function manifestFor(inputPath = 'templates/card.html', outputPath = 'generated/card.html'): ProjectManifest {
+  return projectManifest({
+    invocation: {
+      inputPath: 'templates',
+      outputPath: 'generated',
+      options: { mode: 'plan' },
+    },
+    templates: [{ inputPath, outputPath }],
+  });
+}
+
+function locatedInput(fileName = path.resolve('templates/card.html')): LocatedFlexLayoutInput {
+  return {
+    id: `${fileName}:5`,
+    fileName,
+    elementId: '0',
+    sourceName: 'fxLayout',
+    directive: 'fxLayout',
+    value: 'row',
+    binding: 'literal',
+    breakpoint: undefined,
+    source: { start: 5, end: 19 },
+    nameSource: { start: 5, end: 13 },
+    valueSource: { start: 15, end: 18 },
+  };
+}
+
+function parsedProject(manifest = manifestFor()): AnalyzedProject {
+  const parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }> = {
+    status: 'parsed',
+    elements: [],
+  };
+  return analyzedProject({
+    manifest,
+    templates: [
+      {
+        status: 'parsed',
+        file: { ...manifest.templates[0]! },
+        source: '<div fxLayout="row"></div>',
+        parseResult,
+        inputs: [locatedInput(manifest.templates[0]!.inputPath)],
+      },
+    ],
+  });
+}
+
+function rawFilePlan(inputPath: string, outputPath: string): FileMigrationPlan {
+  return {
+    file: {
+      inputPath,
+      outputPath,
+      changed: false,
+      results: [],
+    },
+  };
+}
+
+function cssRule(): OwnedCssRule {
+  return {
+    owner: 'flex-layout-codemod',
+    id: 'a'.repeat(64),
+    className: `flm-${'a'.repeat(64)}`,
+    family: 'layout',
+    declarations: [{ property: 'display', value: 'flex' }],
+    context: { priority: 0 },
+  };
+}
+
+function renderedCssProject(): RenderedProject {
+  const analyzed = parsedProject();
+  return renderedProject({
+    analyzed,
+    files: [rawFilePlan(analyzed.manifest.templates[0]!.inputPath, analyzed.manifest.templates[0]!.outputPath)],
+    session: { target: 'css', rules: [cssRule()] },
+  });
+}
+
+function captureInternalInvariant(action: () => unknown): MigrationApplicationError {
+  try {
+    action();
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(MigrationApplicationError);
+    expect(error).toMatchObject({ code: 'internal-invariant' });
+    return error as MigrationApplicationError;
+  }
+  throw new Error('Expected an internal invariant error.');
+}
+
+describe('pipeline handoff factories', () => {
+  test('normalizes invocation paths and owns an immutable options copy', () => {
+    const options: MigrationOptions = {
+      mode: 'write',
+      responsiveImages: true,
+      stylesheetPath: 'styles/generated.css',
+      reportPath: 'reports/result.json',
+    };
+
+    const invocation = migrationInvocation({
+      inputPath: 'fixtures/../templates',
+      outputPath: 'dist/../generated',
+      options,
+    });
+
+    expect(invocation).toEqual({
+      inputPath: path.resolve('templates'),
+      outputPath: path.resolve('generated'),
+      options: {
+        mode: 'write',
+        responsiveImages: true,
+        stylesheetPath: 'styles/generated.css',
+        reportPath: 'reports/result.json',
+      },
+    });
+    expect(invocation.options).not.toBe(options);
+    expect(Object.isFrozen(invocation)).toBe(true);
+    expect(Object.isFrozen(invocation.options)).toBe(true);
+
+    (options as { mode: 'write' | 'plan' }).mode = 'plan';
+    expect(invocation.options.mode).toBe('write');
+  });
+
+  test('preserves manifest template order while normalizing and owning every path record', () => {
+    const templates = [
+      { inputPath: 'templates/zeta/../zeta.html', outputPath: 'generated/zeta.html' },
+      { inputPath: 'templates/alpha.html', outputPath: 'generated/nested/../alpha.html' },
+    ];
+
+    const manifest = projectManifest({
+      invocation: {
+        inputPath: 'templates',
+        outputPath: 'generated',
+        options: { mode: 'plan' },
+      },
+      templates,
+    });
+
+    expect(manifest.templates).toEqual([
+      { inputPath: path.resolve('templates/zeta.html'), outputPath: path.resolve('generated/zeta.html') },
+      { inputPath: path.resolve('templates/alpha.html'), outputPath: path.resolve('generated/alpha.html') },
+    ]);
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.templates)).toBe(true);
+    expect(manifest.templates.every(template => Object.isFrozen(template))).toBe(true);
+
+    templates.reverse();
+    templates[0]!.inputPath = 'mutated.html';
+    expect(manifest.templates.map(template => path.basename(template.inputPath))).toEqual(['zeta.html', 'alpha.html']);
+  });
+
+  test('links analyzed templates to manifest identities while preserving source and opaque parse nodes', () => {
+    const manifest = manifestFor();
+    const opaqueNode = new OpaqueTemplateElement();
+    const parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }> = {
+      status: 'parsed',
+      elements: [opaqueNode],
+    };
+    const source = '<div fxLayout="row">\r\né🚀</div>';
+    const inputs = [locatedInput(manifest.templates[0]!.inputPath)];
+    const templates = [
+      {
+        status: 'parsed' as const,
+        file: {
+          inputPath: path.join('templates', '.', 'card.html'),
+          outputPath: path.join('generated', '.', 'card.html'),
+        },
+        source,
+        parseResult,
+        inputs,
+      },
+    ];
+
+    const analyzed = analyzedProject({ manifest, templates });
+
+    expect(analyzed.templates[0]!.file).toBe(analyzed.manifest.templates[0]);
+    expect(analyzed.templates[0]!.source).toBe(source);
+    expect(analyzed.templates[0]!.parseResult).toBe(parseResult);
+    expect(analyzed.templates[0]!.status).toBe('parsed');
+    expect(Object.isFrozen(analyzed)).toBe(true);
+    expect(Object.isFrozen(analyzed.templates)).toBe(true);
+    expect(Object.isFrozen(analyzed.templates[0])).toBe(true);
+    expect(
+      Object.isFrozen((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs),
+    ).toBe(true);
+    expect(
+      Object.isFrozen((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs[0]),
+    ).toBe(true);
+    expect(Object.isFrozen(opaqueNode)).toBe(false);
+
+    inputs.pop();
+    templates.pop();
+    opaqueNode.touch();
+    expect((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs).toHaveLength(1);
+    expect(analyzed.templates).toHaveLength(1);
+    expect(opaqueNode.touched).toBe(true);
+  });
+
+  test('rejects an analyzed template whose normalized path pair is absent from its manifest', () => {
+    const manifest = manifestFor();
+
+    captureInternalInvariant(() =>
+      analyzedProject({
+        manifest,
+        templates: [
+          {
+            status: 'parse-error',
+            file: { inputPath: 'templates/other.html', outputPath: 'generated/other.html' },
+            source: '<span />',
+            parseResult: {
+              status: 'parse-error',
+              diagnostics: [{ message: 'invalid', source: { start: 0, end: 5 } }],
+            },
+          },
+        ],
+      }),
+    );
+  });
+
+  test('owns rendered file plans and CSS session rules through immutable copies', () => {
+    const analyzed = parsedProject();
+    const results: NonNullable<FileMigrationPlan['file']['results']>[number][] = [];
+    const files: FileMigrationPlan[] = [
+      {
+        file: {
+          inputPath: analyzed.manifest.templates[0]!.inputPath,
+          outputPath: analyzed.manifest.templates[0]!.outputPath,
+          changed: false,
+          results,
+        },
+      },
+    ];
+    const rule = cssRule();
+    const rules = [rule];
+    const session: AdapterSessionResult = { target: 'css', rules };
+
+    const rendered = renderedProject({ analyzed, files, session });
+
+    expect(Object.isFrozen(rendered)).toBe(true);
+    expect(Object.isFrozen(rendered.files)).toBe(true);
+    expect(Object.isFrozen(rendered.files[0])).toBe(true);
+    expect(Object.isFrozen(rendered.files[0]!.file.results)).toBe(true);
+    expect(Object.isFrozen(rendered.session)).toBe(true);
+    expect(rendered.session.target).toBe('css');
+    if (rendered.session.target !== 'css') throw new Error('Expected a CSS session.');
+    expect(Object.isFrozen(rendered.session.rules)).toBe(true);
+    expect(Object.isFrozen(rendered.session.rules[0])).toBe(true);
+    expect(rendered.session.rules[0]).not.toBe(rule);
+
+    files.pop();
+    results.push({
+      status: 'parse-error',
+      fileName: 'late.html',
+      code: 'template-parse-error',
+      reason: 'late mutation',
+      source: { start: 0, end: 1 },
+    });
+    rules.pop();
+    expect(rendered.files).toHaveLength(1);
+    expect(rendered.files[0]!.file.results).toHaveLength(0);
+    expect(rendered.session.rules).toHaveLength(1);
+  });
+
+  test('rejects a rendered file whose code-unit-exact normalized pair is absent from analyzed templates', () => {
+    const analyzed = parsedProject();
+
+    captureInternalInvariant(() =>
+      renderedProject({
+        analyzed,
+        files: [
+          rawFilePlan(
+            analyzed.manifest.templates[0]!.inputPath,
+            analyzed.manifest.templates[0]!.outputPath.replace('card.html', 'Card.html'),
+          ),
+        ],
+        session: { target: 'tailwind' },
+      }),
+    );
+  });
+
+  test('owns migration plan contents and a plain stylesheet result record', () => {
+    const rendered = renderedCssProject();
+    const files = [rawFilePlan('templates/card.html', 'generated/card.html').file];
+    const artifacts: MigrationPlan['artifacts'][number][] = [];
+    const plan: MigrationPlan = { target: 'css', files, artifacts };
+    const stylesheet: StylesheetMigrationResult = {
+      path: path.resolve('generated/flex-layout.css'),
+      change: 'created',
+    };
+
+    const validated = validatedProjectPlan({ rendered, plan, stylesheet });
+
+    expect(Object.isFrozen(validated)).toBe(true);
+    expect(Object.isFrozen(validated.plan)).toBe(true);
+    expect(Object.isFrozen(validated.plan.files)).toBe(true);
+    expect(Object.isFrozen(validated.plan.artifacts)).toBe(true);
+    expect(Object.isFrozen(validated.stylesheet)).toBe(true);
+    expect(validated.stylesheet).not.toBe(stylesheet);
+
+    files.pop();
+    artifacts.push({
+      kind: 'stylesheet',
+      path: path.resolve('generated/late.css'),
+      original: { status: 'absent' },
+      proposed: { status: 'present', contents: '.late {}' },
+    });
+    (stylesheet as { path: string }).path = 'mutated.css';
+    expect(validated.plan.files).toHaveLength(1);
+    expect(validated.plan.artifacts).toHaveLength(0);
+    expect(validated.stylesheet?.path).toBe(path.resolve('generated/flex-layout.css'));
+  });
+
+  test('rejects a validated plan whose target differs from the finalized session target', () => {
+    const rendered = renderedCssProject();
+
+    captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'tailwind', files: [], artifacts: [] },
+      }),
+    );
+  });
+});

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -107,7 +107,16 @@ function cssRule(): OwnedCssRule {
 }
 
 function renderedCssProject(): RenderedProject {
-  const analyzed = parsedProject();
+  const analyzed = parsedProject(
+    projectManifest({
+      invocation: {
+        inputPath: 'templates',
+        outputPath: 'generated',
+        options: { mode: 'plan', stylesheetPath: path.resolve('generated/flex-layout.css') },
+      },
+      templates: [{ inputPath: 'templates/card.html', outputPath: 'generated/card.html' }],
+    }),
+  );
   return renderedProject({
     analyzed,
     files: [rawFilePlan(analyzed.manifest.templates[0]!.inputPath, analyzed.manifest.templates[0]!.outputPath)],
@@ -530,7 +539,7 @@ describe('pipeline handoff factories', () => {
     const plan: MigrationPlan = { target: 'css', files, artifacts };
     const stylesheet: StylesheetMigrationResult = {
       path: path.resolve('generated/flex-layout.css'),
-      change: 'created',
+      change: 'unchanged',
     };
 
     const validated = validatedProjectPlan({ rendered, plan, stylesheet });

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -6,26 +6,11 @@ import type { FileMigrationPlan, MigrationPlan } from '../migrator/migration-pla
 import { MigrationApplicationError } from '../migrator/migration-application.error';
 import type { MigrationOptions } from '../migrator/migrator';
 import type { StylesheetMigrationResult } from '../report/migration-report.builder';
-import type { TemplateElement, TemplateParseResult } from '../template/template.model';
-import { analyzedProject, type AnalyzedProject } from './analyzed-project';
-import { migrationInvocation, projectManifest, type ProjectManifest } from './project-manifest';
+import type { TemplateParseResult } from '../template/template.model';
+import { analyzedProject, type AnalyzedProject, type AnalyzedTemplate } from './analyzed-project';
+import { migrationInvocation, projectManifest, type ManifestTemplate, type ProjectManifest } from './project-manifest';
 import { renderedProject, type RenderedProject } from './rendered-project';
 import { validatedProjectPlan } from './validated-project-plan';
-
-class OpaqueTemplateElement implements TemplateElement {
-  readonly id = '0';
-  readonly name = 'div';
-  readonly source = { start: 0, end: 26 };
-  readonly startTag = { start: 0, end: 20 };
-  readonly endTag = { start: 20, end: 26 };
-  readonly structural = false;
-  readonly attributes = [];
-  touched = false;
-
-  touch(): void {
-    this.touched = true;
-  }
-}
 
 function manifestFor(inputPath = 'templates/card.html', outputPath = 'generated/card.html'): ProjectManifest {
   return projectManifest({
@@ -36,6 +21,32 @@ function manifestFor(inputPath = 'templates/card.html', outputPath = 'generated/
     },
     templates: [{ inputPath, outputPath }],
   });
+}
+
+function twoTemplateManifest(): ProjectManifest {
+  return projectManifest({
+    invocation: {
+      inputPath: 'templates',
+      outputPath: 'generated',
+      options: { mode: 'plan' },
+    },
+    templates: [
+      { inputPath: 'templates/alpha.html', outputPath: 'generated/alpha.html' },
+      { inputPath: 'templates/beta.html', outputPath: 'generated/beta.html' },
+    ],
+  });
+}
+
+function parseErrorTemplate(file: ManifestTemplate): AnalyzedTemplate {
+  return {
+    status: 'parse-error',
+    file: { ...file },
+    source: '<div',
+    parseResult: {
+      status: 'parse-error',
+      diagnostics: [{ message: 'incomplete start tag', source: { start: 0, end: 4 } }],
+    },
+  };
 }
 
 function locatedInput(fileName = path.resolve('templates/card.html')): LocatedFlexLayoutInput {
@@ -178,10 +189,35 @@ describe('pipeline handoff factories', () => {
     expect(manifest.templates.map(template => path.basename(template.inputPath))).toEqual(['zeta.html', 'alpha.html']);
   });
 
-  test('owns parsed result wrappers and arrays while preserving opaque element identity and mutability', () => {
+  test('recursively owns parsed elements, attributes, and every nested source range', () => {
     const manifest = manifestFor();
-    const opaqueNode = new OpaqueTemplateElement();
-    const elements = [opaqueNode];
+    const elementSource = { start: 0, end: 26 };
+    const startTag = { start: 0, end: 20 };
+    const endTag = { start: 20, end: 26 };
+    const attributeSource = { start: 5, end: 19 };
+    const attributeNameSource = { start: 5, end: 13 };
+    const attributeValueSource = { start: 15, end: 18 };
+    const attribute = {
+      name: 'fxLayout',
+      rawName: 'fxLayout',
+      rawValue: 'row',
+      value: 'row',
+      binding: 'literal' as const,
+      source: attributeSource,
+      nameSource: attributeNameSource,
+      valueSource: attributeValueSource,
+    };
+    const attributes = [attribute];
+    const element = {
+      id: '0',
+      name: 'div',
+      source: elementSource,
+      startTag,
+      endTag,
+      structural: false,
+      attributes,
+    };
+    const elements = [element];
     const parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }> = {
       status: 'parsed',
       elements,
@@ -209,9 +245,28 @@ describe('pipeline handoff factories', () => {
     if (analyzed.templates[0]!.status !== 'parsed') throw new Error('Expected a parsed template.');
     expect(analyzed.templates[0]!.parseResult).not.toBe(parseResult);
     expect(analyzed.templates[0]!.parseResult.elements).not.toBe(elements);
-    expect(analyzed.templates[0]!.parseResult.elements[0]).toBe(opaqueNode);
+    const ownedElement = analyzed.templates[0]!.parseResult.elements[0]!;
+    const ownedAttribute = ownedElement.attributes[0]!;
+    expect(ownedElement).not.toBe(element);
+    expect(ownedElement.attributes).not.toBe(attributes);
+    expect(ownedAttribute).not.toBe(attribute);
+    expect(ownedElement.source).not.toBe(elementSource);
+    expect(ownedElement.startTag).not.toBe(startTag);
+    expect(ownedElement.endTag).not.toBe(endTag);
+    expect(ownedAttribute.source).not.toBe(attributeSource);
+    expect(ownedAttribute.nameSource).not.toBe(attributeNameSource);
+    expect(ownedAttribute.valueSource).not.toBe(attributeValueSource);
     expect(Object.isFrozen(analyzed.templates[0]!.parseResult)).toBe(true);
     expect(Object.isFrozen(analyzed.templates[0]!.parseResult.elements)).toBe(true);
+    expect(Object.isFrozen(ownedElement)).toBe(true);
+    expect(Object.isFrozen(ownedElement.attributes)).toBe(true);
+    expect(Object.isFrozen(ownedAttribute)).toBe(true);
+    expect(Object.isFrozen(ownedElement.source)).toBe(true);
+    expect(Object.isFrozen(ownedElement.startTag)).toBe(true);
+    expect(Object.isFrozen(ownedElement.endTag)).toBe(true);
+    expect(Object.isFrozen(ownedAttribute.source)).toBe(true);
+    expect(Object.isFrozen(ownedAttribute.nameSource)).toBe(true);
+    expect(Object.isFrozen(ownedAttribute.valueSource)).toBe(true);
     expect(Object.isFrozen(analyzed)).toBe(true);
     expect(Object.isFrozen(analyzed.templates)).toBe(true);
     expect(Object.isFrozen(analyzed.templates[0])).toBe(true);
@@ -221,17 +276,41 @@ describe('pipeline handoff factories', () => {
     expect(
       Object.isFrozen((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs[0]),
     ).toBe(true);
-    expect(Object.isFrozen(opaqueNode)).toBe(false);
+    expect(Object.isFrozen(element)).toBe(false);
+    expect(Object.isFrozen(attribute)).toBe(false);
 
+    const input = inputs[0]!;
+    element.name = 'section';
+    attribute.name = 'class';
+    elementSource.start = 2;
+    startTag.end = 18;
+    endTag.start = 18;
+    attributeSource.start = 4;
+    attributeNameSource.end = 12;
+    attributeValueSource.start = 14;
+    (input.source as { start: number }).start = 4;
+    (input.nameSource as { end: number }).end = 12;
+    (input.valueSource as { start: number }).start = 14;
     inputs.pop();
     templates.pop();
     elements.pop();
-    (parseResult as { elements: readonly TemplateElement[] }).elements = [];
-    opaqueNode.touch();
+    attributes.pop();
+    (parseResult as unknown as { elements: readonly (typeof element)[] }).elements = [];
     expect((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs).toHaveLength(1);
     expect(analyzed.templates).toHaveLength(1);
-    expect(analyzed.templates[0]!.parseResult.elements).toEqual([opaqueNode]);
-    expect(opaqueNode.touched).toBe(true);
+    expect(ownedElement.name).toBe('div');
+    expect(ownedElement.source).toEqual({ start: 0, end: 26 });
+    expect(ownedElement.startTag).toEqual({ start: 0, end: 20 });
+    expect(ownedElement.endTag).toEqual({ start: 20, end: 26 });
+    expect(ownedElement.attributes).toHaveLength(1);
+    expect(ownedAttribute.name).toBe('fxLayout');
+    expect(ownedAttribute.source).toEqual({ start: 5, end: 19 });
+    expect(ownedAttribute.nameSource).toEqual({ start: 5, end: 13 });
+    expect(ownedAttribute.valueSource).toEqual({ start: 15, end: 18 });
+    const ownedInput = (analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs[0]!;
+    expect(ownedInput.source).toEqual({ start: 5, end: 19 });
+    expect(ownedInput.nameSource).toEqual({ start: 5, end: 13 });
+    expect(ownedInput.valueSource).toEqual({ start: 15, end: 18 });
   });
 
   test('recursively owns parse-error diagnostics and source ranges', () => {
@@ -299,6 +378,25 @@ describe('pipeline handoff factories', () => {
     );
   });
 
+  test('requires analyzed templates to match every manifest template once and in the same order', () => {
+    const manifest = twoTemplateManifest();
+    const first = parseErrorTemplate(manifest.templates[0]!);
+    const second = parseErrorTemplate(manifest.templates[1]!);
+    const malformedSequences = [
+      { name: 'omission', templates: [first] },
+      { name: 'duplicate', templates: [first, first] },
+      { name: 'extra', templates: [first, second, first] },
+      { name: 'reordered', templates: [second, first] },
+    ];
+
+    for (const scenario of malformedSequences) {
+      const error = captureInternalInvariant(() => analyzedProject({ manifest, templates: scenario.templates }));
+      expect(error.message, scenario.name).toBe(
+        'Analyzed project templates must match its manifest one-to-one and in the same order.',
+      );
+    }
+  });
+
   test('owns rendered file plans and CSS session rules through immutable copies', () => {
     const analyzed = parsedProject();
     const results: NonNullable<FileMigrationPlan['file']['results']>[number][] = [];
@@ -358,6 +456,71 @@ describe('pipeline handoff factories', () => {
         session: { target: 'tailwind' },
       }),
     );
+  });
+
+  test('requires rendered files to match every analyzed template once and in the same order', () => {
+    const manifest = twoTemplateManifest();
+    const analyzed = analyzedProject({
+      manifest,
+      templates: manifest.templates.map(file => parseErrorTemplate(file)),
+    });
+    const first = rawFilePlan(manifest.templates[0]!.inputPath, manifest.templates[0]!.outputPath);
+    const second = rawFilePlan(manifest.templates[1]!.inputPath, manifest.templates[1]!.outputPath);
+    const malformedSequences = [
+      { name: 'omission', files: [first] },
+      { name: 'duplicate', files: [first, first] },
+      { name: 'extra', files: [first, second, first] },
+      { name: 'reordered', files: [second, first] },
+    ];
+
+    for (const scenario of malformedSequences) {
+      const error = captureInternalInvariant(() =>
+        renderedProject({ analyzed, files: scenario.files, session: { target: 'tailwind' } }),
+      );
+      expect(error.message, scenario.name).toBe(
+        'Rendered project files must match its analyzed templates one-to-one and in the same order.',
+      );
+    }
+  });
+
+  test('canonicalizes rendered file identities without dropping results or template artifacts', () => {
+    const analyzed = parsedProject();
+    const identity = analyzed.manifest.templates[0]!;
+    const inputPath = `${path.dirname(identity.inputPath)}${path.sep}nested${path.sep}..${path.sep}${path.basename(identity.inputPath)}`;
+    const outputPath = `${path.dirname(identity.outputPath)}${path.sep}nested${path.sep}..${path.sep}${path.basename(identity.outputPath)}`;
+    const result = {
+      status: 'parse-error' as const,
+      fileName: inputPath,
+      code: 'template-parse-error' as const,
+      reason: 'fixture diagnostic',
+      source: { start: 1, end: 2 },
+    };
+    const artifact: MigrationPlan['artifacts'][number] = {
+      kind: 'template',
+      path: identity.outputPath,
+      original: { status: 'absent' },
+      proposed: { status: 'present', contents: '<div></div>' },
+    };
+
+    const rendered = renderedProject({
+      analyzed,
+      files: [
+        {
+          file: { inputPath, outputPath, changed: true, results: [result] },
+          artifact,
+        },
+      ],
+      session: { target: 'tailwind' },
+    });
+
+    expect(rendered.files[0]!.file).toEqual({
+      inputPath: identity.inputPath,
+      outputPath: identity.outputPath,
+      changed: true,
+      results: [result],
+    });
+    expect(rendered.files[0]!.artifact).toEqual(artifact);
+    expect(rendered.files[0]!.artifact).not.toBe(artifact);
   });
 
   test('owns migration plan contents and a plain stylesheet result record', () => {

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -198,6 +198,28 @@ describe('pipeline handoff factories', () => {
     expect(manifest.templates.map(template => path.basename(template.inputPath))).toEqual(['zeta.html', 'alpha.html']);
   });
 
+  test('preserves invocation canonical identities when the current working directory changes', () => {
+    const originalWorkingDirectory = process.cwd();
+    const invocation = migrationInvocation({
+      inputPath: 'templates/source',
+      outputPath: 'generated/output',
+      options: { mode: 'plan' },
+    });
+    const expectedInputPath = path.join(originalWorkingDirectory, 'templates', 'source');
+    const expectedOutputPath = path.join(originalWorkingDirectory, 'generated', 'output');
+
+    try {
+      process.chdir(path.dirname(originalWorkingDirectory));
+
+      const manifest = projectManifest({ invocation, templates: [] });
+
+      expect(manifest.invocation.canonicalInputPath).toBe(expectedInputPath);
+      expect(manifest.invocation.canonicalOutputPath).toBe(expectedOutputPath);
+    } finally {
+      process.chdir(originalWorkingDirectory);
+    }
+  });
+
   test('recursively owns parsed elements, attributes, and every nested source range', () => {
     const manifest = manifestFor();
     const elementSource = { start: 0, end: 26 };

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -116,7 +116,7 @@ function captureInternalInvariant(action: () => unknown): MigrationApplicationEr
 }
 
 describe('pipeline handoff factories', () => {
-  test('normalizes invocation paths and owns an immutable options copy', () => {
+  test('preserves raw invocation paths, exposes canonical identities, and owns an immutable options copy', () => {
     const options: MigrationOptions = {
       mode: 'write',
       responsiveImages: true,
@@ -131,8 +131,10 @@ describe('pipeline handoff factories', () => {
     });
 
     expect(invocation).toEqual({
-      inputPath: path.resolve('templates'),
-      outputPath: path.resolve('generated'),
+      inputPath: 'fixtures/../templates',
+      outputPath: 'dist/../generated',
+      canonicalInputPath: path.resolve('templates'),
+      canonicalOutputPath: path.resolve('generated'),
       options: {
         mode: 'write',
         responsiveImages: true,

--- a/src/pipeline/pipeline-handoffs.spec.ts
+++ b/src/pipeline/pipeline-handoffs.spec.ts
@@ -176,12 +176,13 @@ describe('pipeline handoff factories', () => {
     expect(manifest.templates.map(template => path.basename(template.inputPath))).toEqual(['zeta.html', 'alpha.html']);
   });
 
-  test('links analyzed templates to manifest identities while preserving source and opaque parse nodes', () => {
+  test('owns parsed result wrappers and arrays while preserving opaque element identity and mutability', () => {
     const manifest = manifestFor();
     const opaqueNode = new OpaqueTemplateElement();
+    const elements = [opaqueNode];
     const parseResult: Extract<TemplateParseResult, { readonly status: 'parsed' }> = {
       status: 'parsed',
-      elements: [opaqueNode],
+      elements,
     };
     const source = '<div fxLayout="row">\r\né🚀</div>';
     const inputs = [locatedInput(manifest.templates[0]!.inputPath)];
@@ -202,8 +203,13 @@ describe('pipeline handoff factories', () => {
 
     expect(analyzed.templates[0]!.file).toBe(analyzed.manifest.templates[0]);
     expect(analyzed.templates[0]!.source).toBe(source);
-    expect(analyzed.templates[0]!.parseResult).toBe(parseResult);
     expect(analyzed.templates[0]!.status).toBe('parsed');
+    if (analyzed.templates[0]!.status !== 'parsed') throw new Error('Expected a parsed template.');
+    expect(analyzed.templates[0]!.parseResult).not.toBe(parseResult);
+    expect(analyzed.templates[0]!.parseResult.elements).not.toBe(elements);
+    expect(analyzed.templates[0]!.parseResult.elements[0]).toBe(opaqueNode);
+    expect(Object.isFrozen(analyzed.templates[0]!.parseResult)).toBe(true);
+    expect(Object.isFrozen(analyzed.templates[0]!.parseResult.elements)).toBe(true);
     expect(Object.isFrozen(analyzed)).toBe(true);
     expect(Object.isFrozen(analyzed.templates)).toBe(true);
     expect(Object.isFrozen(analyzed.templates[0])).toBe(true);
@@ -217,10 +223,57 @@ describe('pipeline handoff factories', () => {
 
     inputs.pop();
     templates.pop();
+    elements.pop();
+    (parseResult as { elements: readonly TemplateElement[] }).elements = [];
     opaqueNode.touch();
     expect((analyzed.templates[0] as { readonly inputs: readonly LocatedFlexLayoutInput[] }).inputs).toHaveLength(1);
     expect(analyzed.templates).toHaveLength(1);
+    expect(analyzed.templates[0]!.parseResult.elements).toEqual([opaqueNode]);
     expect(opaqueNode.touched).toBe(true);
+  });
+
+  test('recursively owns parse-error diagnostics and source ranges', () => {
+    const manifest = manifestFor();
+    const sourceRange = { start: 0, end: 5 };
+    const diagnostic = { message: 'invalid template', source: sourceRange };
+    const diagnostics = [diagnostic];
+    const parseResult: Extract<TemplateParseResult, { readonly status: 'parse-error' }> = {
+      status: 'parse-error',
+      diagnostics,
+    };
+
+    const analyzed = analyzedProject({
+      manifest,
+      templates: [
+        {
+          status: 'parse-error',
+          file: { ...manifest.templates[0]! },
+          source: '<span />',
+          parseResult,
+        },
+      ],
+    });
+
+    const template = analyzed.templates[0]!;
+    expect(template.status).toBe('parse-error');
+    if (template.status !== 'parse-error') throw new Error('Expected a parse-error template.');
+    expect(template.parseResult).not.toBe(parseResult);
+    expect(template.parseResult.diagnostics).not.toBe(diagnostics);
+    expect(template.parseResult.diagnostics[0]).not.toBe(diagnostic);
+    expect(template.parseResult.diagnostics[0]!.source).not.toBe(sourceRange);
+    expect(Object.isFrozen(template.parseResult)).toBe(true);
+    expect(Object.isFrozen(template.parseResult.diagnostics)).toBe(true);
+    expect(Object.isFrozen(template.parseResult.diagnostics[0])).toBe(true);
+    expect(Object.isFrozen(template.parseResult.diagnostics[0]!.source)).toBe(true);
+
+    diagnostics.pop();
+    diagnostic.message = 'mutated message';
+    sourceRange.start = 4;
+    (parseResult as { diagnostics: readonly (typeof diagnostic)[] }).diagnostics = [];
+    expect(template.parseResult).toEqual({
+      status: 'parse-error',
+      diagnostics: [{ message: 'invalid template', source: { start: 0, end: 5 } }],
+    });
   });
 
   test('rejects an analyzed template whose normalized path pair is absent from its manifest', () => {

--- a/src/pipeline/pipeline-stage.error.ts
+++ b/src/pipeline/pipeline-stage.error.ts
@@ -1,0 +1,13 @@
+import type { PipelineStageName } from './migration-pipeline';
+
+export type { PipelineStageName } from './migration-pipeline';
+
+export class PipelineStageError extends Error {
+  constructor(
+    readonly stage: PipelineStageName,
+    override readonly cause: unknown,
+  ) {
+    super(`Migration pipeline ${stage} stage failed.`, { cause });
+    this.name = 'PipelineStageError';
+  }
+}

--- a/src/pipeline/project-manifest.ts
+++ b/src/pipeline/project-manifest.ts
@@ -22,20 +22,24 @@ export interface ProjectManifest {
 }
 
 export function migrationInvocation(invocation: MigrationInvocationInput): MigrationInvocation {
-  return Object.freeze({
+  return freezeMigrationInvocation({
     inputPath: invocation.inputPath,
     outputPath: invocation.outputPath,
     canonicalInputPath: normalizedAbsolutePath(invocation.inputPath),
     canonicalOutputPath: normalizedAbsolutePath(invocation.outputPath),
-    options: Object.freeze({ ...invocation.options }),
+    options: invocation.options,
   });
 }
 
 export function projectManifest(
-  manifest: Omit<ProjectManifest, 'invocation'> & { readonly invocation: MigrationInvocationInput },
+  manifest: Omit<ProjectManifest, 'invocation'> & {
+    readonly invocation: MigrationInvocationInput | MigrationInvocation;
+  },
 ): ProjectManifest {
   return Object.freeze({
-    invocation: migrationInvocation(manifest.invocation),
+    invocation: hasCanonicalIdentity(manifest.invocation)
+      ? freezeMigrationInvocation(manifest.invocation)
+      : migrationInvocation(manifest.invocation),
     templates: Object.freeze(
       manifest.templates.map(template =>
         Object.freeze({
@@ -44,6 +48,22 @@ export function projectManifest(
         }),
       ),
     ),
+  });
+}
+
+function hasCanonicalIdentity(
+  invocation: MigrationInvocationInput | MigrationInvocation,
+): invocation is MigrationInvocation {
+  return 'canonicalInputPath' in invocation && 'canonicalOutputPath' in invocation;
+}
+
+function freezeMigrationInvocation(invocation: MigrationInvocation): MigrationInvocation {
+  return Object.freeze({
+    inputPath: invocation.inputPath,
+    outputPath: invocation.outputPath,
+    canonicalInputPath: invocation.canonicalInputPath,
+    canonicalOutputPath: invocation.canonicalOutputPath,
+    options: Object.freeze({ ...invocation.options }),
   });
 }
 

--- a/src/pipeline/project-manifest.ts
+++ b/src/pipeline/project-manifest.ts
@@ -1,0 +1,44 @@
+import * as path from 'node:path';
+import type { MigrationOptions } from '../migrator/migrator';
+
+export interface MigrationInvocation {
+  readonly inputPath: string;
+  readonly outputPath: string;
+  readonly options: Readonly<MigrationOptions>;
+}
+
+export interface ManifestTemplate {
+  readonly inputPath: string;
+  readonly outputPath: string;
+}
+
+export interface ProjectManifest {
+  readonly invocation: MigrationInvocation;
+  readonly templates: readonly ManifestTemplate[];
+}
+
+export function migrationInvocation(invocation: MigrationInvocation): MigrationInvocation {
+  return Object.freeze({
+    inputPath: normalizedAbsolutePath(invocation.inputPath),
+    outputPath: normalizedAbsolutePath(invocation.outputPath),
+    options: Object.freeze({ ...invocation.options }),
+  });
+}
+
+export function projectManifest(manifest: ProjectManifest): ProjectManifest {
+  return Object.freeze({
+    invocation: migrationInvocation(manifest.invocation),
+    templates: Object.freeze(
+      manifest.templates.map(template =>
+        Object.freeze({
+          inputPath: normalizedAbsolutePath(template.inputPath),
+          outputPath: normalizedAbsolutePath(template.outputPath),
+        }),
+      ),
+    ),
+  });
+}
+
+function normalizedAbsolutePath(value: string): string {
+  return path.normalize(path.resolve(value));
+}

--- a/src/pipeline/project-manifest.ts
+++ b/src/pipeline/project-manifest.ts
@@ -4,8 +4,12 @@ import type { MigrationOptions } from '../migrator/migrator';
 export interface MigrationInvocation {
   readonly inputPath: string;
   readonly outputPath: string;
+  readonly canonicalInputPath: string;
+  readonly canonicalOutputPath: string;
   readonly options: Readonly<MigrationOptions>;
 }
+
+type MigrationInvocationInput = Pick<MigrationInvocation, 'inputPath' | 'outputPath' | 'options'>;
 
 export interface ManifestTemplate {
   readonly inputPath: string;
@@ -17,15 +21,19 @@ export interface ProjectManifest {
   readonly templates: readonly ManifestTemplate[];
 }
 
-export function migrationInvocation(invocation: MigrationInvocation): MigrationInvocation {
+export function migrationInvocation(invocation: MigrationInvocationInput): MigrationInvocation {
   return Object.freeze({
-    inputPath: normalizedAbsolutePath(invocation.inputPath),
-    outputPath: normalizedAbsolutePath(invocation.outputPath),
+    inputPath: invocation.inputPath,
+    outputPath: invocation.outputPath,
+    canonicalInputPath: normalizedAbsolutePath(invocation.inputPath),
+    canonicalOutputPath: normalizedAbsolutePath(invocation.outputPath),
     options: Object.freeze({ ...invocation.options }),
   });
 }
 
-export function projectManifest(manifest: ProjectManifest): ProjectManifest {
+export function projectManifest(
+  manifest: Omit<ProjectManifest, 'invocation'> & { readonly invocation: MigrationInvocationInput },
+): ProjectManifest {
   return Object.freeze({
     invocation: migrationInvocation(manifest.invocation),
     templates: Object.freeze(

--- a/src/pipeline/rendered-project.ts
+++ b/src/pipeline/rendered-project.ts
@@ -1,0 +1,78 @@
+import * as path from 'node:path';
+import type { AdapterSessionResult } from '../adapter/conversion-adapter.session';
+import type { MediaDefinition } from '../breakpoint/breakpoint-catalog';
+import type { OwnedCssRule } from '../adapter/css/css-artifact.model';
+import { MigrationApplicationError } from '../migrator/migration-application.error';
+import { fileMigrationPlan, type FileMigrationPlan } from '../migrator/migration-plan';
+import { analyzedProject, type AnalyzedProject } from './analyzed-project';
+import type { ManifestTemplate } from './project-manifest';
+
+export interface RenderedProject {
+  readonly analyzed: AnalyzedProject;
+  readonly files: readonly FileMigrationPlan[];
+  readonly session: AdapterSessionResult;
+}
+
+export function renderedProject(project: RenderedProject): RenderedProject {
+  const analyzed = analyzedProject(project.analyzed);
+  const files = project.files.map(file => fileMigrationPlan(file));
+
+  for (const file of files) {
+    if (!analyzed.templates.some(template => samePathPair(template.file, file.file))) {
+      throw internalInvariant('Rendered file is not represented by an analyzed template.', [
+        file.file.inputPath,
+        file.file.outputPath,
+      ]);
+    }
+  }
+
+  return Object.freeze({
+    analyzed,
+    files: Object.freeze(files),
+    session: freezeSessionResult(project.session),
+  });
+}
+
+function freezeSessionResult(session: AdapterSessionResult): AdapterSessionResult {
+  if (session.target === 'tailwind') return Object.freeze({ target: session.target });
+  return Object.freeze({
+    target: session.target,
+    rules: Object.freeze(session.rules.map(rule => freezeOwnedCssRule(rule))),
+  });
+}
+
+function freezeOwnedCssRule(rule: OwnedCssRule): OwnedCssRule {
+  return Object.freeze({
+    ...rule,
+    declarations: Object.freeze(rule.declarations.map(declaration => Object.freeze({ ...declaration }))),
+    context: Object.freeze({
+      ...rule.context,
+      ...(rule.context.media === undefined ? {} : { media: freezeMedia(rule.context.media) }),
+    }),
+  });
+}
+
+function freezeMedia(media: MediaDefinition): MediaDefinition {
+  return Object.freeze({
+    ...media,
+    clauses: Object.freeze(media.clauses.map(clause => Object.freeze({ ...clause }))),
+  });
+}
+
+function samePathPair(
+  left: ManifestTemplate,
+  right: { readonly inputPath: string; readonly outputPath: string },
+): boolean {
+  return (
+    normalizedAbsolutePath(left.inputPath) === normalizedAbsolutePath(right.inputPath) &&
+    normalizedAbsolutePath(left.outputPath) === normalizedAbsolutePath(right.outputPath)
+  );
+}
+
+function normalizedAbsolutePath(value: string): string {
+  return path.normalize(path.resolve(value));
+}
+
+function internalInvariant(message: string, paths: readonly string[]): MigrationApplicationError {
+  return new MigrationApplicationError('internal-invariant', message, paths);
+}

--- a/src/pipeline/rendered-project.ts
+++ b/src/pipeline/rendered-project.ts
@@ -15,16 +15,23 @@ export interface RenderedProject {
 
 export function renderedProject(project: RenderedProject): RenderedProject {
   const analyzed = analyzedProject(project.analyzed);
-  const files = project.files.map(file => fileMigrationPlan(file));
-
-  for (const file of files) {
-    if (!analyzed.templates.some(template => samePathPair(template.file, file.file))) {
-      throw internalInvariant('Rendered file is not represented by an analyzed template.', [
-        file.file.inputPath,
-        file.file.outputPath,
-      ]);
-    }
+  if (project.files.length !== analyzed.templates.length) {
+    throw sequenceInvariant();
   }
+  const files = project.files.map((file, index) => {
+    const identity = analyzed.templates[index]?.file;
+    if (identity === undefined || !samePathPair(identity, file.file)) {
+      throw sequenceInvariant([file.file.inputPath, file.file.outputPath]);
+    }
+    return fileMigrationPlan({
+      file: {
+        ...file.file,
+        inputPath: identity.inputPath,
+        outputPath: identity.outputPath,
+      },
+      ...(file.artifact === undefined ? {} : { artifact: file.artifact }),
+    });
+  });
 
   return Object.freeze({
     analyzed,
@@ -73,6 +80,13 @@ function normalizedAbsolutePath(value: string): string {
   return path.normalize(path.resolve(value));
 }
 
-function internalInvariant(message: string, paths: readonly string[]): MigrationApplicationError {
+function sequenceInvariant(paths: readonly string[] = []): MigrationApplicationError {
+  return internalInvariant(
+    'Rendered project files must match its analyzed templates one-to-one and in the same order.',
+    paths,
+  );
+}
+
+function internalInvariant(message: string, paths: readonly string[] = []): MigrationApplicationError {
   return new MigrationApplicationError('internal-invariant', message, paths);
 }

--- a/src/pipeline/validated-project-plan.spec.ts
+++ b/src/pipeline/validated-project-plan.spec.ts
@@ -277,6 +277,78 @@ describe('validatedProjectPlan', () => {
     },
   );
 
+  test.each([
+    {
+      name: 'template input',
+      inputPath: (stylesheetPath: string) => noncanonicalPath(stylesheetPath),
+      outputPath: () => path.resolve('generated/card.html'),
+    },
+    {
+      name: 'unchanged template output',
+      inputPath: () => path.resolve('templates/card.html'),
+      outputPath: (stylesheetPath: string) => noncanonicalPath(stylesheetPath),
+    },
+  ])('rejects a CSS stylesheet path that collides with a $name path', scenario => {
+    const stylesheetPath = path.resolve('generated/flex-layout.css');
+    const manifest = projectManifest({
+      invocation: {
+        inputPath: 'templates',
+        outputPath: 'generated',
+        options: { mode: 'plan', stylesheetPath },
+      },
+      templates: [
+        {
+          inputPath: scenario.inputPath(stylesheetPath),
+          outputPath: scenario.outputPath(stylesheetPath),
+        },
+      ],
+    });
+    const rendered = renderedFor(manifest, 'css');
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'css', files: rendered.files.map(file => file.file), artifacts: [] },
+        stylesheet: { path: stylesheetPath, change: 'unchanged' },
+      }),
+    );
+
+    expect(error.message).toBe(
+      'Configured stylesheet path must not collide with any template input, output, or artifact path.',
+    );
+  });
+
+  test('rejects colliding template and stylesheet artifacts at the configured CSS path', () => {
+    const stylesheetPath = path.resolve('generated/flex-layout.css');
+    const manifest = projectManifest({
+      invocation: {
+        inputPath: 'templates',
+        outputPath: 'generated',
+        options: { mode: 'plan', stylesheetPath },
+      },
+      templates: [{ inputPath: path.resolve('templates/card.html'), outputPath: stylesheetPath }],
+    });
+    const rendered = renderedFor(manifest, 'css', [changedFile(manifest.templates[0]!, '<article>card</article>')]);
+    const template = rendered.files[0]!.artifact!;
+    const stylesheet = stylesheetArtifact(stylesheetPath, 'created');
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: {
+          target: 'css',
+          files: rendered.files.map(file => file.file),
+          artifacts: [template, stylesheet],
+        },
+        stylesheet: { path: stylesheetPath, change: 'created' },
+      }),
+    );
+
+    expect(error.message).toBe(
+      'Configured stylesheet path must not collide with any template input, output, or artifact path.',
+    );
+  });
+
   test('rejects every inconsistent CSS stylesheet metadata and artifact combination', () => {
     const stylesheetPath = path.resolve('generated/flex-layout.css');
     const otherStylesheetPath = path.resolve('generated/other.css');
@@ -378,6 +450,20 @@ describe('validatedProjectPlan', () => {
         rendered,
         plan: { target: 'tailwind', files: rendered.files.map(file => file.file), artifacts: scenario.artifacts },
         ...(scenario.stylesheet === undefined ? {} : { stylesheet: scenario.stylesheet }),
+      }),
+    );
+
+    expect(error.message).toBe('Tailwind migration plans cannot contain stylesheet artifacts or metadata.');
+  });
+
+  test('rejects a Tailwind plan whose invocation configures a stylesheet path', () => {
+    const stylesheetPath = path.resolve('generated/flex-layout.css');
+    const rendered = renderedFor(manifestFor(['card.html'], stylesheetPath), 'tailwind');
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'tailwind', files: rendered.files.map(file => file.file), artifacts: [] },
       }),
     );
 

--- a/src/pipeline/validated-project-plan.spec.ts
+++ b/src/pipeline/validated-project-plan.spec.ts
@@ -1,0 +1,386 @@
+import * as path from 'node:path';
+import type { ArtifactState, FileMigrationPlan, PlannedOutputArtifact } from '../migrator/migration-plan';
+import { MigrationApplicationError } from '../migrator/migration-application.error';
+import type { StylesheetMigrationResult } from '../report/migration-report.builder';
+import { analyzedProject } from './analyzed-project';
+import { projectManifest, type ManifestTemplate, type ProjectManifest } from './project-manifest';
+import { renderedProject, type RenderedProject } from './rendered-project';
+import { validatedProjectPlan } from './validated-project-plan';
+
+function manifestFor(names: readonly string[], stylesheetPath?: string): ProjectManifest {
+  return projectManifest({
+    invocation: {
+      inputPath: 'templates',
+      outputPath: 'generated',
+      options: { mode: 'plan', ...(stylesheetPath === undefined ? {} : { stylesheetPath }) },
+    },
+    templates: names.map(name => ({
+      inputPath: path.resolve('templates', name),
+      outputPath: path.resolve('generated', name),
+    })),
+  });
+}
+
+function unchangedFile(file: ManifestTemplate): FileMigrationPlan {
+  return {
+    file: {
+      inputPath: file.inputPath,
+      outputPath: file.outputPath,
+      changed: false,
+      results: [],
+    },
+  };
+}
+
+function templateArtifact(file: ManifestTemplate, contents: string): PlannedOutputArtifact {
+  return {
+    kind: 'template',
+    path: file.outputPath,
+    original: { status: 'absent' },
+    proposed: { status: 'present', contents },
+  };
+}
+
+function changedFile(file: ManifestTemplate, contents: string): FileMigrationPlan {
+  return {
+    file: {
+      inputPath: file.inputPath,
+      outputPath: file.outputPath,
+      changed: true,
+      results: [],
+    },
+    artifact: templateArtifact(file, contents),
+  };
+}
+
+function renderedFor(
+  manifest: ProjectManifest,
+  target: 'css' | 'tailwind',
+  files: readonly FileMigrationPlan[] = manifest.templates.map(file => unchangedFile(file)),
+): RenderedProject {
+  const analyzed = analyzedProject({
+    manifest,
+    templates: manifest.templates.map(file => ({
+      status: 'parse-error',
+      file,
+      source: '<div',
+      parseResult: {
+        status: 'parse-error',
+        diagnostics: [{ message: 'incomplete start tag', source: { start: 0, end: 4 } }],
+      },
+    })),
+  });
+
+  return renderedProject({
+    analyzed,
+    files,
+    session: target === 'tailwind' ? { target } : { target, rules: [] },
+  });
+}
+
+function stylesheetArtifact(
+  stylesheetPath: string,
+  change: Exclude<StylesheetMigrationResult['change'], 'unchanged'>,
+): PlannedOutputArtifact {
+  let original: ArtifactState;
+  let proposed: ArtifactState;
+  switch (change) {
+    case 'created':
+      original = { status: 'absent' };
+      proposed = { status: 'present', contents: '.created {}' };
+      break;
+    case 'updated':
+      original = { status: 'present', contents: '.before {}' };
+      proposed = { status: 'present', contents: '.after {}' };
+      break;
+    case 'removed':
+      original = { status: 'present', contents: '.removed {}' };
+      proposed = { status: 'absent' };
+      break;
+  }
+  return { kind: 'stylesheet', path: stylesheetPath, original, proposed };
+}
+
+function noncanonicalPath(value: string): string {
+  return `${path.dirname(value)}${path.sep}nested${path.sep}..${path.sep}${path.basename(value)}`;
+}
+
+function captureInternalInvariant(action: () => unknown): MigrationApplicationError {
+  try {
+    action();
+  } catch (error: unknown) {
+    expect(error).toBeInstanceOf(MigrationApplicationError);
+    expect(error).toMatchObject({ code: 'internal-invariant' });
+    return error as MigrationApplicationError;
+  }
+  throw new Error('Expected an internal invariant error.');
+}
+
+describe('validatedProjectPlan', () => {
+  test('requires plan files to match every rendered file once, in order, and with the same state', () => {
+    const manifest = manifestFor(['alpha.html', 'beta.html']);
+    const rendered = renderedFor(manifest, 'tailwind');
+    const first = rendered.files[0]!.file;
+    const second = rendered.files[1]!.file;
+    const malformedSequences = [
+      { name: 'omission', files: [first] },
+      { name: 'duplicate', files: [first, first] },
+      { name: 'extra', files: [first, second, first] },
+      { name: 'reordered', files: [second, first] },
+      { name: 'changed state', files: [{ ...first, changed: true }, second] },
+      {
+        name: 'changed results',
+        files: [
+          {
+            ...first,
+            results: [
+              {
+                status: 'parse-error' as const,
+                fileName: first.inputPath,
+                code: 'template-parse-error' as const,
+                reason: 'unrelated diagnostic',
+                source: { start: 0, end: 1 },
+              },
+            ],
+          },
+          second,
+        ],
+      },
+    ];
+
+    for (const scenario of malformedSequences) {
+      const error = captureInternalInvariant(() =>
+        validatedProjectPlan({
+          rendered,
+          plan: { target: 'tailwind', files: scenario.files, artifacts: [] },
+        }),
+      );
+      expect(error.message, scenario.name).toBe(
+        'Validated migration plan files must match rendered files one-to-one and in the same order.',
+      );
+    }
+  });
+
+  test('canonicalizes equivalent plan file identities to the rendered manifest identities', () => {
+    const manifest = manifestFor(['card.html']);
+    const rendered = renderedFor(manifest, 'tailwind');
+    const renderedFile = rendered.files[0]!.file;
+
+    const validated = validatedProjectPlan({
+      rendered,
+      plan: {
+        target: 'tailwind',
+        files: [
+          {
+            ...renderedFile,
+            inputPath: noncanonicalPath(renderedFile.inputPath),
+            outputPath: noncanonicalPath(renderedFile.outputPath),
+          },
+        ],
+        artifacts: [],
+      },
+    });
+
+    expect(validated.plan.files[0]).toEqual(renderedFile);
+    expect(validated.plan.files[0]!.inputPath).toBe(manifest.templates[0]!.inputPath);
+    expect(validated.plan.files[0]!.outputPath).toBe(manifest.templates[0]!.outputPath);
+  });
+
+  test('requires plan template artifacts to exactly match rendered file artifacts in file order', () => {
+    const manifest = manifestFor(['alpha.html', 'beta.html']);
+    const rendered = renderedFor(manifest, 'tailwind', [
+      changedFile(manifest.templates[0]!, '<article>alpha</article>'),
+      changedFile(manifest.templates[1]!, '<article>beta</article>'),
+    ]);
+    const first = rendered.files[0]!.artifact!;
+    const second = rendered.files[1]!.artifact!;
+    const files = rendered.files.map(file => file.file);
+    const validated = validatedProjectPlan({
+      rendered,
+      plan: { target: 'tailwind', files, artifacts: [first, second] },
+    });
+    const malformedArtifacts = [
+      { name: 'omission', artifacts: [first] },
+      { name: 'duplicate', artifacts: [first, first] },
+      { name: 'extra', artifacts: [first, second, first] },
+      { name: 'reordered', artifacts: [second, first] },
+      {
+        name: 'different state',
+        artifacts: [
+          first,
+          { ...second, proposed: { status: 'present' as const, contents: '<article>tampered</article>' } },
+        ],
+      },
+    ];
+
+    expect(validated.plan.artifacts).toEqual([first, second]);
+    expect(validated.plan.artifacts[0]).not.toBe(first);
+
+    for (const scenario of malformedArtifacts) {
+      const error = captureInternalInvariant(() =>
+        validatedProjectPlan({
+          rendered,
+          plan: { target: 'tailwind', files, artifacts: scenario.artifacts },
+        }),
+      );
+      expect(error.message, scenario.name).toBe(
+        'Validated migration plan template artifacts must match rendered template artifacts in file order.',
+      );
+    }
+  });
+
+  test('requires every rendered template artifact to describe its changed file output', () => {
+    const manifest = manifestFor(['card.html']);
+    const unrelatedArtifact = {
+      ...templateArtifact(manifest.templates[0]!, '<article>card</article>'),
+      path: path.resolve('generated/unrelated.html'),
+    };
+    const rendered = renderedFor(manifest, 'tailwind', [
+      {
+        file: { ...unchangedFile(manifest.templates[0]!).file, changed: true },
+        artifact: unrelatedArtifact,
+      },
+    ]);
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'tailwind', files: rendered.files.map(file => file.file), artifacts: [unrelatedArtifact] },
+      }),
+    );
+
+    expect(error.message).toBe('Rendered template artifacts must correspond exactly to changed file outputs.');
+  });
+
+  test.each(['created', 'updated', 'removed', 'unchanged'] as const)(
+    'accepts CSS stylesheet metadata that exactly represents a %s artifact state',
+    change => {
+      const stylesheetPath = path.resolve('generated/flex-layout.css');
+      const manifest = manifestFor(['card.html'], stylesheetPath);
+      const rendered = renderedFor(manifest, 'css');
+      const artifact =
+        change === 'unchanged' ? undefined : stylesheetArtifact(noncanonicalPath(stylesheetPath), change);
+
+      const validated = validatedProjectPlan({
+        rendered,
+        plan: {
+          target: 'css',
+          files: rendered.files.map(file => file.file),
+          artifacts: artifact === undefined ? [] : [artifact],
+        },
+        stylesheet: { path: noncanonicalPath(stylesheetPath), change },
+      });
+
+      expect(validated.stylesheet).toEqual({ path: stylesheetPath, change });
+      expect(validated.plan.artifacts).toHaveLength(artifact === undefined ? 0 : 1);
+      expect(validated.plan.artifacts[0]?.path).toBe(artifact === undefined ? undefined : stylesheetPath);
+    },
+  );
+
+  test('rejects every inconsistent CSS stylesheet metadata and artifact combination', () => {
+    const stylesheetPath = path.resolve('generated/flex-layout.css');
+    const otherStylesheetPath = path.resolve('generated/other.css');
+    const manifest = manifestFor(['card.html'], stylesheetPath);
+    const rendered = renderedFor(manifest, 'css');
+    const files = rendered.files.map(file => file.file);
+    const created = stylesheetArtifact(stylesheetPath, 'created');
+    const inconsistent = [
+      {
+        name: 'missing metadata for unchanged stylesheet',
+        plan: { target: 'css' as const, files, artifacts: [] },
+      },
+      {
+        name: 'changed metadata without artifact',
+        plan: { target: 'css' as const, files, artifacts: [] },
+        stylesheet: { path: stylesheetPath, change: 'created' as const },
+      },
+      {
+        name: 'artifact without metadata',
+        plan: { target: 'css' as const, files, artifacts: [created] },
+      },
+      {
+        name: 'metadata path mismatch',
+        plan: { target: 'css' as const, files, artifacts: [created] },
+        stylesheet: { path: otherStylesheetPath, change: 'created' as const },
+      },
+      {
+        name: 'artifact path mismatch',
+        plan: {
+          target: 'css' as const,
+          files,
+          artifacts: [stylesheetArtifact(otherStylesheetPath, 'created')],
+        },
+        stylesheet: { path: stylesheetPath, change: 'created' as const },
+      },
+      {
+        name: 'artifact change mismatch',
+        plan: { target: 'css' as const, files, artifacts: [created] },
+        stylesheet: { path: stylesheetPath, change: 'updated' as const },
+      },
+      {
+        name: 'multiple stylesheet artifacts',
+        plan: {
+          target: 'css' as const,
+          files,
+          artifacts: [created, stylesheetArtifact(otherStylesheetPath, 'created')],
+        },
+        stylesheet: { path: stylesheetPath, change: 'created' as const },
+      },
+    ];
+
+    for (const scenario of inconsistent) {
+      const error = captureInternalInvariant(() =>
+        validatedProjectPlan({
+          rendered,
+          plan: scenario.plan,
+          ...(scenario.stylesheet === undefined ? {} : { stylesheet: scenario.stylesheet }),
+        }),
+      );
+      expect(error.message, scenario.name).toBe(
+        'CSS stylesheet metadata must correspond exactly to its configured path and artifact change state.',
+      );
+    }
+  });
+
+  test('rejects CSS stylesheet state when the analyzed invocation has no configured stylesheet path', () => {
+    const stylesheetPath = path.resolve('generated/flex-layout.css');
+    const rendered = renderedFor(manifestFor(['card.html']), 'css');
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'css', files: rendered.files.map(file => file.file), artifacts: [] },
+        stylesheet: { path: stylesheetPath, change: 'unchanged' },
+      }),
+    );
+
+    expect(error.message).toBe(
+      'CSS stylesheet metadata must correspond exactly to its configured path and artifact change state.',
+    );
+  });
+
+  test.each([
+    {
+      name: 'metadata',
+      artifacts: [] as const,
+      stylesheet: { path: path.resolve('generated/flex-layout.css'), change: 'unchanged' as const },
+    },
+    {
+      name: 'artifact',
+      artifacts: [stylesheetArtifact(path.resolve('generated/flex-layout.css'), 'created')],
+      stylesheet: undefined,
+    },
+  ])('rejects Tailwind stylesheet $name', scenario => {
+    const rendered = renderedFor(manifestFor(['card.html']), 'tailwind');
+
+    const error = captureInternalInvariant(() =>
+      validatedProjectPlan({
+        rendered,
+        plan: { target: 'tailwind', files: rendered.files.map(file => file.file), artifacts: scenario.artifacts },
+        ...(scenario.stylesheet === undefined ? {} : { stylesheet: scenario.stylesheet }),
+      }),
+    );
+
+    expect(error.message).toBe('Tailwind migration plans cannot contain stylesheet artifacts or metadata.');
+  });
+});

--- a/src/pipeline/validated-project-plan.ts
+++ b/src/pipeline/validated-project-plan.ts
@@ -1,0 +1,29 @@
+import type { StylesheetMigrationResult } from '../report/migration-report.builder';
+import { MigrationApplicationError } from '../migrator/migration-application.error';
+import { migrationPlan, type MigrationPlan } from '../migrator/migration-plan';
+import { renderedProject, type RenderedProject } from './rendered-project';
+
+export interface ValidatedProjectPlan {
+  readonly rendered: RenderedProject;
+  readonly plan: MigrationPlan;
+  readonly stylesheet?: StylesheetMigrationResult;
+}
+
+export function validatedProjectPlan(project: ValidatedProjectPlan): ValidatedProjectPlan {
+  const rendered = renderedProject(project.rendered);
+  const plan = migrationPlan(project.plan);
+
+  if (plan.target !== rendered.session.target) {
+    throw internalInvariant('Validated migration plan target differs from its finalized adapter session target.');
+  }
+
+  return Object.freeze({
+    rendered,
+    plan,
+    ...(project.stylesheet === undefined ? {} : { stylesheet: Object.freeze({ ...project.stylesheet }) }),
+  });
+}
+
+function internalInvariant(message: string): MigrationApplicationError {
+  return new MigrationApplicationError('internal-invariant', message);
+}

--- a/src/pipeline/validated-project-plan.ts
+++ b/src/pipeline/validated-project-plan.ts
@@ -84,8 +84,10 @@ function validatedStylesheet(
   supplied: StylesheetMigrationResult | undefined,
 ): StylesheetMigrationResult | undefined {
   const nonTemplateArtifacts = plan.artifacts.filter(artifact => artifact.kind !== 'template');
+  const configuredPath = rendered.analyzed.manifest.invocation.options.stylesheetPath;
   if (rendered.session.target === 'tailwind') {
     if (
+      configuredPath !== undefined ||
       supplied !== undefined ||
       nonTemplateArtifacts.length > 0 ||
       !sameArtifactSequence(plan.artifacts, templateArtifacts)
@@ -95,7 +97,6 @@ function validatedStylesheet(
     return undefined;
   }
 
-  const configuredPath = rendered.analyzed.manifest.invocation.options.stylesheetPath;
   const stylesheetArtifact = nonTemplateArtifacts.length === 1 ? nonTemplateArtifacts[0] : undefined;
   const canonicalConfiguredPath =
     configuredPath === undefined || configuredPath.trim().length === 0
@@ -103,6 +104,20 @@ function validatedStylesheet(
       : normalizedAbsolutePath(configuredPath);
   const expectedChange = stylesheetArtifact === undefined ? 'unchanged' : stylesheetChange(stylesheetArtifact);
   const expectedArtifacts = [...templateArtifacts, ...(stylesheetArtifact === undefined ? [] : [stylesheetArtifact])];
+
+  if (
+    canonicalConfiguredPath !== undefined &&
+    (plan.files.some(
+      file =>
+        normalizedAbsolutePath(file.inputPath) === canonicalConfiguredPath ||
+        normalizedAbsolutePath(file.outputPath) === canonicalConfiguredPath,
+    ) ||
+      templateArtifacts.some(artifact => normalizedAbsolutePath(artifact.path) === canonicalConfiguredPath))
+  ) {
+    throw internalInvariant(
+      'Configured stylesheet path must not collide with any template input, output, or artifact path.',
+    );
+  }
 
   if (
     canonicalConfiguredPath === undefined ||

--- a/src/pipeline/validated-project-plan.ts
+++ b/src/pipeline/validated-project-plan.ts
@@ -1,6 +1,8 @@
-import type { StylesheetMigrationResult } from '../report/migration-report.builder';
+import * as path from 'node:path';
 import { MigrationApplicationError } from '../migrator/migration-application.error';
-import { migrationPlan, type MigrationPlan } from '../migrator/migration-plan';
+import { fileMigrationResult, type FileMigrationResult } from '../migrator/file-migration-result';
+import { migrationPlan, type MigrationPlan, type PlannedOutputArtifact } from '../migrator/migration-plan';
+import type { StylesheetMigrationResult } from '../report/migration-report.builder';
 import { renderedProject, type RenderedProject } from './rendered-project';
 
 export interface ValidatedProjectPlan {
@@ -11,17 +13,177 @@ export interface ValidatedProjectPlan {
 
 export function validatedProjectPlan(project: ValidatedProjectPlan): ValidatedProjectPlan {
   const rendered = renderedProject(project.rendered);
-  const plan = migrationPlan(project.plan);
+  const suppliedPlan = migrationPlan(project.plan);
 
-  if (plan.target !== rendered.session.target) {
+  if (suppliedPlan.target !== rendered.session.target) {
     throw internalInvariant('Validated migration plan target differs from its finalized adapter session target.');
   }
+
+  const plan = canonicalPlan(rendered, suppliedPlan);
+  const templateArtifacts = renderedTemplateArtifacts(rendered);
+  assertTemplateArtifactCongruence(templateArtifacts, plan.artifacts);
+  const stylesheet = validatedStylesheet(rendered, plan, templateArtifacts, project.stylesheet);
 
   return Object.freeze({
     rendered,
     plan,
-    ...(project.stylesheet === undefined ? {} : { stylesheet: Object.freeze({ ...project.stylesheet }) }),
+    ...(stylesheet === undefined ? {} : { stylesheet }),
   });
+}
+
+function canonicalPlan(rendered: RenderedProject, supplied: MigrationPlan): MigrationPlan {
+  if (supplied.files.length !== rendered.files.length) throw fileCongruenceInvariant();
+  const files = supplied.files.map((file, index) => {
+    const expected = rendered.files[index]?.file;
+    if (expected === undefined || !samePathPair(expected, file)) throw fileCongruenceInvariant();
+    const canonical = fileMigrationResult({
+      ...file,
+      inputPath: expected.inputPath,
+      outputPath: expected.outputPath,
+    });
+    if (!sameOwnedValue(canonical, expected)) throw fileCongruenceInvariant();
+    return canonical;
+  });
+
+  return migrationPlan({ target: supplied.target, files, artifacts: supplied.artifacts });
+}
+
+function renderedTemplateArtifacts(rendered: RenderedProject): readonly PlannedOutputArtifact[] {
+  return rendered.files.flatMap(file => {
+    const artifact = file.artifact;
+    if (
+      file.file.changed !== (artifact !== undefined) ||
+      (artifact !== undefined &&
+        (artifact.kind !== 'template' || normalizedAbsolutePath(artifact.path) !== file.file.outputPath))
+    ) {
+      throw internalInvariant('Rendered template artifacts must correspond exactly to changed file outputs.');
+    }
+    return artifact === undefined ? [] : [artifact];
+  });
+}
+
+function assertTemplateArtifactCongruence(
+  renderedArtifacts: readonly PlannedOutputArtifact[],
+  planArtifacts: readonly PlannedOutputArtifact[],
+): void {
+  const templateArtifacts = planArtifacts.filter(artifact => artifact.kind === 'template');
+  if (
+    templateArtifacts.length !== renderedArtifacts.length ||
+    templateArtifacts.some((artifact, index) => !sameArtifact(artifact, renderedArtifacts[index]))
+  ) {
+    throw internalInvariant(
+      'Validated migration plan template artifacts must match rendered template artifacts in file order.',
+    );
+  }
+}
+
+function validatedStylesheet(
+  rendered: RenderedProject,
+  plan: MigrationPlan,
+  templateArtifacts: readonly PlannedOutputArtifact[],
+  supplied: StylesheetMigrationResult | undefined,
+): StylesheetMigrationResult | undefined {
+  const nonTemplateArtifacts = plan.artifacts.filter(artifact => artifact.kind !== 'template');
+  if (rendered.session.target === 'tailwind') {
+    if (
+      supplied !== undefined ||
+      nonTemplateArtifacts.length > 0 ||
+      !sameArtifactSequence(plan.artifacts, templateArtifacts)
+    ) {
+      throw internalInvariant('Tailwind migration plans cannot contain stylesheet artifacts or metadata.');
+    }
+    return undefined;
+  }
+
+  const configuredPath = rendered.analyzed.manifest.invocation.options.stylesheetPath;
+  const stylesheetArtifact = nonTemplateArtifacts.length === 1 ? nonTemplateArtifacts[0] : undefined;
+  const canonicalConfiguredPath =
+    configuredPath === undefined || configuredPath.trim().length === 0
+      ? undefined
+      : normalizedAbsolutePath(configuredPath);
+  const expectedChange = stylesheetArtifact === undefined ? 'unchanged' : stylesheetChange(stylesheetArtifact);
+  const expectedArtifacts = [...templateArtifacts, ...(stylesheetArtifact === undefined ? [] : [stylesheetArtifact])];
+
+  if (
+    canonicalConfiguredPath === undefined ||
+    supplied === undefined ||
+    nonTemplateArtifacts.length > 1 ||
+    (stylesheetArtifact !== undefined && stylesheetArtifact.kind !== 'stylesheet') ||
+    normalizedAbsolutePath(supplied.path) !== canonicalConfiguredPath ||
+    (stylesheetArtifact !== undefined && normalizedAbsolutePath(stylesheetArtifact.path) !== canonicalConfiguredPath) ||
+    supplied.change !== expectedChange ||
+    !sameArtifactSequence(plan.artifacts, expectedArtifacts)
+  ) {
+    throw internalInvariant(
+      'CSS stylesheet metadata must correspond exactly to its configured path and artifact change state.',
+    );
+  }
+
+  return Object.freeze({ path: canonicalConfiguredPath, change: supplied.change });
+}
+
+function stylesheetChange(artifact: PlannedOutputArtifact): StylesheetMigrationResult['change'] {
+  if (artifact.original.status === 'absent') return 'created';
+  if (artifact.proposed.status === 'absent') return 'removed';
+  return 'updated';
+}
+
+function sameArtifactSequence(
+  left: readonly PlannedOutputArtifact[],
+  right: readonly PlannedOutputArtifact[],
+): boolean {
+  return left.length === right.length && left.every((artifact, index) => sameArtifact(artifact, right[index]));
+}
+
+function sameArtifact(left: PlannedOutputArtifact, right: PlannedOutputArtifact | undefined): boolean {
+  return (
+    right !== undefined &&
+    left.kind === right.kind &&
+    normalizedAbsolutePath(left.path) === normalizedAbsolutePath(right.path) &&
+    sameOwnedValue(left.original, right.original) &&
+    sameOwnedValue(left.proposed, right.proposed)
+  );
+}
+
+function samePathPair(left: FileMigrationResult, right: FileMigrationResult): boolean {
+  return (
+    normalizedAbsolutePath(left.inputPath) === normalizedAbsolutePath(right.inputPath) &&
+    normalizedAbsolutePath(left.outputPath) === normalizedAbsolutePath(right.outputPath)
+  );
+}
+
+function sameOwnedValue(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((item, index) => sameOwnedValue(item, right[index]))
+    );
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) return false;
+  const keys = Object.keys(left);
+  return (
+    keys.length === Object.keys(right).length &&
+    keys.every(key => Object.hasOwn(right, key) && sameOwnedValue(left[key], right[key]))
+  );
+}
+
+function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  if (value === null || typeof value !== 'object') return false;
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+}
+
+function normalizedAbsolutePath(value: string): string {
+  return path.normalize(path.resolve(value));
+}
+
+function fileCongruenceInvariant(): MigrationApplicationError {
+  return internalInvariant(
+    'Validated migration plan files must match rendered files one-to-one and in the same order.',
+  );
 }
 
 function internalInvariant(message: string): MigrationApplicationError {

--- a/test/architecture/enterprise-pipeline-boundary.test.ts
+++ b/test/architecture/enterprise-pipeline-boundary.test.ts
@@ -17,6 +17,7 @@ const flexRoot = join(productionRoot, 'flex');
 const pipelineRoot = join(productionRoot, 'pipeline');
 const atomicWriterPath = join(productionRoot, 'lib', 'atomic-file.writer.ts');
 const roguePath = join(productionRoot, '__architecture-fixture__', 'rogue.ts');
+const wholeProjectInspectionTimeout = 60_000;
 const expectedRendererRelativePaths = [
   'adapter/css/css.adapter.ts',
   'adapter/css/flex/flex-align.css-renderer.ts',
@@ -74,7 +75,7 @@ function rendererMutationAuthorities(source: string): readonly string[] {
   ];
 }
 
-describe('enterprise pipeline dependency boundary', { timeout: 20_000 }, () => {
+describe('enterprise pipeline dependency boundary', { timeout: wholeProjectInspectionTimeout }, () => {
   test('keeps Flex semantics independent from both target adapters', () => {
     for (const path of productionTypeScriptFiles(flexRoot)) {
       const targetImport = inspectTypeScript(readFileSync(path, 'utf8'), path).moduleReferences.find(reference =>

--- a/test/architecture/enterprise-pipeline-boundary.test.ts
+++ b/test/architecture/enterprise-pipeline-boundary.test.ts
@@ -14,6 +14,7 @@ import {
 
 const productionRoot = join(process.cwd(), 'src');
 const flexRoot = join(productionRoot, 'flex');
+const pipelineRoot = join(productionRoot, 'pipeline');
 const atomicWriterPath = join(productionRoot, 'lib', 'atomic-file.writer.ts');
 const roguePath = join(productionRoot, '__architecture-fixture__', 'rogue.ts');
 const expectedRendererRelativePaths = [
@@ -142,9 +143,11 @@ describe('enterprise pipeline dependency boundary', { timeout: 20_000 }, () => {
   });
 
   test('reserves project mutation APIs for transaction and atomic-writer modules', () => {
-    const forbidden = inspectTypeScriptProject(
-      productionTypeScriptFiles(productionRoot),
-    ).filesystemMutationCalls.filter(
+    const productionPaths = productionTypeScriptFiles(productionRoot);
+    const pipelinePaths = productionTypeScriptFiles(pipelineRoot);
+    expect(productionPaths).toEqual(expect.arrayContaining([...pipelinePaths]));
+
+    const forbidden = inspectTypeScriptProject(productionPaths).filesystemMutationCalls.filter(
       finding =>
         !finding.sourcePath.startsWith(`${join(productionRoot, 'transaction')}/`) &&
         finding.sourcePath !== atomicWriterPath,

--- a/test/architecture/enterprise-pipeline-shell-boundary.test.ts
+++ b/test/architecture/enterprise-pipeline-shell-boundary.test.ts
@@ -1,0 +1,282 @@
+import { readFileSync } from 'node:fs';
+import { basename, join, relative } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { analyzedProject } from '../../src/pipeline/analyzed-project';
+import { MigrationPipeline } from '../../src/pipeline/migration-pipeline';
+import { migrationInvocation, projectManifest } from '../../src/pipeline/project-manifest';
+import { renderedProject } from '../../src/pipeline/rendered-project';
+import { validatedProjectPlan } from '../../src/pipeline/validated-project-plan';
+import {
+  inspectTypeScript,
+  inspectTypeScriptProject,
+  moduleReferenceContainsPath,
+  productionTypeScriptFiles,
+  runtimeModuleReferences,
+} from './typescript-boundary';
+
+const productionRoot = join(process.cwd(), 'src');
+const pipelineRoot = join(productionRoot, 'pipeline');
+const cliPath = join(productionRoot, 'cli', 'run-cli.ts');
+const currentPipelinePath = join(pipelineRoot, 'current-migration.pipeline.ts');
+const migrationPipelinePath = join(pipelineRoot, 'migration-pipeline.ts');
+const handoffImports = new Map<string, readonly string[]>([
+  [
+    'analyzed-project.ts',
+    [
+      './project-manifest',
+      '../analyzer/flex-layout-attribute.analyzer',
+      '../migrator/migration-application.error',
+      '../template/template.model',
+      'node:path',
+    ],
+  ],
+  ['project-manifest.ts', ['../migrator/migrator', 'node:path']],
+  [
+    'rendered-project.ts',
+    [
+      './analyzed-project',
+      './project-manifest',
+      '../adapter/conversion-adapter.session',
+      '../adapter/css/css-artifact.model',
+      '../breakpoint/breakpoint-catalog',
+      '../migrator/migration-application.error',
+      '../migrator/migration-plan',
+      'node:path',
+    ],
+  ],
+  [
+    'validated-project-plan.ts',
+    [
+      './rendered-project',
+      '../migrator/migration-application.error',
+      '../migrator/migration-plan',
+      '../report/migration-report.builder',
+    ],
+  ],
+]);
+
+function sourceInspection(path: string) {
+  return inspectTypeScript(readFileSync(path, 'utf8'), path);
+}
+
+function sorted(values: readonly string[]): readonly string[] {
+  return [...values].sort();
+}
+
+function expectFrozenAgainstMutation(value: object): void {
+  expect(Object.isFrozen(value)).toBe(true);
+  const property = Array.isArray(value) ? value.length : '__pipeline_boundary_mutation__';
+  expect(Reflect.set(value, property, Symbol('mutation'))).toBe(false);
+}
+
+describe('enterprise pipeline shell dependency boundary', { timeout: 20_000 }, () => {
+  test('keeps handoff models limited to target-neutral model imports and Node path normalization', () => {
+    for (const [fileName, allowedImports] of handoffImports) {
+      const path = join(pipelineRoot, fileName);
+      const source = readFileSync(path, 'utf8');
+      const inspection = inspectTypeScript(source, path);
+
+      expect(sorted(inspection.moduleReferences), relative(process.cwd(), path)).toEqual(sorted(allowedImports));
+      expect(
+        runtimeModuleReferences(source, path).filter(reference =>
+          ['adapter', 'breakpoint'].some(layer => moduleReferenceContainsPath(reference, layer)),
+        ),
+        relative(process.cwd(), path),
+      ).toEqual([]);
+    }
+  });
+
+  test('limits the staged coordinator to handoffs, its stage error, and the application result model', () => {
+    const source = readFileSync(migrationPipelinePath, 'utf8');
+    expect(sorted(inspectTypeScript(source, migrationPipelinePath).moduleReferences)).toEqual(
+      sorted([
+        './analyzed-project',
+        './pipeline-stage.error',
+        './project-manifest',
+        './rendered-project',
+        './validated-project-plan',
+        '../report/migration-report',
+      ]),
+    );
+    expect(runtimeModuleReferences(source, migrationPipelinePath)).toEqual(['./pipeline-stage.error']);
+  });
+
+  test('keeps the stage error dependent only on the coordinator stage-name type', () => {
+    const stageErrorPath = join(pipelineRoot, 'pipeline-stage.error.ts');
+    const source = readFileSync(stageErrorPath, 'utf8');
+
+    expect([...new Set(inspectTypeScript(source, stageErrorPath).moduleReferences)]).toEqual(['./migration-pipeline']);
+    expect(runtimeModuleReferences(source, stageErrorPath)).toEqual([]);
+  });
+
+  test('keeps the current-pipeline facade as the sole concrete Migrator and live adapter-session owner', () => {
+    const pipelinePaths = productionTypeScriptFiles(pipelineRoot);
+    const concreteMigratorOwners = pipelinePaths.flatMap(path =>
+      sourceInspection(path).runtimeImports.flatMap(runtimeImport =>
+        runtimeImport.importedName === 'Migrator' &&
+        moduleReferenceContainsPath(runtimeImport.moduleReference, 'migrator/migrator')
+          ? [relative(productionRoot, path).replaceAll('\\', '/')]
+          : [],
+      ),
+    );
+    const liveAdapterSessionOwners = pipelinePaths.flatMap(path =>
+      sourceInspection(path).identifiers.includes('ConversionAdapterSession')
+        ? [relative(productionRoot, path).replaceAll('\\', '/')]
+        : [],
+    );
+
+    expect(concreteMigratorOwners).toEqual(['pipeline/current-migration.pipeline.ts']);
+    expect(liveAdapterSessionOwners).toEqual(['pipeline/current-migration.pipeline.ts']);
+  });
+
+  test('keeps the current-pipeline facade to one migrate call and no stage or policy ownership', () => {
+    const inspection = sourceInspection(currentPipelinePath);
+    const forbiddenSymbols = [
+      ...inspection.identifiers,
+      ...inspection.callExpressionNames,
+      ...inspection.constructedExpressionNames,
+    ].filter(identifier =>
+      /(?:directive|breakpoint|render|validat|reportbuilder|buildreport|filesystem|transaction|exitpolicy|resolveexitcode|presenter|writer)/iu.test(
+        identifier,
+      ),
+    );
+
+    expect(sorted(inspection.moduleReferences)).toEqual(
+      sorted([
+        './project-manifest',
+        '../adapter/conversion-adapter.session',
+        '../migrator/migrator',
+        '../report/migration-report',
+      ]),
+    );
+    expect(inspection.callExpressionNames.filter(name => name === 'migrate')).toEqual(['migrate']);
+    expect(forbiddenSymbols).toEqual([]);
+    expect(inspectTypeScriptProject([currentPipelinePath]).filesystemMutationCalls).toEqual([]);
+    expect(inspectTypeScriptProject([currentPipelinePath]).transactionApplyCalls).toEqual([]);
+  });
+
+  test('routes the CLI through the runner port without a direct Migrator dependency', () => {
+    const inspection = sourceInspection(cliPath);
+
+    expect(inspection.moduleReferences).toContain('../pipeline/current-migration.pipeline');
+    expect(inspection.identifiers).toContain('MigrationRunner');
+    expect(inspection.identifiers).toContain('CurrentMigrationPipeline');
+    expect(inspection.identifiers).not.toContain('Migrator');
+    expect(
+      inspection.moduleReferences.find(reference => moduleReferenceContainsPath(reference, 'migrator/migrator')),
+    ).toBeUndefined();
+  });
+
+  test('reserves CurrentMigrationPipeline imports for the CLI production entry point', () => {
+    const importers = productionTypeScriptFiles(productionRoot).flatMap(path =>
+      sourceInspection(path).moduleReferences.some(reference =>
+        moduleReferenceContainsPath(reference, 'pipeline/current-migration.pipeline'),
+      )
+        ? [relative(productionRoot, path).replaceAll('\\', '/')]
+        : [],
+    );
+
+    expect(importers).toEqual(['cli/run-cli.ts']);
+  });
+
+  test('keeps handoff arrays and completed result objects frozen under mutation attempts', async () => {
+    const invocation = migrationInvocation({
+      inputPath: 'fixtures/source',
+      outputPath: 'fixtures/output',
+      options: { mode: 'plan' },
+    });
+    const manifest = projectManifest({
+      invocation,
+      templates: [{ inputPath: 'fixtures/source/card.html', outputPath: 'fixtures/output/card.html' }],
+    });
+    const analyzed = analyzedProject({
+      manifest,
+      templates: [
+        {
+          status: 'parse-error',
+          file: manifest.templates[0]!,
+          source: '<div',
+          parseResult: {
+            status: 'parse-error',
+            diagnostics: [{ message: 'incomplete start tag', source: { start: 0, end: 4 } }],
+          },
+        },
+      ],
+    });
+    const rendered = renderedProject({
+      analyzed,
+      files: [
+        {
+          file: {
+            inputPath: manifest.templates[0]!.inputPath,
+            outputPath: manifest.templates[0]!.outputPath,
+            changed: false,
+            results: [],
+          },
+        },
+      ],
+      session: { target: 'css', rules: [] },
+    });
+    const validated = validatedProjectPlan({
+      rendered,
+      plan: { target: 'css', files: [rendered.files[0]!.file], artifacts: [] },
+    });
+    const result = await new MigrationPipeline(
+      { run: () => Promise.resolve(manifest) },
+      { run: () => Promise.resolve(analyzed) },
+      { run: () => Promise.resolve(rendered) },
+      { run: () => Promise.resolve(validated) },
+      { run: () => Promise.resolve({ application: { status: 'skipped', reason: 'plan-only' } }) },
+    ).run(invocation);
+    const parsed = analyzed.templates[0]!;
+    if (parsed.status !== 'parse-error') throw new Error('Expected a parse-error fixture.');
+    if (rendered.session.target !== 'css') throw new Error('Expected a CSS session fixture.');
+
+    for (const value of [
+      invocation,
+      invocation.options,
+      manifest,
+      manifest.templates,
+      manifest.templates[0]!,
+      analyzed,
+      analyzed.templates,
+      parsed,
+      parsed.parseResult,
+      parsed.parseResult.diagnostics,
+      rendered,
+      rendered.files,
+      rendered.files[0]!,
+      rendered.files[0]!.file,
+      rendered.files[0]!.file.results,
+      rendered.session,
+      rendered.session.rules,
+      validated,
+      validated.plan,
+      validated.plan.files,
+      validated.plan.files[0]!,
+      validated.plan.artifacts,
+      result,
+      result.application,
+    ]) {
+      expectFrozenAgainstMutation(value);
+    }
+  });
+
+  test('covers every production pipeline module with the no-mutation inspection', () => {
+    const pipelinePaths = productionTypeScriptFiles(pipelineRoot);
+
+    expect(pipelinePaths.map(path => basename(path)).sort()).toEqual([
+      'analyzed-project.ts',
+      'current-migration.pipeline.ts',
+      'migration-pipeline.ts',
+      'pipeline-stage.error.ts',
+      'project-manifest.ts',
+      'rendered-project.ts',
+      'validated-project-plan.ts',
+    ]);
+    expect(inspectTypeScriptProject(pipelinePaths).filesystemMutationCalls).toEqual([]);
+    expect(inspectTypeScriptProject(pipelinePaths).transactionApplyCalls).toEqual([]);
+  });
+});

--- a/test/architecture/enterprise-pipeline-shell-boundary.test.ts
+++ b/test/architecture/enterprise-pipeline-shell-boundary.test.ts
@@ -50,9 +50,11 @@ const handoffImports = new Map<string, readonly string[]>([
     'validated-project-plan.ts',
     [
       './rendered-project',
+      '../migrator/file-migration-result',
       '../migrator/migration-application.error',
       '../migrator/migration-plan',
       '../report/migration-report.builder',
+      'node:path',
     ],
   ],
 ]);
@@ -182,10 +184,11 @@ describe('enterprise pipeline shell dependency boundary', { timeout: 20_000 }, (
   });
 
   test('keeps handoff arrays and completed result objects frozen under mutation attempts', async () => {
+    const stylesheetPath = join(process.cwd(), 'fixtures', 'migration.css');
     const invocation = migrationInvocation({
       inputPath: 'fixtures/source',
       outputPath: 'fixtures/output',
-      options: { mode: 'plan' },
+      options: { mode: 'plan', stylesheetPath },
     });
     const manifest = projectManifest({
       invocation,
@@ -222,6 +225,7 @@ describe('enterprise pipeline shell dependency boundary', { timeout: 20_000 }, (
     const validated = validatedProjectPlan({
       rendered,
       plan: { target: 'css', files: [rendered.files[0]!.file], artifacts: [] },
+      stylesheet: { path: stylesheetPath, change: 'unchanged' },
     });
     const result = await new MigrationPipeline(
       { run: () => Promise.resolve(manifest) },
@@ -257,6 +261,7 @@ describe('enterprise pipeline shell dependency boundary', { timeout: 20_000 }, (
       validated.plan.files,
       validated.plan.files[0]!,
       validated.plan.artifacts,
+      validated.stylesheet!,
       result,
       result.application,
     ]) {

--- a/test/architecture/migration-mode-boundary.test.ts
+++ b/test/architecture/migration-mode-boundary.test.ts
@@ -23,7 +23,7 @@ function fixtureModeInputs(source: string): readonly ExecutionModeInput[] {
   return executionModeInputs(new Map([[fixturePath, source]]), [fixturePath]);
 }
 
-describe('migration mode architecture boundary', () => {
+describe('migration mode architecture boundary', { timeout: wholeProjectInspectionTimeout }, () => {
   test('detects the canonical MigrationMode type through an aliased type-only import', () => {
     const source = `
       import type { MigrationMode as RequestedExecution } from '../migrator/migration-mode.js';

--- a/test/architecture/migration-transaction-boundary.test.ts
+++ b/test/architecture/migration-transaction-boundary.test.ts
@@ -1173,6 +1173,146 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     expect(transactionApplyCalls(new Map([[presenter, source]]), [presenter])).toEqual([]);
   });
 
+  test('detects a re-exported MigrationTransaction.apply target invoked through Reflect.apply', () => {
+    const helper = join(projectFixtureRoot, 'reflected-transaction.helper.ts');
+    const barrel = join(projectFixtureRoot, 'reflected-transaction.index.ts');
+    const presenter = join(projectFixtureRoot, 'reflected-transaction.presenter.ts');
+    const sources = new Map([
+      [
+        helper,
+        `
+          import type { MigrationTransaction } from '../transaction/migration-transaction.js';
+          declare const transaction: Pick<MigrationTransaction, 'apply'>;
+          export const applyPlan = transaction.apply;
+        `,
+      ],
+      [barrel, "export { applyPlan as execute } from './reflected-transaction.helper.js';"],
+      [
+        presenter,
+        `
+          import { execute as target } from './reflected-transaction.index.js';
+          import type { MigrationPlan } from '../migrator/migration-plan.js';
+          declare const plan: MigrationPlan;
+          void Reflect.apply(target, undefined, [plan]);
+        `,
+      ],
+    ]);
+
+    expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'apply' }]);
+  });
+
+  test('detects a computed Migrator.migrate target through a re-exported Reflect.apply alias', () => {
+    const helper = join(projectFixtureRoot, 'reflect-apply.helper.ts');
+    const barrel = join(projectFixtureRoot, 'reflect-apply.index.ts');
+    const presenter = join(projectFixtureRoot, 'reflected-migrator.presenter.ts');
+    const sources = new Map([
+      [helper, 'export const invokeReflect = Reflect.apply;'],
+      [barrel, "export { invokeReflect as invoke } from './reflect-apply.helper.js';"],
+      [
+        presenter,
+        `
+          import { invoke as invokeReflect } from './reflect-apply.index.js';
+          import { Migrator as Coordinator } from '../migrator/migrator.js';
+          declare const migrator: Coordinator;
+          const method = 'migrate' as const;
+          void invokeReflect(migrator[method], migrator, [{ mode: 'write' }]);
+        `,
+      ],
+    ]);
+
+    expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'migrate' }]);
+  });
+
+  test.each([
+    [
+      'CurrentMigrationPipeline class',
+      `
+        import { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';
+        declare const runner: Runner;
+      `,
+    ],
+    [
+      're-exported MigrationRunner port',
+      `
+        import type { RunnerPort as Runner } from './reflected-runner.index.js';
+        declare const runner: Runner;
+      `,
+    ],
+  ])('detects a computed %s target invoked through computed Reflect.apply', (_label, setup) => {
+    const barrel = join(projectFixtureRoot, 'reflected-runner.index.ts');
+    const presenter = join(projectFixtureRoot, 'reflected-runner.presenter.ts');
+    const sources = new Map([
+      [barrel, "export type { MigrationRunner as RunnerPort } from '../pipeline/current-migration.pipeline.js';"],
+      [
+        presenter,
+        `
+          ${setup}
+          const reflectMethod = 'apply' as const;
+          declare const runMethod: string;
+          void Reflect[reflectMethod](runner[runMethod], runner, [{
+            inputPath: 'input.html',
+            outputPath: 'output.html',
+            options: { mode: 'write' },
+          }]);
+        `,
+      ],
+    ]);
+
+    expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'run' }]);
+  });
+
+  test.each([
+    [
+      'Migrator plan',
+      `
+        import { Migrator as Coordinator } from '../migrator/migrator.js';
+        declare const migrator: Coordinator;
+        void Reflect.apply(migrator.migrate, migrator, [{ mode: 'plan' }]);
+      `,
+    ],
+    [
+      'MigrationRunner plan',
+      `
+        import type { MigrationRunner as Runner } from '../pipeline/current-migration.pipeline.js';
+        declare const runner: Runner;
+        void Reflect.apply(runner.run, runner, [{
+          inputPath: 'input.html',
+          outputPath: 'output.html',
+          options: { mode: 'plan' },
+        }]);
+      `,
+    ],
+  ])('does not assign write authority to an explicit reflected %s', (_label, source) => {
+    const presenter = join(projectFixtureRoot, 'reflected-plan.presenter.ts');
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([]);
+  });
+
+  test.each([
+    [
+      'unrelated formatter target',
+      `
+        interface Formatter { apply(value: string): string }
+        declare const formatter: Formatter;
+        void Reflect.apply(formatter.apply, formatter, ['text']);
+      `,
+    ],
+    [
+      'locally shadowed Reflect object',
+      `
+        import { Migrator as Coordinator } from '../migrator/migrator.js';
+        declare const migrator: Coordinator;
+        const Reflect = { apply: (target: Function, receiver: unknown, values: unknown[]) =>
+          target.apply(receiver, values) };
+        void Reflect.apply(migrator.migrate, migrator, [{ mode: 'write' }]);
+      `,
+    ],
+  ])('does not confuse a Reflect.apply-shaped %s with write authority', (_label, source) => {
+    const presenter = join(projectFixtureRoot, 'unrelated-reflect-apply.presenter.ts');
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([]);
+  });
+
   test('ignores a same-named CommonJS class without transaction provenance', () => {
     const localModule = join(projectFixtureRoot, 'local-transaction.ts');
     const presenter = join(projectFixtureRoot, 'local-commonjs.presenter.ts');

--- a/test/architecture/migration-transaction-boundary.test.ts
+++ b/test/architecture/migration-transaction-boundary.test.ts
@@ -483,6 +483,54 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     ]);
   });
 
+  test('treats the canonical MigrationRunner port as current-pipeline write authority', () => {
+    const presenter = join(projectFixtureRoot, 'migration-runner-port.presenter.ts');
+    const source = `
+      import type { MigrationRunner as RunnerPort } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: RunnerPort;
+      void runner.run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
+  test('follows the canonical MigrationRunner port through a re-exported type alias', () => {
+    const barrel = join(projectFixtureRoot, 'migration-runner-port.index.ts');
+    const presenter = join(projectFixtureRoot, 'aliased-migration-runner-port.presenter.ts');
+    const sources = new Map([
+      [barrel, "export type { MigrationRunner as RunnerPort } from '../pipeline/current-migration.pipeline.js';"],
+      [
+        presenter,
+        `
+          import type { RunnerPort as ImportedPort } from './migration-runner-port.index.js';
+          declare const runner: ImportedPort;
+          void runner.run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+        `,
+      ],
+    ]);
+
+    expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'run' }]);
+  });
+
+  test.each([
+    ['a const literal method alias', "const method = 'run' as const;"],
+    ['an unknown computed method', 'declare const method: string;'],
+  ])('fails closed for canonical MigrationRunner invocation through %s', (_label, methodDeclaration) => {
+    const presenter = join(projectFixtureRoot, 'computed-migration-runner-port.presenter.ts');
+    const source = `
+      import type { MigrationRunner as RunnerPort } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: RunnerPort;
+      ${methodDeclaration}
+      void runner[method]({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
   test.each([
     [
       'direct bound callable',
@@ -596,6 +644,23 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
       `
         class CurrentMigrationPipeline { run(invocation: { options: { mode: 'write' } }): void {} }
         new CurrentMigrationPipeline().run({ options: { mode: 'write' } });
+      `,
+    ],
+    [
+      'a same-named local runner port',
+      `
+        interface MigrationRunner { run(invocation: { options: { mode: 'write' } }): void }
+        declare const runner: MigrationRunner;
+        runner.run({ options: { mode: 'write' } });
+      `,
+    ],
+    [
+      'an unrelated receiver with an unknown computed method',
+      `
+        interface Previewer { run(invocation: { options: { mode: 'write' } }): void }
+        declare const previewer: Previewer;
+        declare const method: string;
+        previewer[method]({ options: { mode: 'write' } });
       `,
     ],
   ])('does not confuse %s with current-pipeline write authority', (_label, source) => {

--- a/test/architecture/migration-transaction-boundary.test.ts
+++ b/test/architecture/migration-transaction-boundary.test.ts
@@ -1265,6 +1265,9 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     {
       label: 'MigrationTransaction.apply',
       name: 'apply' as const,
+      reflectedCall: `
+        void Reflect.apply(transaction.apply.call, transaction.apply, [transaction, plan]);
+      `,
       setup: `
         import type { MigrationTransaction } from '../transaction/migration-transaction.js';
         import type { MigrationPlan } from '../migrator/migration-plan.js';
@@ -1278,6 +1281,9 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     {
       label: 'Migrator.migrate',
       name: 'migrate' as const,
+      reflectedCall: `
+        void Reflect.apply(migrator.migrate.call, migrator.migrate, [migrator, { mode: 'write' }]);
+      `,
       setup: `
         import { Migrator } from '../migrator/migrator.js';
         declare const migrator: Migrator;
@@ -1289,6 +1295,13 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     {
       label: 'MigrationRunner.run',
       name: 'run' as const,
+      reflectedCall: `
+        void Reflect.apply(runner.run.call, runner.run, [runner, {
+          inputPath: 'input.html',
+          outputPath: 'output.html',
+          options: { mode: 'write' },
+        }]);
+      `,
       setup: `
         import type { MigrationRunner } from '../pipeline/current-migration.pipeline.js';
         declare const runner: MigrationRunner;
@@ -1315,6 +1328,18 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
 
       expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
         { sourcePath: presenter, name },
+        { sourcePath: presenter, name },
+      ]);
+    },
+  );
+
+  test.each(reflectiveAuthorityFixtures)(
+    'detects $label when Reflect.apply invokes the authority nested Function.call target',
+    ({ setup, reflectedCall, name }) => {
+      const presenter = join(projectFixtureRoot, `reflected-call-target-${name}.presenter.ts`);
+      const source = `${setup}${reflectedCall}`;
+
+      expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
         { sourcePath: presenter, name },
       ]);
     },
@@ -1363,6 +1388,18 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
         import { Migrator as Coordinator } from '../migrator/migrator.js';
         declare const migrator: Coordinator;
         void Reflect.apply.call(undefined, migrator.migrate, migrator, [{ mode: 'plan' }]);
+      `,
+    ],
+    [
+      'nested-call-target Migrator plan',
+      `
+        import { Migrator as Coordinator } from '../migrator/migrator.js';
+        declare const migrator: Coordinator;
+        void Reflect.apply(
+          migrator.migrate.call,
+          migrator.migrate,
+          [migrator, { mode: 'plan' }],
+        );
       `,
     ],
     [
@@ -1418,6 +1455,14 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
         declare const formatter: Formatter;
         const invoke = Reflect.apply.bind(undefined, formatter.format, formatter);
         void invoke(['text']);
+      `,
+    ],
+    [
+      'unrelated nested Function.call target',
+      `
+        interface Formatter { format(value: string): string }
+        declare const formatter: Formatter;
+        void Reflect.apply(formatter.format.call, formatter.format, [formatter, 'text']);
       `,
     ],
   ])('does not confuse a Reflect.apply-shaped %s with write authority', (_label, source) => {

--- a/test/architecture/migration-transaction-boundary.test.ts
+++ b/test/architecture/migration-transaction-boundary.test.ts
@@ -1261,6 +1261,81 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'run' }]);
   });
 
+  const reflectiveAuthorityFixtures = [
+    {
+      label: 'MigrationTransaction.apply',
+      name: 'apply' as const,
+      setup: `
+        import type { MigrationTransaction } from '../transaction/migration-transaction.js';
+        import type { MigrationPlan } from '../migrator/migration-plan.js';
+        declare const transaction: Pick<MigrationTransaction, 'apply'>;
+        declare const plan: MigrationPlan;
+        const target = transaction.apply;
+        const receiver = transaction;
+        const values = [plan];
+      `,
+    },
+    {
+      label: 'Migrator.migrate',
+      name: 'migrate' as const,
+      setup: `
+        import { Migrator } from '../migrator/migrator.js';
+        declare const migrator: Migrator;
+        const target = migrator.migrate;
+        const receiver = migrator;
+        const values = [{ mode: 'write' as const }];
+      `,
+    },
+    {
+      label: 'MigrationRunner.run',
+      name: 'run' as const,
+      setup: `
+        import type { MigrationRunner } from '../pipeline/current-migration.pipeline.js';
+        declare const runner: MigrationRunner;
+        const target = runner.run;
+        const receiver = runner;
+        const values = [{
+          inputPath: 'input.html',
+          outputPath: 'output.html',
+          options: { mode: 'write' as const },
+        }];
+      `,
+    },
+  ];
+
+  test.each(reflectiveAuthorityFixtures)(
+    'detects $label through single and nested Function.call routes to Reflect.apply',
+    ({ setup, name }) => {
+      const presenter = join(projectFixtureRoot, `nested-reflect-${name}.presenter.ts`);
+      const source = `
+        ${setup}
+        void Reflect.apply.call(undefined, target, receiver, values);
+        void Reflect.apply.call.call(Reflect.apply, undefined, target, receiver, values);
+      `;
+
+      expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+        { sourcePath: presenter, name },
+        { sourcePath: presenter, name },
+      ]);
+    },
+  );
+
+  test.each(reflectiveAuthorityFixtures)(
+    'detects $label through Reflect.apply with its target and receiver prebound',
+    ({ setup, name }) => {
+      const presenter = join(projectFixtureRoot, `prebound-reflect-${name}.presenter.ts`);
+      const source = `
+        ${setup}
+        const invoke = Reflect.apply.bind(undefined, target, receiver);
+        void invoke(values);
+      `;
+
+      expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+        { sourcePath: presenter, name },
+      ]);
+    },
+  );
+
   test.each([
     [
       'Migrator plan',
@@ -1276,6 +1351,27 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
         import type { MigrationRunner as Runner } from '../pipeline/current-migration.pipeline.js';
         declare const runner: Runner;
         void Reflect.apply(runner.run, runner, [{
+          inputPath: 'input.html',
+          outputPath: 'output.html',
+          options: { mode: 'plan' },
+        }]);
+      `,
+    ],
+    [
+      'nested Migrator plan',
+      `
+        import { Migrator as Coordinator } from '../migrator/migrator.js';
+        declare const migrator: Coordinator;
+        void Reflect.apply.call(undefined, migrator.migrate, migrator, [{ mode: 'plan' }]);
+      `,
+    ],
+    [
+      'prebound MigrationRunner plan',
+      `
+        import type { MigrationRunner as Runner } from '../pipeline/current-migration.pipeline.js';
+        declare const runner: Runner;
+        const invoke = Reflect.apply.bind(undefined, runner.run, runner);
+        void invoke([{
           inputPath: 'input.html',
           outputPath: 'output.html',
           options: { mode: 'plan' },
@@ -1305,6 +1401,23 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
         const Reflect = { apply: (target: Function, receiver: unknown, values: unknown[]) =>
           target.apply(receiver, values) };
         void Reflect.apply(migrator.migrate, migrator, [{ mode: 'write' }]);
+      `,
+    ],
+    [
+      'unrelated target through nested Function.call',
+      `
+        interface Formatter { format(value: string): string }
+        declare const formatter: Formatter;
+        void Reflect.apply.call.call(Reflect.apply, undefined, formatter.format, formatter, ['text']);
+      `,
+    ],
+    [
+      'unrelated prebound target',
+      `
+        interface Formatter { format(value: string): string }
+        declare const formatter: Formatter;
+        const invoke = Reflect.apply.bind(undefined, formatter.format, formatter);
+        void invoke(['text']);
       `,
     ],
   ])('does not confuse a Reflect.apply-shaped %s with write authority', (_label, source) => {

--- a/test/architecture/migration-transaction-boundary.test.ts
+++ b/test/architecture/migration-transaction-boundary.test.ts
@@ -54,12 +54,12 @@ interface TransactionApplyCall {
 
 interface ProjectWriteAuthorityCall {
   readonly sourcePath: string;
-  readonly name: 'apply' | 'migrate';
+  readonly name: 'apply' | 'migrate' | 'run';
 }
 
 interface NormalizedAuthorityEdge {
   readonly caller: string;
-  readonly authority: 'MigrationTransaction.apply' | 'Migrator.migrate';
+  readonly authority: 'CurrentMigrationPipeline.run' | 'MigrationTransaction.apply' | 'Migrator.migrate';
 }
 
 function transactionApplyCalls(
@@ -80,7 +80,12 @@ function normalizedAuthorityGraph(calls: readonly ProjectWriteAuthorityCall[]): 
   return calls
     .map(call => ({
       caller: relative(productionRoot, call.sourcePath).replaceAll('\\', '/'),
-      authority: call.name === 'apply' ? ('MigrationTransaction.apply' as const) : ('Migrator.migrate' as const),
+      authority:
+        call.name === 'apply'
+          ? ('MigrationTransaction.apply' as const)
+          : call.name === 'migrate'
+            ? ('Migrator.migrate' as const)
+            : ('CurrentMigrationPipeline.run' as const),
     }))
     .sort((left, right) => `${left.caller}\0${left.authority}`.localeCompare(`${right.caller}\0${right.authority}`));
 }
@@ -463,6 +468,140 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
     expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
       { sourcePath: presenter, name: 'migrate' },
     ]);
+  });
+
+  test('detects a caller invoking canonical CurrentMigrationPipeline#run in write mode', () => {
+    const presenter = join(projectFixtureRoot, 'current-pipeline.presenter.ts');
+    const source = `
+      import { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: Runner;
+      void runner.run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
+  test.each([
+    [
+      'direct bound callable',
+      "const execute = runner.run.bind(runner, { inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } }); void execute();",
+    ],
+    [
+      'aliased bound callable',
+      "const execute = runner.run.bind(runner); const run = execute; void run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });",
+    ],
+  ])('detects canonical current-pipeline write authority through a %s', (_label, invocation) => {
+    const presenter = join(projectFixtureRoot, 'bound-current-pipeline.presenter.ts');
+    const source = `
+      import { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: Runner;
+      ${invocation}
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
+  test('follows current-pipeline write authority through a re-export alias', () => {
+    const barrel = join(projectFixtureRoot, 'current-pipeline.index.ts');
+    const presenter = join(projectFixtureRoot, 'barrel-current-pipeline.presenter.ts');
+    const sources = new Map([
+      [barrel, "export { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';"],
+      [
+        presenter,
+        `
+          import { Runner as ImportedRunner } from './current-pipeline.index.js';
+          declare const runner: ImportedRunner;
+          void runner.run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+        `,
+      ],
+    ]);
+
+    expect(projectWriteAuthorityCalls(sources, [presenter])).toEqual([{ sourcePath: presenter, name: 'run' }]);
+  });
+
+  test.each([
+    [
+      'dynamic import',
+      `
+        const { CurrentMigrationPipeline: Runner } = await import('../pipeline/current-migration.pipeline.js');
+        const runner = new Runner(undefined as never);
+      `,
+    ],
+    [
+      'CommonJS require',
+      `
+        const { CurrentMigrationPipeline: Runner } = require('../pipeline/current-migration.pipeline.js');
+        const runner = new Runner(undefined);
+      `,
+    ],
+  ])('detects canonical current-pipeline write authority acquired through %s', (_label, setup) => {
+    const presenter = join(projectFixtureRoot, 'runtime-current-pipeline.presenter.ts');
+    const source = `
+      async function present() {
+        ${setup}
+        await runner.run({ inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'write' } });
+      }
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
+  test('fails closed for a mutable current-pipeline invocation', () => {
+    const presenter = join(projectFixtureRoot, 'mutable-current-pipeline.presenter.ts');
+    const source = `
+      import { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: Runner;
+      const invocation = { inputPath: 'input.html', outputPath: 'output.html', options: { mode: 'plan' } };
+      void runner.run(invocation);
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([
+      { sourcePath: presenter, name: 'run' },
+    ]);
+  });
+
+  test('allows an immutable explicit plan through the current pipeline without granting write authority', () => {
+    const presenter = join(projectFixtureRoot, 'plan-current-pipeline.presenter.ts');
+    const source = `
+      import { CurrentMigrationPipeline as Runner } from '../pipeline/current-migration.pipeline.js';
+      declare const runner: Runner;
+      const invocation = {
+        inputPath: 'input.html',
+        outputPath: 'output.html',
+        options: { mode: 'plan' },
+      } as const;
+      void runner.run(invocation);
+    `;
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([]);
+  });
+
+  test.each([
+    [
+      'an unrelated run method',
+      `
+        interface Previewer { run(invocation: { options: { mode: 'write' } }): void }
+        declare const previewer: Previewer;
+        previewer.run({ options: { mode: 'write' } });
+      `,
+    ],
+    [
+      'a same-named local class',
+      `
+        class CurrentMigrationPipeline { run(invocation: { options: { mode: 'write' } }): void {} }
+        new CurrentMigrationPipeline().run({ options: { mode: 'write' } });
+      `,
+    ],
+  ])('does not confuse %s with current-pipeline write authority', (_label, source) => {
+    const presenter = join(projectFixtureRoot, 'unrelated-current-pipeline.presenter.ts');
+
+    expect(projectWriteAuthorityCalls(new Map([[presenter, source]]), [presenter])).toEqual([]);
   });
 
   test.each([
@@ -1004,15 +1143,16 @@ describe('migration transaction architecture boundary', { timeout: wholeProjectI
   });
 
   test(
-    'keeps the production authority graph exactly CLI to Migrator and Migrator to MigrationTransaction',
+    'keeps the production authority graph exactly CLI to CurrentMigrationPipeline to Migrator to MigrationTransaction',
     () => {
       const graph = normalizedAuthorityGraph(
         projectWriteAuthorityCalls(new Map(), productionTypeScriptFiles(productionRoot)),
       );
 
       expect(graph).toEqual([
-        { caller: 'cli/run-cli.ts', authority: 'Migrator.migrate' },
+        { caller: 'cli/run-cli.ts', authority: 'CurrentMigrationPipeline.run' },
         { caller: 'migrator/migrator.ts', authority: 'MigrationTransaction.apply' },
+        { caller: 'pipeline/current-migration.pipeline.ts', authority: 'Migrator.migrate' },
       ]);
     },
     wholeProjectInspectionTimeout,

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -913,6 +913,7 @@ function currentMigrationPipelineRunDeclaration(declaration: ts.Declaration): bo
   if (!normalizedDeclarationPath(declaration).endsWith('/pipeline/current-migration.pipeline.ts')) return false;
   for (let current: ts.Node | undefined = declaration; current !== undefined; current = current.parent) {
     if (ts.isClassDeclaration(current)) return current.name?.text === 'CurrentMigrationPipeline';
+    if (ts.isInterfaceDeclaration(current)) return current.name.text === 'MigrationRunner';
   }
   return false;
 }
@@ -1697,6 +1698,18 @@ interface CurrentMigrationPipelineRunCallableProvenance {
   readonly boundArguments: readonly ts.Expression[];
 }
 
+function currentMigrationPipelineMemberName(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  checker: ts.TypeChecker,
+): string | undefined {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  const directName = moduleText(expression.argumentExpression);
+  if (directName !== undefined) return directName;
+  if (expression.argumentExpression === undefined) return undefined;
+  const argumentType = checker.getTypeAtLocation(unwrapExpression(expression.argumentExpression));
+  return argumentType.isStringLiteral() || argumentType.isNumberLiteral() ? String(argumentType.value) : undefined;
+}
+
 function currentMigrationPipelineRunSymbolProvenance(
   symbol: ts.Symbol | undefined,
   checker: ts.TypeChecker,
@@ -1794,9 +1807,7 @@ function currentMigrationPipelineRunCallableProvenance(
   }
 
   if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
-    const name = ts.isPropertyAccessExpression(unwrapped)
-      ? unwrapped.name.text
-      : moduleText(unwrapped.argumentExpression);
+    const name = currentMigrationPipelineMemberName(unwrapped, checker);
     if (name === 'run') {
       const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), name);
       if (
@@ -1805,6 +1816,13 @@ function currentMigrationPipelineRunCallableProvenance(
       ) {
         return { boundArguments: [] };
       }
+    }
+    if (
+      name === undefined &&
+      ts.isElementAccessExpression(unwrapped) &&
+      currentMigrationPipelineReceiverProvenance(unwrapped.expression, checker, program)
+    ) {
+      return { boundArguments: [] };
     }
     const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
     if (propertyNode !== undefined) {

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -1212,23 +1212,36 @@ function resolvedCallableInvocation<Provenance>(
   checker: ts.TypeChecker,
   resolveCallable: (target: ts.Expression) => Provenance | undefined,
 ): ResolvedCallableInvocation<Provenance> | undefined {
-  const direct = resolveCallable(expression.expression);
-  if (direct !== undefined) return { provenance: direct, arguments: expression.arguments };
+  return resolvedCallableApplication(expression.expression, expression.arguments, checker, resolveCallable);
+}
 
-  const target = unwrapExpression(expression.expression);
+function resolvedCallableApplication<Provenance>(
+  expression: ts.Expression,
+  suppliedArguments: readonly ts.Expression[] | undefined,
+  checker: ts.TypeChecker,
+  resolveCallable: (target: ts.Expression) => Provenance | undefined,
+): ResolvedCallableInvocation<Provenance> | undefined {
+  const direct = resolveCallable(expression);
+  if (direct !== undefined) {
+    return suppliedArguments === undefined
+      ? { provenance: direct }
+      : { provenance: direct, arguments: suppliedArguments };
+  }
+
+  const target = unwrapExpression(expression);
   if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) return undefined;
   const name = resolvedMemberName(target, checker);
   if (name === 'apply') {
     const provenance = resolveCallable(target.expression);
     if (provenance === undefined) return undefined;
-    const callArguments = arrayLiteralArguments(expression.arguments[1]);
+    const callArguments = arrayLiteralArguments(suppliedArguments?.[1]);
     return callArguments === undefined ? { provenance } : { provenance, arguments: callArguments };
   }
   if (name !== 'call') return undefined;
 
   const provenance = resolveCallable(target.expression);
   if (provenance !== undefined) {
-    return { provenance, arguments: expression.arguments.slice(1) };
+    return suppliedArguments === undefined ? { provenance } : { provenance, arguments: suppliedArguments.slice(1) };
   }
 
   const nestedTarget = unwrapExpression(target.expression);
@@ -1239,12 +1252,13 @@ function resolvedCallableInvocation<Provenance>(
   ) {
     return undefined;
   }
-  const reboundTarget = expression.arguments[0];
+  if (suppliedArguments === undefined) return undefined;
+  const reboundTarget = suppliedArguments[0];
   if (reboundTarget === undefined) return undefined;
   const reboundProvenance = resolveCallable(reboundTarget);
   return reboundProvenance === undefined
     ? undefined
-    : { provenance: reboundProvenance, arguments: expression.arguments.slice(2) };
+    : { provenance: reboundProvenance, arguments: suppliedArguments.slice(2) };
 }
 
 function reflectedApplyInvocation(
@@ -1631,8 +1645,11 @@ function transactionApplicationInvocation(
   seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
 ): boolean {
   const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
-  if (reflected !== undefined && transactionApplyCallableProvenance(reflected.target, checker, program, seenSymbols)) {
-    return true;
+  if (reflected !== undefined) {
+    const invocation = resolvedCallableApplication(reflected.target, reflected.arguments, checker, target =>
+      transactionApplyCallableProvenance(target, checker, program, seenSymbols) ? true : undefined,
+    );
+    if (invocation !== undefined) return true;
   }
   return (
     resolvedCallableInvocation(expression, checker, target =>
@@ -2116,11 +2133,13 @@ function currentPipelineWriteInvocation(
 ): boolean {
   const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
   if (reflected !== undefined) {
-    const provenance = currentMigrationPipelineRunCallableProvenance(reflected.target, checker, program, seenSymbols);
-    if (provenance !== undefined) {
-      return reflected.arguments === undefined
+    const invocation = resolvedCallableApplication(reflected.target, reflected.arguments, checker, target =>
+      currentMigrationPipelineRunCallableProvenance(target, checker, program, seenSymbols),
+    );
+    if (invocation !== undefined) {
+      return invocation.arguments === undefined
         ? true
-        : boundCurrentPipelineInvocationCanWrite(provenance, reflected.arguments, checker);
+        : boundCurrentPipelineInvocationCanWrite(invocation.provenance, invocation.arguments, checker);
     }
     return currentPipelineWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
   }
@@ -2205,11 +2224,13 @@ function migrationWriteInvocation(
 ): boolean {
   const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
   if (reflected !== undefined) {
-    const provenance = migratorMigrateCallableProvenance(reflected.target, checker, program, seenSymbols);
-    if (provenance !== undefined) {
-      return reflected.arguments === undefined
+    const invocation = resolvedCallableApplication(reflected.target, reflected.arguments, checker, target =>
+      migratorMigrateCallableProvenance(target, checker, program, seenSymbols),
+    );
+    if (invocation !== undefined) {
+      return invocation.arguments === undefined
         ? true
-        : boundMigrationInvocationCanWrite(provenance, reflected.arguments, checker);
+        : boundMigrationInvocationCanWrite(invocation.provenance, invocation.arguments, checker);
     }
     return migrationWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
   }

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -106,7 +106,7 @@ export interface TypeScriptProjectInspection {
   readonly transactionApplyCalls: readonly { readonly sourcePath: string; readonly name: 'apply' }[];
   readonly projectWriteAuthorityCalls: readonly {
     readonly sourcePath: string;
-    readonly name: 'apply' | 'migrate';
+    readonly name: 'apply' | 'migrate' | 'run';
   }[];
 }
 
@@ -909,6 +909,42 @@ function migratorClassSymbol(
   );
 }
 
+function currentMigrationPipelineRunDeclaration(declaration: ts.Declaration): boolean {
+  if (!normalizedDeclarationPath(declaration).endsWith('/pipeline/current-migration.pipeline.ts')) return false;
+  for (let current: ts.Node | undefined = declaration; current !== undefined; current = current.parent) {
+    if (ts.isClassDeclaration(current)) return current.name?.text === 'CurrentMigrationPipeline';
+  }
+  return false;
+}
+
+function currentMigrationPipelineRunSymbol(symbol: ts.Symbol | undefined): boolean {
+  return (
+    symbol?.getName() === 'run' &&
+    symbol.declarations?.some(declaration => currentMigrationPipelineRunDeclaration(declaration)) === true
+  );
+}
+
+function currentMigrationPipelineClassSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  if (symbol === undefined || seenSymbols.has(symbol)) return false;
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    const aliased = checker.getAliasedSymbol(symbol);
+    if (aliased !== symbol && currentMigrationPipelineClassSymbol(aliased, checker, nextSeen)) return true;
+  }
+  return (
+    symbol.getName() === 'CurrentMigrationPipeline' &&
+    symbol.declarations?.some(
+      declaration =>
+        ts.isClassDeclaration(declaration) &&
+        normalizedDeclarationPath(declaration).endsWith('/pipeline/current-migration.pipeline.ts'),
+    ) === true
+  );
+}
+
 function localModuleCandidates(reference: string, containingSourcePath: string): readonly string[] {
   if (!reference.startsWith('.')) return [];
   const base = resolve(dirname(containingSourcePath), reference);
@@ -1001,6 +1037,26 @@ function moduleExportsMigrator(
   }
 
   return migratorClassSymbol(commonJsExportedSymbol(moduleReference, exportedName, checker, program), checker);
+}
+
+function moduleExportsCurrentMigrationPipeline(
+  moduleReference: CommonJsModuleReference,
+  exportedName: string,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+): boolean {
+  const candidates = localModuleCandidates(moduleReference.reference, moduleReference.containingSourcePath);
+  if (
+    exportedName === 'CurrentMigrationPipeline' &&
+    candidates.some(candidate => candidate.replaceAll('\\', '/').endsWith('/pipeline/current-migration.pipeline.ts'))
+  ) {
+    return true;
+  }
+
+  return currentMigrationPipelineClassSymbol(
+    commonJsExportedSymbol(moduleReference, exportedName, checker, program),
+    checker,
+  );
 }
 
 function migrationTransactionConstructorProvenance(
@@ -1109,6 +1165,59 @@ function migratorConstructorProvenance(
   });
 }
 
+function currentMigrationPipelineConstructorProvenance(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  const unwrapped = unwrapExpression(expression);
+  const directSymbol = checker.getSymbolAtLocation(unwrapped);
+  if (currentMigrationPipelineClassSymbol(directSymbol, checker)) return true;
+
+  if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
+    const exportedName = ts.isPropertyAccessExpression(unwrapped)
+      ? unwrapped.name.text
+      : moduleText(unwrapped.argumentExpression);
+    const moduleReference = commonJsModuleReference(unwrapped.expression, checker, seenSymbols);
+    if (
+      exportedName !== undefined &&
+      moduleReference !== undefined &&
+      moduleExportsCurrentMigrationPipeline(moduleReference, exportedName, checker, program)
+    ) {
+      return true;
+    }
+  }
+
+  if (directSymbol === undefined || seenSymbols.has(directSymbol)) return false;
+  const nextSeen = new Set(seenSymbols).add(directSymbol);
+  if ((directSymbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    const aliased = checker.getAliasedSymbol(directSymbol);
+    if (currentMigrationPipelineClassSymbol(aliased, checker)) return true;
+  }
+  return (directSymbol.declarations ?? []).some(declaration => {
+    if (ts.isVariableDeclaration(declaration) && declaration.initializer !== undefined) {
+      return currentMigrationPipelineConstructorProvenance(declaration.initializer, checker, program, nextSeen);
+    }
+    if (ts.isBindingElement(declaration)) {
+      const pattern = declaration.parent;
+      const variable =
+        ts.isObjectBindingPattern(pattern) || ts.isArrayBindingPattern(pattern) ? pattern.parent : undefined;
+      if (variable === undefined || !ts.isVariableDeclaration(variable) || variable.initializer === undefined) {
+        return false;
+      }
+      const exportedName = bindingElementPropertyName(declaration);
+      const moduleReference = commonJsModuleReference(variable.initializer, checker, nextSeen);
+      return (
+        exportedName !== undefined &&
+        moduleReference !== undefined &&
+        moduleExportsCurrentMigrationPipeline(moduleReference, exportedName, checker, program)
+      );
+    }
+    return false;
+  });
+}
+
 function migrationTransactionReceiverProvenance(
   expression: ts.Expression,
   checker: ts.TypeChecker,
@@ -1154,6 +1263,36 @@ function migratorReceiverProvenance(
       ts.isVariableDeclaration(declaration) &&
       declaration.initializer !== undefined &&
       migratorReceiverProvenance(declaration.initializer, checker, program, nextSeen),
+  );
+}
+
+function currentMigrationPipelineReceiverProvenance(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  const unwrapped = unwrapExpression(expression);
+  const runProperty = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped), 'run');
+  if (currentMigrationPipelineRunSymbol(runProperty)) return true;
+  if (ts.isNewExpression(unwrapped)) {
+    return currentMigrationPipelineConstructorProvenance(unwrapped.expression, checker, program, seenSymbols);
+  }
+  if (ts.isConditionalExpression(unwrapped)) {
+    return (
+      currentMigrationPipelineReceiverProvenance(unwrapped.whenTrue, checker, program, seenSymbols) ||
+      currentMigrationPipelineReceiverProvenance(unwrapped.whenFalse, checker, program, seenSymbols)
+    );
+  }
+
+  const symbol = checker.getSymbolAtLocation(unwrapped);
+  if (symbol === undefined || seenSymbols.has(symbol)) return false;
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  return (symbol.declarations ?? []).some(
+    declaration =>
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer !== undefined &&
+      currentMigrationPipelineReceiverProvenance(declaration.initializer, checker, program, nextSeen),
   );
 }
 
@@ -1500,6 +1639,291 @@ function migratorMigrateCallableProvenance(
   return migratorMigrateSymbolProvenance(checker.getSymbolAtLocation(unwrapped), checker, program, seenSymbols);
 }
 
+function migrationModeFromPipelineInvocation(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): MigrationOptionsMode {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isObjectLiteralExpression(unwrapped)) {
+    let mode: MigrationOptionsMode = 'absent';
+    for (const property of unwrapped.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        const spreadMode = migrationModeFromPipelineInvocation(property.expression, checker, seenSymbols);
+        if (spreadMode !== 'absent') mode = spreadMode;
+        continue;
+      }
+      const propertyName = objectPropertyName(property);
+      if (propertyName === undefined && ts.isComputedPropertyName(property.name)) {
+        mode = 'unknown';
+        continue;
+      }
+      if (propertyName !== 'options') continue;
+      if (ts.isPropertyAssignment(property)) {
+        mode = migrationModeFromOptions(property.initializer, checker, seenSymbols);
+      } else if (ts.isShorthandPropertyAssignment(property)) {
+        mode = migrationModeFromOptions(property.name, checker, seenSymbols);
+      } else {
+        mode = 'unknown';
+      }
+    }
+    return mode;
+  }
+
+  const symbol = checker.getSymbolAtLocation(unwrapped);
+  if (symbol === undefined || seenSymbols.has(symbol)) return 'unknown';
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  for (const declaration of symbol.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer !== undefined &&
+      isConstVariableDeclaration(declaration) &&
+      isConstAssertion(declaration.initializer)
+    ) {
+      return migrationModeFromPipelineInvocation(declaration.initializer, checker, nextSeen);
+    }
+  }
+  return 'unknown';
+}
+
+function currentPipelineInvocationCanWrite(invocation: ts.Expression | undefined, checker: ts.TypeChecker): boolean {
+  if (invocation === undefined) return true;
+  const unwrapped = unwrapExpression(invocation);
+  if (ts.isIdentifier(unwrapped) && unwrapped.text === 'undefined') return true;
+  return migrationModeFromPipelineInvocation(unwrapped, checker) !== 'plan';
+}
+
+interface CurrentMigrationPipelineRunCallableProvenance {
+  readonly boundArguments: readonly ts.Expression[];
+}
+
+function currentMigrationPipelineRunSymbolProvenance(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol>,
+): CurrentMigrationPipelineRunCallableProvenance | undefined {
+  if (symbol === undefined || seenSymbols.has(symbol)) return undefined;
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  if (currentMigrationPipelineRunSymbol(symbol)) return { boundArguments: [] };
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    const aliased = checker.getAliasedSymbol(symbol);
+    const provenance = currentMigrationPipelineRunSymbolProvenance(aliased, checker, program, nextSeen);
+    if (provenance !== undefined) return provenance;
+  }
+  for (const declaration of symbol.declarations ?? []) {
+    if (
+      (ts.isVariableDeclaration(declaration) ||
+        ts.isPropertyAssignment(declaration) ||
+        ts.isPropertyDeclaration(declaration)) &&
+      declaration.initializer !== undefined
+    ) {
+      const provenance = currentMigrationPipelineRunCallableProvenance(
+        declaration.initializer,
+        checker,
+        program,
+        nextSeen,
+      );
+      if (provenance !== undefined) return provenance;
+    }
+    if (ts.isShorthandPropertyAssignment(declaration)) {
+      const provenance = currentMigrationPipelineRunSymbolProvenance(
+        checker.getShorthandAssignmentValueSymbol(declaration),
+        checker,
+        program,
+        nextSeen,
+      );
+      if (provenance !== undefined) return provenance;
+    }
+    if (ts.isExportAssignment(declaration)) {
+      const provenance = currentMigrationPipelineRunCallableProvenance(
+        declaration.expression,
+        checker,
+        program,
+        nextSeen,
+      );
+      if (provenance !== undefined) return provenance;
+    }
+    if (ts.isBindingElement(declaration)) {
+      const pattern = declaration.parent;
+      const variable =
+        ts.isObjectBindingPattern(pattern) || ts.isArrayBindingPattern(pattern) ? pattern.parent : undefined;
+      if (variable === undefined || !ts.isVariableDeclaration(variable) || variable.initializer === undefined) {
+        continue;
+      }
+      const propertyName = bindingElementPropertyName(declaration);
+      if (propertyName === undefined) continue;
+      const property = checker.getPropertyOfType(checker.getTypeAtLocation(variable.initializer), propertyName);
+      const provenance = currentMigrationPipelineRunSymbolProvenance(property, checker, program, nextSeen);
+      if (provenance !== undefined) return provenance;
+      if (
+        propertyName === 'run' &&
+        currentMigrationPipelineReceiverProvenance(variable.initializer, checker, program, nextSeen)
+      ) {
+        return { boundArguments: [] };
+      }
+    }
+  }
+  return undefined;
+}
+
+function currentMigrationPipelineRunCallableProvenance(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): CurrentMigrationPipelineRunCallableProvenance | undefined {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isCallExpression(unwrapped)) {
+    const target = unwrapExpression(unwrapped.expression);
+    if (
+      (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
+      (ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression)) === 'bind'
+    ) {
+      const provenance = currentMigrationPipelineRunCallableProvenance(
+        target.expression,
+        checker,
+        program,
+        seenSymbols,
+      );
+      return provenance === undefined
+        ? undefined
+        : { boundArguments: [...provenance.boundArguments, ...unwrapped.arguments.slice(1)] };
+    }
+    return undefined;
+  }
+
+  if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
+    const name = ts.isPropertyAccessExpression(unwrapped)
+      ? unwrapped.name.text
+      : moduleText(unwrapped.argumentExpression);
+    if (name === 'run') {
+      const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), name);
+      if (
+        currentMigrationPipelineRunSymbol(property) ||
+        currentMigrationPipelineReceiverProvenance(unwrapped.expression, checker, program)
+      ) {
+        return { boundArguments: [] };
+      }
+    }
+    const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
+    if (propertyNode !== undefined) {
+      const provenance = currentMigrationPipelineRunSymbolProvenance(
+        checker.getSymbolAtLocation(propertyNode),
+        checker,
+        program,
+        seenSymbols,
+      );
+      if (provenance !== undefined) return provenance;
+    }
+  }
+
+  return currentMigrationPipelineRunSymbolProvenance(
+    checker.getSymbolAtLocation(unwrapped),
+    checker,
+    program,
+    seenSymbols,
+  );
+}
+
+function currentPipelineWriteSymbolProvenance(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol>,
+): boolean {
+  if (symbol === undefined || seenSymbols.has(symbol)) return false;
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    const aliased = checker.getAliasedSymbol(symbol);
+    if (currentPipelineWriteSymbolProvenance(aliased, checker, program, nextSeen)) return true;
+  }
+  return (symbol.declarations ?? []).some(declaration => {
+    const callableBody = declarationCallableBody(declaration);
+    if (callableBody !== undefined && shouldTraceCallableBody(declaration, program)) {
+      return callableBodyContainsCurrentPipelineWrite(callableBody, checker, program, nextSeen);
+    }
+    if (
+      (ts.isVariableDeclaration(declaration) ||
+        ts.isPropertyAssignment(declaration) ||
+        ts.isPropertyDeclaration(declaration)) &&
+      declaration.initializer !== undefined
+    ) {
+      return currentPipelineWriteCallableProvenance(declaration.initializer, checker, program, nextSeen);
+    }
+    if (ts.isShorthandPropertyAssignment(declaration)) {
+      return currentPipelineWriteSymbolProvenance(
+        checker.getShorthandAssignmentValueSymbol(declaration),
+        checker,
+        program,
+        nextSeen,
+      );
+    }
+    if (ts.isExportAssignment(declaration)) {
+      return currentPipelineWriteCallableProvenance(declaration.expression, checker, program, nextSeen);
+    }
+    return false;
+  });
+}
+
+function currentPipelineWriteCallableProvenance(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isArrowFunction(unwrapped) || ts.isFunctionExpression(unwrapped)) {
+    return callableBodyContainsCurrentPipelineWrite(unwrapped.body, checker, program, seenSymbols);
+  }
+  return currentPipelineWriteSymbolProvenance(checker.getSymbolAtLocation(unwrapped), checker, program, seenSymbols);
+}
+
+function boundCurrentPipelineInvocationCanWrite(
+  provenance: CurrentMigrationPipelineRunCallableProvenance,
+  callArguments: readonly ts.Expression[],
+  checker: ts.TypeChecker,
+): boolean {
+  return currentPipelineInvocationCanWrite([...provenance.boundArguments, ...callArguments][0], checker);
+}
+
+function currentPipelineWriteInvocation(
+  expression: ts.CallExpression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  const target = unwrapExpression(expression.expression);
+  if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
+    const name = ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression);
+    const provenance = currentMigrationPipelineRunCallableProvenance(target.expression, checker, program, seenSymbols);
+    if (name === 'call' && provenance !== undefined) {
+      return boundCurrentPipelineInvocationCanWrite(provenance, expression.arguments.slice(1), checker);
+    }
+    if (name === 'apply' && provenance !== undefined) {
+      const argumentList = expression.arguments[1];
+      const unwrappedArguments = argumentList === undefined ? undefined : unwrapExpression(argumentList);
+      if (unwrappedArguments !== undefined && ts.isArrayLiteralExpression(unwrappedArguments)) {
+        const callArguments = unwrappedArguments.elements.flatMap(argument =>
+          ts.isOmittedExpression(argument) ? [] : [argument],
+        );
+        return boundCurrentPipelineInvocationCanWrite(provenance, callArguments, checker);
+      }
+      return true;
+    }
+  }
+  const provenance = currentMigrationPipelineRunCallableProvenance(
+    expression.expression,
+    checker,
+    program,
+    seenSymbols,
+  );
+  if (provenance !== undefined) {
+    return boundCurrentPipelineInvocationCanWrite(provenance, expression.arguments, checker);
+  }
+  return currentPipelineWriteCallableProvenance(expression.expression, checker, program, seenSymbols);
+}
+
 function migrationWriteSymbolProvenance(
   symbol: ts.Symbol | undefined,
   checker: ts.TypeChecker,
@@ -1507,6 +1931,7 @@ function migrationWriteSymbolProvenance(
   seenSymbols: ReadonlySet<ts.Symbol>,
 ): boolean {
   if (symbol === undefined || seenSymbols.has(symbol)) return false;
+  if (currentMigrationPipelineRunSymbol(symbol)) return false;
   const nextSeen = new Set(seenSymbols).add(symbol);
   if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
     const aliased = checker.getAliasedSymbol(symbol);
@@ -1651,6 +2076,26 @@ function callableBodyContainsMigrationWrite(
   return found;
 }
 
+function callableBodyContainsCurrentPipelineWrite(
+  body: ts.ConciseBody,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol>,
+): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (ts.isFunctionLike(node) || ts.isClassDeclaration(node) || ts.isClassExpression(node)) return;
+    if (ts.isCallExpression(node) && currentPipelineWriteInvocation(node, checker, program, seenSymbols)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(body);
+  return found;
+}
+
 /** Semantically inspects mutation authority and boundary inputs across local module edges. */
 export function inspectTypeScriptProject(
   sourcePaths: readonly string[],
@@ -1664,7 +2109,7 @@ export function inspectTypeScriptProject(
   const transactionApplyCalls: { sourcePath: string; name: 'apply' }[] = [];
   const projectWriteAuthorityCalls: {
     sourcePath: string;
-    name: 'apply' | 'migrate';
+    name: 'apply' | 'migrate' | 'run';
   }[] = [];
   const seenAdapterPaths = new Set<string>();
   const seenExecutionModeInputs = new Set<string>();
@@ -1686,6 +2131,9 @@ export function inspectTypeScriptProject(
         }
         if (migrationWriteInvocation(node, checker, program)) {
           projectWriteAuthorityCalls.push({ sourcePath, name: 'migrate' });
+        }
+        if (currentPipelineWriteInvocation(node, checker, program)) {
+          projectWriteAuthorityCalls.push({ sourcePath, name: 'run' });
         }
       }
       if (ts.isFunctionLike(node)) {

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -1089,53 +1089,62 @@ function canonicalReflectApplySymbol(symbol: ts.Symbol | undefined): boolean {
   );
 }
 
+interface ReflectApplyCallableProvenance {
+  readonly boundArguments: readonly ts.Expression[];
+}
+
 function reflectApplySymbolProvenance(
   symbol: ts.Symbol | undefined,
   checker: ts.TypeChecker,
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol>,
-): boolean {
-  if (symbol === undefined || seenSymbols.has(symbol)) return false;
+): ReflectApplyCallableProvenance | undefined {
+  if (symbol === undefined || seenSymbols.has(symbol)) return undefined;
   const nextSeen = new Set(seenSymbols).add(symbol);
-  if (canonicalReflectApplySymbol(symbol)) return true;
+  if (canonicalReflectApplySymbol(symbol)) return { boundArguments: [] };
   if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
     const aliased = checker.getAliasedSymbol(symbol);
-    if (reflectApplySymbolProvenance(aliased, checker, program, nextSeen)) return true;
+    const provenance = reflectApplySymbolProvenance(aliased, checker, program, nextSeen);
+    if (provenance !== undefined) return provenance;
   }
-  return (symbol.declarations ?? []).some(declaration => {
+  for (const declaration of symbol.declarations ?? []) {
     if (
       (ts.isVariableDeclaration(declaration) ||
         ts.isPropertyAssignment(declaration) ||
         ts.isPropertyDeclaration(declaration)) &&
       declaration.initializer !== undefined
     ) {
-      return reflectApplyCallableProvenance(declaration.initializer, checker, program, nextSeen);
+      const provenance = reflectApplyCallableProvenance(declaration.initializer, checker, program, nextSeen);
+      if (provenance !== undefined) return provenance;
     }
     if (ts.isShorthandPropertyAssignment(declaration)) {
-      return reflectApplySymbolProvenance(
+      const provenance = reflectApplySymbolProvenance(
         checker.getShorthandAssignmentValueSymbol(declaration),
         checker,
         program,
         nextSeen,
       );
+      if (provenance !== undefined) return provenance;
     }
     if (ts.isExportAssignment(declaration)) {
-      return reflectApplyCallableProvenance(declaration.expression, checker, program, nextSeen);
+      const provenance = reflectApplyCallableProvenance(declaration.expression, checker, program, nextSeen);
+      if (provenance !== undefined) return provenance;
     }
     if (ts.isBindingElement(declaration)) {
       const pattern = declaration.parent;
       const variable =
         ts.isObjectBindingPattern(pattern) || ts.isArrayBindingPattern(pattern) ? pattern.parent : undefined;
       if (variable === undefined || !ts.isVariableDeclaration(variable) || variable.initializer === undefined) {
-        return false;
+        continue;
       }
       const propertyName = bindingElementPropertyName(declaration);
-      if (propertyName === undefined) return false;
+      if (propertyName === undefined) continue;
       const property = checker.getPropertyOfType(checker.getTypeAtLocation(variable.initializer), propertyName);
-      return reflectApplySymbolProvenance(property, checker, program, nextSeen);
+      const provenance = reflectApplySymbolProvenance(property, checker, program, nextSeen);
+      if (provenance !== undefined) return provenance;
     }
-    return false;
-  });
+  }
+  return undefined;
 }
 
 function reflectApplyCallableProvenance(
@@ -1143,32 +1152,38 @@ function reflectApplyCallableProvenance(
   checker: ts.TypeChecker,
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
-): boolean {
+): ReflectApplyCallableProvenance | undefined {
   const unwrapped = unwrapExpression(expression);
   if (ts.isCallExpression(unwrapped)) {
     const target = unwrapExpression(unwrapped.expression);
     if (
-      unwrapped.arguments.length === 1 &&
       (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
       resolvedMemberName(target, checker) === 'bind'
     ) {
-      return reflectApplyCallableProvenance(target.expression, checker, program, seenSymbols);
+      const provenance = reflectApplyCallableProvenance(target.expression, checker, program, seenSymbols);
+      return provenance === undefined
+        ? undefined
+        : { boundArguments: [...provenance.boundArguments, ...unwrapped.arguments.slice(1)] };
     }
-    return false;
+    return undefined;
   }
 
   if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
     const name = resolvedMemberName(unwrapped, checker);
     if (name === 'apply' || (name === undefined && ts.isElementAccessExpression(unwrapped))) {
       const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), 'apply');
-      if (reflectApplySymbolProvenance(property, checker, program, seenSymbols)) return true;
+      const provenance = reflectApplySymbolProvenance(property, checker, program, seenSymbols);
+      if (provenance !== undefined) return provenance;
     }
     const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
-    if (
-      propertyNode !== undefined &&
-      reflectApplySymbolProvenance(checker.getSymbolAtLocation(propertyNode), checker, program, seenSymbols)
-    ) {
-      return true;
+    if (propertyNode !== undefined) {
+      const provenance = reflectApplySymbolProvenance(
+        checker.getSymbolAtLocation(propertyNode),
+        checker,
+        program,
+        seenSymbols,
+      );
+      if (provenance !== undefined) return provenance;
     }
   }
 
@@ -1187,16 +1202,68 @@ function arrayLiteralArguments(expression: ts.Expression | undefined): readonly 
   return unwrapped.elements.flatMap(element => (ts.isOmittedExpression(element) ? [] : [element]));
 }
 
+interface ResolvedCallableInvocation<Provenance> {
+  readonly provenance: Provenance;
+  readonly arguments?: readonly ts.Expression[];
+}
+
+function resolvedCallableInvocation<Provenance>(
+  expression: ts.CallExpression,
+  checker: ts.TypeChecker,
+  resolveCallable: (target: ts.Expression) => Provenance | undefined,
+): ResolvedCallableInvocation<Provenance> | undefined {
+  const direct = resolveCallable(expression.expression);
+  if (direct !== undefined) return { provenance: direct, arguments: expression.arguments };
+
+  const target = unwrapExpression(expression.expression);
+  if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) return undefined;
+  const name = resolvedMemberName(target, checker);
+  if (name === 'apply') {
+    const provenance = resolveCallable(target.expression);
+    if (provenance === undefined) return undefined;
+    const callArguments = arrayLiteralArguments(expression.arguments[1]);
+    return callArguments === undefined ? { provenance } : { provenance, arguments: callArguments };
+  }
+  if (name !== 'call') return undefined;
+
+  const provenance = resolveCallable(target.expression);
+  if (provenance !== undefined) {
+    return { provenance, arguments: expression.arguments.slice(1) };
+  }
+
+  const nestedTarget = unwrapExpression(target.expression);
+  if (
+    (!ts.isPropertyAccessExpression(nestedTarget) && !ts.isElementAccessExpression(nestedTarget)) ||
+    resolvedMemberName(nestedTarget, checker) !== 'call' ||
+    resolveCallable(nestedTarget.expression) === undefined
+  ) {
+    return undefined;
+  }
+  const reboundTarget = expression.arguments[0];
+  if (reboundTarget === undefined) return undefined;
+  const reboundProvenance = resolveCallable(reboundTarget);
+  return reboundProvenance === undefined
+    ? undefined
+    : { provenance: reboundProvenance, arguments: expression.arguments.slice(2) };
+}
+
 function reflectedApplyInvocation(
   expression: ts.CallExpression,
   checker: ts.TypeChecker,
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol>,
 ): ReflectedApplyInvocation | undefined {
-  if (!reflectApplyCallableProvenance(expression.expression, checker, program, seenSymbols)) return undefined;
-  const target = expression.arguments[0];
+  const invocation = resolvedCallableInvocation(expression, checker, target =>
+    reflectApplyCallableProvenance(target, checker, program, seenSymbols),
+  );
+  if (invocation === undefined) return undefined;
+  const effectiveArguments =
+    invocation.arguments === undefined
+      ? invocation.provenance.boundArguments
+      : [...invocation.provenance.boundArguments, ...invocation.arguments];
+  const target = effectiveArguments[0];
   if (target === undefined) return undefined;
-  const reflectedArguments = arrayLiteralArguments(expression.arguments[2]);
+  const reflectedArguments = arrayLiteralArguments(effectiveArguments[2]);
   return reflectedArguments === undefined ? { target } : { target, arguments: reflectedArguments };
 }
 
@@ -1567,17 +1634,11 @@ function transactionApplicationInvocation(
   if (reflected !== undefined && transactionApplyCallableProvenance(reflected.target, checker, program, seenSymbols)) {
     return true;
   }
-  const target = unwrapExpression(expression.expression);
-  if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = resolvedMemberName(target, checker);
-    if (
-      (name === 'call' || name === 'apply') &&
-      transactionApplyCallableProvenance(target.expression, checker, program, seenSymbols)
-    ) {
-      return true;
-    }
-  }
-  return transactionApplyCallableProvenance(expression.expression, checker, program, seenSymbols);
+  return (
+    resolvedCallableInvocation(expression, checker, target =>
+      transactionApplyCallableProvenance(target, checker, program, seenSymbols) ? true : undefined,
+    ) !== undefined
+  );
 }
 
 type MigrationModeLiteral = 'plan' | 'write';
@@ -2063,29 +2124,13 @@ function currentPipelineWriteInvocation(
     }
     return currentPipelineWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
   }
-  const target = unwrapExpression(expression.expression);
-  if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = resolvedMemberName(target, checker);
-    const provenance = currentMigrationPipelineRunCallableProvenance(target.expression, checker, program, seenSymbols);
-    if (name === 'call' && provenance !== undefined) {
-      return boundCurrentPipelineInvocationCanWrite(provenance, expression.arguments.slice(1), checker);
-    }
-    if (name === 'apply' && provenance !== undefined) {
-      const callArguments = arrayLiteralArguments(expression.arguments[1]);
-      if (callArguments !== undefined) {
-        return boundCurrentPipelineInvocationCanWrite(provenance, callArguments, checker);
-      }
-      return true;
-    }
-  }
-  const provenance = currentMigrationPipelineRunCallableProvenance(
-    expression.expression,
-    checker,
-    program,
-    seenSymbols,
+  const invocation = resolvedCallableInvocation(expression, checker, target =>
+    currentMigrationPipelineRunCallableProvenance(target, checker, program, seenSymbols),
   );
-  if (provenance !== undefined) {
-    return boundCurrentPipelineInvocationCanWrite(provenance, expression.arguments, checker);
+  if (invocation !== undefined) {
+    return invocation.arguments === undefined
+      ? true
+      : boundCurrentPipelineInvocationCanWrite(invocation.provenance, invocation.arguments, checker);
   }
   return currentPipelineWriteCallableProvenance(expression.expression, checker, program, seenSymbols);
 }
@@ -2168,24 +2213,13 @@ function migrationWriteInvocation(
     }
     return migrationWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
   }
-  const target = unwrapExpression(expression.expression);
-  if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = resolvedMemberName(target, checker);
-    const provenance = migratorMigrateCallableProvenance(target.expression, checker, program, seenSymbols);
-    if (name === 'call' && provenance !== undefined) {
-      return boundMigrationInvocationCanWrite(provenance, expression.arguments.slice(1), checker);
-    }
-    if (name === 'apply' && provenance !== undefined) {
-      const callArguments = arrayLiteralArguments(expression.arguments[1]);
-      if (callArguments !== undefined) {
-        return boundMigrationInvocationCanWrite(provenance, callArguments, checker);
-      }
-      return true;
-    }
-  }
-  const provenance = migratorMigrateCallableProvenance(expression.expression, checker, program, seenSymbols);
-  if (provenance !== undefined) {
-    return boundMigrationInvocationCanWrite(provenance, expression.arguments, checker);
+  const invocation = resolvedCallableInvocation(expression, checker, target =>
+    migratorMigrateCallableProvenance(target, checker, program, seenSymbols),
+  );
+  if (invocation !== undefined) {
+    return invocation.arguments === undefined
+      ? true
+      : boundMigrationInvocationCanWrite(invocation.provenance, invocation.arguments, checker);
   }
   return migrationWriteCallableProvenance(expression.expression, checker, program, seenSymbols);
 }

--- a/test/architecture/typescript-boundary.ts
+++ b/test/architecture/typescript-boundary.ts
@@ -117,6 +117,18 @@ function moduleText(expression: ts.Expression | undefined): string | undefined {
   return expression && ts.isStringLiteralLike(expression) ? expression.text : undefined;
 }
 
+function resolvedMemberName(
+  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  checker: ts.TypeChecker,
+): string | undefined {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  const directName = moduleText(expression.argumentExpression);
+  if (directName !== undefined) return directName;
+  if (expression.argumentExpression === undefined) return undefined;
+  const argumentType = checker.getTypeAtLocation(unwrapExpression(expression.argumentExpression));
+  return argumentType.isStringLiteral() || argumentType.isNumberLiteral() ? String(argumentType.value) : undefined;
+}
+
 function modulePathSegments(reference: string): readonly string[] {
   return reference
     .replaceAll('\\', '/')
@@ -1060,6 +1072,134 @@ function moduleExportsCurrentMigrationPipeline(
   );
 }
 
+function reflectApplyDeclaration(declaration: ts.Declaration): boolean {
+  if (!normalizedDeclarationPath(declaration).endsWith('/lib.es2015.reflect.d.ts')) return false;
+  for (let current: ts.Node | undefined = declaration; current !== undefined; current = current.parent) {
+    if (ts.isModuleDeclaration(current) && (ts.isIdentifier(current.name) || ts.isStringLiteralLike(current.name))) {
+      return current.name.text === 'Reflect';
+    }
+  }
+  return false;
+}
+
+function canonicalReflectApplySymbol(symbol: ts.Symbol | undefined): boolean {
+  return (
+    symbol?.getName() === 'apply' &&
+    symbol.declarations?.some(declaration => reflectApplyDeclaration(declaration)) === true
+  );
+}
+
+function reflectApplySymbolProvenance(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol>,
+): boolean {
+  if (symbol === undefined || seenSymbols.has(symbol)) return false;
+  const nextSeen = new Set(seenSymbols).add(symbol);
+  if (canonicalReflectApplySymbol(symbol)) return true;
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    const aliased = checker.getAliasedSymbol(symbol);
+    if (reflectApplySymbolProvenance(aliased, checker, program, nextSeen)) return true;
+  }
+  return (symbol.declarations ?? []).some(declaration => {
+    if (
+      (ts.isVariableDeclaration(declaration) ||
+        ts.isPropertyAssignment(declaration) ||
+        ts.isPropertyDeclaration(declaration)) &&
+      declaration.initializer !== undefined
+    ) {
+      return reflectApplyCallableProvenance(declaration.initializer, checker, program, nextSeen);
+    }
+    if (ts.isShorthandPropertyAssignment(declaration)) {
+      return reflectApplySymbolProvenance(
+        checker.getShorthandAssignmentValueSymbol(declaration),
+        checker,
+        program,
+        nextSeen,
+      );
+    }
+    if (ts.isExportAssignment(declaration)) {
+      return reflectApplyCallableProvenance(declaration.expression, checker, program, nextSeen);
+    }
+    if (ts.isBindingElement(declaration)) {
+      const pattern = declaration.parent;
+      const variable =
+        ts.isObjectBindingPattern(pattern) || ts.isArrayBindingPattern(pattern) ? pattern.parent : undefined;
+      if (variable === undefined || !ts.isVariableDeclaration(variable) || variable.initializer === undefined) {
+        return false;
+      }
+      const propertyName = bindingElementPropertyName(declaration);
+      if (propertyName === undefined) return false;
+      const property = checker.getPropertyOfType(checker.getTypeAtLocation(variable.initializer), propertyName);
+      return reflectApplySymbolProvenance(property, checker, program, nextSeen);
+    }
+    return false;
+  });
+}
+
+function reflectApplyCallableProvenance(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
+): boolean {
+  const unwrapped = unwrapExpression(expression);
+  if (ts.isCallExpression(unwrapped)) {
+    const target = unwrapExpression(unwrapped.expression);
+    if (
+      unwrapped.arguments.length === 1 &&
+      (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
+      resolvedMemberName(target, checker) === 'bind'
+    ) {
+      return reflectApplyCallableProvenance(target.expression, checker, program, seenSymbols);
+    }
+    return false;
+  }
+
+  if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
+    const name = resolvedMemberName(unwrapped, checker);
+    if (name === 'apply' || (name === undefined && ts.isElementAccessExpression(unwrapped))) {
+      const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), 'apply');
+      if (reflectApplySymbolProvenance(property, checker, program, seenSymbols)) return true;
+    }
+    const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
+    if (
+      propertyNode !== undefined &&
+      reflectApplySymbolProvenance(checker.getSymbolAtLocation(propertyNode), checker, program, seenSymbols)
+    ) {
+      return true;
+    }
+  }
+
+  return reflectApplySymbolProvenance(checker.getSymbolAtLocation(unwrapped), checker, program, seenSymbols);
+}
+
+interface ReflectedApplyInvocation {
+  readonly target: ts.Expression;
+  readonly arguments?: readonly ts.Expression[];
+}
+
+function arrayLiteralArguments(expression: ts.Expression | undefined): readonly ts.Expression[] | undefined {
+  if (expression === undefined) return undefined;
+  const unwrapped = unwrapExpression(expression);
+  if (!ts.isArrayLiteralExpression(unwrapped)) return undefined;
+  return unwrapped.elements.flatMap(element => (ts.isOmittedExpression(element) ? [] : [element]));
+}
+
+function reflectedApplyInvocation(
+  expression: ts.CallExpression,
+  checker: ts.TypeChecker,
+  program: ts.Program,
+  seenSymbols: ReadonlySet<ts.Symbol>,
+): ReflectedApplyInvocation | undefined {
+  if (!reflectApplyCallableProvenance(expression.expression, checker, program, seenSymbols)) return undefined;
+  const target = expression.arguments[0];
+  if (target === undefined) return undefined;
+  const reflectedArguments = arrayLiteralArguments(expression.arguments[2]);
+  return reflectedArguments === undefined ? { target } : { target, arguments: reflectedArguments };
+}
+
 function migrationTransactionConstructorProvenance(
   expression: ts.Expression,
   checker: ts.TypeChecker,
@@ -1374,7 +1514,7 @@ function transactionApplyCallableProvenance(
     const target = unwrapExpression(unwrapped.expression);
     if (
       (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
-      (ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression)) === 'bind'
+      resolvedMemberName(target, checker) === 'bind'
     ) {
       return transactionApplyCallableProvenance(target.expression, checker, program, seenSymbols);
     }
@@ -1382,9 +1522,7 @@ function transactionApplyCallableProvenance(
   }
 
   if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
-    const name = ts.isPropertyAccessExpression(unwrapped)
-      ? unwrapped.name.text
-      : moduleText(unwrapped.argumentExpression);
+    const name = resolvedMemberName(unwrapped, checker);
     const moduleReference = commonJsModuleReference(unwrapped.expression, checker, seenSymbols);
     if (name !== undefined && moduleReference !== undefined) {
       const exportedSymbol = commonJsExportedSymbol(moduleReference, name, checker, program);
@@ -1398,6 +1536,13 @@ function transactionApplyCallableProvenance(
       ) {
         return true;
       }
+    }
+    if (
+      name === undefined &&
+      ts.isElementAccessExpression(unwrapped) &&
+      migrationTransactionReceiverProvenance(unwrapped.expression, checker, program, seenSymbols)
+    ) {
+      return true;
     }
     const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
     if (
@@ -1418,9 +1563,13 @@ function transactionApplicationInvocation(
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
 ): boolean {
+  const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
+  if (reflected !== undefined && transactionApplyCallableProvenance(reflected.target, checker, program, seenSymbols)) {
+    return true;
+  }
   const target = unwrapExpression(expression.expression);
   if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression);
+    const name = resolvedMemberName(target, checker);
     if (
       (name === 'call' || name === 'apply') &&
       transactionApplyCallableProvenance(target.expression, checker, program, seenSymbols)
@@ -1605,7 +1754,7 @@ function migratorMigrateCallableProvenance(
     const target = unwrapExpression(unwrapped.expression);
     if (
       (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
-      (ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression)) === 'bind'
+      resolvedMemberName(target, checker) === 'bind'
     ) {
       const provenance = migratorMigrateCallableProvenance(target.expression, checker, program, seenSymbols);
       return provenance === undefined
@@ -1616,14 +1765,19 @@ function migratorMigrateCallableProvenance(
   }
 
   if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
-    const name = ts.isPropertyAccessExpression(unwrapped)
-      ? unwrapped.name.text
-      : moduleText(unwrapped.argumentExpression);
+    const name = resolvedMemberName(unwrapped, checker);
     if (name === 'migrate') {
       const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), name);
       if (migratorMigrateSymbol(property) || migratorReceiverProvenance(unwrapped.expression, checker, program)) {
         return { boundArguments: [] };
       }
+    }
+    if (
+      name === undefined &&
+      ts.isElementAccessExpression(unwrapped) &&
+      migratorReceiverProvenance(unwrapped.expression, checker, program, seenSymbols)
+    ) {
+      return { boundArguments: [] };
     }
     const propertyNode = ts.isPropertyAccessExpression(unwrapped) ? unwrapped.name : unwrapped.argumentExpression;
     if (propertyNode !== undefined) {
@@ -1696,18 +1850,6 @@ function currentPipelineInvocationCanWrite(invocation: ts.Expression | undefined
 
 interface CurrentMigrationPipelineRunCallableProvenance {
   readonly boundArguments: readonly ts.Expression[];
-}
-
-function currentMigrationPipelineMemberName(
-  expression: ts.PropertyAccessExpression | ts.ElementAccessExpression,
-  checker: ts.TypeChecker,
-): string | undefined {
-  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
-  const directName = moduleText(expression.argumentExpression);
-  if (directName !== undefined) return directName;
-  if (expression.argumentExpression === undefined) return undefined;
-  const argumentType = checker.getTypeAtLocation(unwrapExpression(expression.argumentExpression));
-  return argumentType.isStringLiteral() || argumentType.isNumberLiteral() ? String(argumentType.value) : undefined;
 }
 
 function currentMigrationPipelineRunSymbolProvenance(
@@ -1791,7 +1933,7 @@ function currentMigrationPipelineRunCallableProvenance(
     const target = unwrapExpression(unwrapped.expression);
     if (
       (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) &&
-      (ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression)) === 'bind'
+      resolvedMemberName(target, checker) === 'bind'
     ) {
       const provenance = currentMigrationPipelineRunCallableProvenance(
         target.expression,
@@ -1807,7 +1949,7 @@ function currentMigrationPipelineRunCallableProvenance(
   }
 
   if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
-    const name = currentMigrationPipelineMemberName(unwrapped, checker);
+    const name = resolvedMemberName(unwrapped, checker);
     if (name === 'run') {
       const property = checker.getPropertyOfType(checker.getTypeAtLocation(unwrapped.expression), name);
       if (
@@ -1911,20 +2053,26 @@ function currentPipelineWriteInvocation(
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
 ): boolean {
+  const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
+  if (reflected !== undefined) {
+    const provenance = currentMigrationPipelineRunCallableProvenance(reflected.target, checker, program, seenSymbols);
+    if (provenance !== undefined) {
+      return reflected.arguments === undefined
+        ? true
+        : boundCurrentPipelineInvocationCanWrite(provenance, reflected.arguments, checker);
+    }
+    return currentPipelineWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
+  }
   const target = unwrapExpression(expression.expression);
   if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression);
+    const name = resolvedMemberName(target, checker);
     const provenance = currentMigrationPipelineRunCallableProvenance(target.expression, checker, program, seenSymbols);
     if (name === 'call' && provenance !== undefined) {
       return boundCurrentPipelineInvocationCanWrite(provenance, expression.arguments.slice(1), checker);
     }
     if (name === 'apply' && provenance !== undefined) {
-      const argumentList = expression.arguments[1];
-      const unwrappedArguments = argumentList === undefined ? undefined : unwrapExpression(argumentList);
-      if (unwrappedArguments !== undefined && ts.isArrayLiteralExpression(unwrappedArguments)) {
-        const callArguments = unwrappedArguments.elements.flatMap(argument =>
-          ts.isOmittedExpression(argument) ? [] : [argument],
-        );
+      const callArguments = arrayLiteralArguments(expression.arguments[1]);
+      if (callArguments !== undefined) {
         return boundCurrentPipelineInvocationCanWrite(provenance, callArguments, checker);
       }
       return true;
@@ -2010,20 +2158,26 @@ function migrationWriteInvocation(
   program: ts.Program,
   seenSymbols: ReadonlySet<ts.Symbol> = new Set(),
 ): boolean {
+  const reflected = reflectedApplyInvocation(expression, checker, program, seenSymbols);
+  if (reflected !== undefined) {
+    const provenance = migratorMigrateCallableProvenance(reflected.target, checker, program, seenSymbols);
+    if (provenance !== undefined) {
+      return reflected.arguments === undefined
+        ? true
+        : boundMigrationInvocationCanWrite(provenance, reflected.arguments, checker);
+    }
+    return migrationWriteCallableProvenance(reflected.target, checker, program, seenSymbols);
+  }
   const target = unwrapExpression(expression.expression);
   if (ts.isPropertyAccessExpression(target) || ts.isElementAccessExpression(target)) {
-    const name = ts.isPropertyAccessExpression(target) ? target.name.text : moduleText(target.argumentExpression);
+    const name = resolvedMemberName(target, checker);
     const provenance = migratorMigrateCallableProvenance(target.expression, checker, program, seenSymbols);
     if (name === 'call' && provenance !== undefined) {
       return boundMigrationInvocationCanWrite(provenance, expression.arguments.slice(1), checker);
     }
     if (name === 'apply' && provenance !== undefined) {
-      const argumentList = expression.arguments[1];
-      const unwrappedArguments = argumentList === undefined ? undefined : unwrapExpression(argumentList);
-      if (unwrappedArguments !== undefined && ts.isArrayLiteralExpression(unwrappedArguments)) {
-        const callArguments = unwrappedArguments.elements.flatMap(argument =>
-          ts.isOmittedExpression(argument) ? [] : [argument],
-        );
+      const callArguments = arrayLiteralArguments(expression.arguments[1]);
+      if (callArguments !== undefined) {
         return boundMigrationInvocationCanWrite(provenance, callArguments, checker);
       }
       return true;

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { basename, join, relative, resolve, sep } from 'node:path';
 import packageJson from '../../package.json' with { type: 'json' };
 
 const repository = resolve(import.meta.dirname, '../..');
@@ -49,6 +49,32 @@ describe('packaged CLI execution', () => {
 
     expect(result).toMatchObject({ status: 0, stdout: `${packageJson.version}\n`, stderr: '' });
     expect(result.stdout).not.toContain('Flex-Layout Migrator');
+  });
+
+  test('preserves the relative missing input path in the packaged CLI error', async () => {
+    const input = `${basename(temporaryDirectory)}-missing.html`;
+
+    const result = await execute([input]);
+
+    expect(result).toEqual({
+      status: 1,
+      stdout: '',
+      stderr: `Error: ENOENT: no such file or directory, stat '${input}'\n`,
+    });
+  });
+
+  test('rejects a trailing separator on a packaged single-file HTML input', async () => {
+    const input = join(temporaryDirectory, 'trailing.html');
+    await writeFile(input, '<div fxLayout="row"></div>', 'utf8');
+    const relativeInput = `${relative(repository, input)}${sep}`;
+
+    const result = await execute([relativeInput]);
+
+    expect(result).toEqual({
+      status: 1,
+      stdout: '',
+      stderr: `Error: ENOTDIR: not a directory, stat '${relativeInput}'\n`,
+    });
   });
 
   test('plans a clean Tailwind migration by default and applies it only with --write', async () => {

--- a/test/package/test-discovery.test.ts
+++ b/test/package/test-discovery.test.ts
@@ -1,4 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
+import { relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 describe('Vitest discovery', () => {
@@ -7,5 +9,19 @@ describe('Vitest discovery', () => {
 
     expect(config).toContain("include: ['src/**/*.spec.ts', 'scripts/**/*.spec.ts', 'test/**/*.test.ts']");
     expect(config).toContain("exclude: ['dist/**', 'coverage/**', 'node_modules/**']");
+  });
+
+  it('discovers every pipeline specification through the source specification policy', async () => {
+    const config = await readFile(new URL('../../vitest.config.ts', import.meta.url), 'utf8');
+    const pipelineDirectory = new URL('../../src/pipeline/', import.meta.url);
+    const pipelineSpecifications = (await readdir(pipelineDirectory, { withFileTypes: true }))
+      .filter(entry => entry.isFile() && entry.name.endsWith('.spec.ts'))
+      .map(entry =>
+        relative(process.cwd(), fileURLToPath(new URL(entry.name, pipelineDirectory))).replaceAll('\\', '/'),
+      );
+
+    expect(config).toContain("'src/**/*.spec.ts'");
+    expect(pipelineSpecifications.length).toBeGreaterThan(0);
+    expect(pipelineSpecifications.every(path => path.startsWith('src/') && path.endsWith('.spec.ts'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Introduce the enterprise migration pipeline shell while preserving the existing migration engine and public CLI behavior.

- define immutable, target-neutral handoffs for discovery, analysis, rendering, validation, and application
- add explicit stage ports, a linear coordinator, and stage-aware internal errors
- route the CLI through a thin compatibility façade that delegates once to the existing `Migrator`
- enforce the exact write-authority graph and pipeline dependency direction with semantic architecture tests
- validate stable canonical identities, complete ordered handoffs, and CSS/Tailwind stylesheet ownership invariants
- document the transition seam and planned façade removal in the enterprise architecture rewrite

## Verification

- [x] Tests were added or updated before behavior changed.
- [x] `npm run verify` passes locally.
- [x] User-facing behavior and documentation agree.
- [x] The diff contains no unrelated formatting or generated files.
- [x] Dependency changes are explained below.

Fresh final verification passed 125 test files and 3,327 tests, including coverage, build, and packaged-artifact checks. The final scoped architecture review approved the branch with no open Critical, Important, or Minor findings.

## Migration example

Not applicable. This slice introduces internal architecture seams and preserves existing plan/write migration behavior and terminal output.

## Dependencies and compatibility

None. No dependency, lockfile, Node.js, Angular, CSS, Tailwind, Changeset, workload-counter, inventory, or benchmark-schema changes.
