### PR TITLE
chore: prepare beta.2 release changeset

### DIFF
--- a/.changeset/bright-layouts-preview.md
+++ b/.changeset/bright-layouts-preview.md
@@ -1,0 +1,5 @@
+---
+'@nipe-solutions/flex-layout-codemod': minor
+---
+
+Launch the public documentation site and browser-only single-template migration playground, and point package metadata to the production documentation homepage.

--- a/.changeset/pre/calm-layouts-migrate.md
+++ b/.changeset/pre/calm-layouts-migrate.md
@@ -1,5 +1,0 @@
----
-'@nipe-solutions/flex-layout-codemod': minor
----
-
-Target Tailwind CSS v4 with exact static Flex-Layout semantics, add coupled `fxGrow` and `fxShrink` conversion, support `fxFlexAlign` and `fxFill`, and preserve gap or context-sensitive cases that cannot be converted safely.

--- a/.changeset/pre/exact-breakpoints-migrate.md
+++ b/.changeset/pre/exact-breakpoints-migrate.md
@@ -1,5 +1,0 @@
----
-'@nipe-solutions/flex-layout-codemod': minor
----
-
-Convert literal standard Angular Flex-Layout viewport aliases to exact Tailwind CSS v4 arbitrary media variants, while preserving dynamic, optional, custom, and unsafe overlapping responsive declarations for review.

--- a/.changeset/pre/exact-responsive-class-style.md
+++ b/.changeset/pre/exact-responsive-class-style.md
@@ -1,5 +1,0 @@
----
-'@nipe-solutions/flex-layout-codemod': minor
----
-
-Convert provable literal responsive `ngClass` and `ngStyle` families for all standard Angular Flex-Layout viewport aliases. Preserve project-specific, raw-source-unsafe, target-changing, compiler-empty, or ownership-ambiguous class candidates; preserve unsafe, priority-bearing, or exact-key-aliasing style families and unsuffixed fallback replacement; retain existing class bytes and emit only tokens with compiler-complete ownership that Tailwind's raw template scanner discovers. Existing Tailwind classes now use compiler-backed text, directional-border, and shadow ownership, while recognized unmodeled built-ins conservatively block conflicting conversion.

--- a/.changeset/pre/exact-visibility-migrate.md
+++ b/.changeset/pre/exact-visibility-migrate.md
@@ -1,5 +1,0 @@
----
-'@nipe-solutions/flex-layout-codemod': minor
----
-
-Convert Angular-decoded literal `fxShow` and `fxHide` families at base and standard viewport breakpoints when their complete display behavior is provable, and preserve dynamic, conflicting, restoration-unsafe, partially overlapping layout, or responsive class/style-authority cases with structured diagnostics.

--- a/.changeset/pre/quiet-rivers-report.md
+++ b/.changeset/pre/quiet-rivers-report.md
@@ -1,5 +1,0 @@
----
-'@nipe-solutions/flex-layout-codemod': minor
----
-
-Add dry-run migrations, versioned JSON reporting, concise deterministic output, and stable automation exit codes.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,6 +20,7 @@ jobs:
         with: { node-version: 24 }
       - run: npm install --global npm@11.19.0
       - run: npm ci
+      - run: node scripts/prepare-changesets-action.mjs
       - uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           version: npm run release:version

--- a/scripts/prepare-changesets-action.mjs
+++ b/scripts/prepare-changesets-action.mjs
@@ -1,0 +1,6 @@
+import { rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+const repository = resolve(process.argv[2] ?? process.cwd());
+await rm(join(repository, '.changeset', 'pre'), { recursive: true, force: true });

--- a/scripts/prepare-changesets-action.spec.ts
+++ b/scripts/prepare-changesets-action.spec.ts
@@ -1,0 +1,38 @@
+import { execFile } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const repository = resolve(import.meta.dirname, '..');
+
+describe('prepare Changesets action input', () => {
+  it('removes only consumed prerelease archives before the action reads pending changesets', async () => {
+    const temporaryRepository = await mkdtemp(join(tmpdir(), 'changesets-action-input-'));
+    const changesetDirectory = join(temporaryRepository, '.changeset');
+    const pendingChangeset = join(changesetDirectory, 'pending-release.md');
+    const prereleaseState = join(changesetDirectory, 'pre.json');
+    const archivedChangeset = join(changesetDirectory, 'pre', 'already-released.md');
+
+    try {
+      await mkdir(join(changesetDirectory, 'pre'), { recursive: true });
+      await writeFile(pendingChangeset, 'pending', 'utf8');
+      await writeFile(prereleaseState, '{"mode":"pre","tag":"beta"}\n', 'utf8');
+      await writeFile(archivedChangeset, 'released', 'utf8');
+
+      await execFileAsync(process.execPath, [
+        join(repository, 'scripts', 'prepare-changesets-action.mjs'),
+        temporaryRepository,
+      ]);
+
+      await expect(access(join(changesetDirectory, 'pre'))).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(readFile(pendingChangeset, 'utf8')).resolves.toBe('pending');
+      await expect(readFile(prereleaseState, 'utf8')).resolves.toBe('{"mode":"pre","tag":"beta"}\n');
+    } finally {
+      await rm(temporaryRepository, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/package/ci-contract.test.ts
+++ b/test/package/ci-contract.test.ts
@@ -25,6 +25,7 @@ describe('continuous integration', () => {
           },
           { run: 'npm install --global npm@11.19.0' },
           { run: 'npm ci' },
+          { run: 'node scripts/prepare-changesets-action.mjs' },
           {
             uses: 'changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d',
             with: {

--- a/test/package/release-policy.test.ts
+++ b/test/package/release-policy.test.ts
@@ -37,6 +37,14 @@ describe('release policy', () => {
       },
       env: { GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}' },
     });
+    const prepareInputIndex = workflow.jobs.version.steps.findIndex(
+      (step: { run?: string }) => step.run === 'node scripts/prepare-changesets-action.mjs',
+    );
+    const changesetsActionIndex = workflow.jobs.version.steps.findIndex(
+      (step: { uses?: string }) => step.uses === 'changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d',
+    );
+    expect(prepareInputIndex).toBeGreaterThanOrEqual(0);
+    expect(changesetsActionIndex).toBeGreaterThan(prepareInputIndex);
 
     expect(source).not.toMatch(/\b(?:npm publish|npm stage|git tag|gh release)\b/u);
     expect(source).not.toMatch(/\bNODE_AUTH_TOKEN\b|secrets\.NPM/u);


### PR DESCRIPTION
## Summary

- add the beta.2 documentation/playground Changeset
- remove consumed prerelease archives before the Changesets Action reads pending changesets
- regression-test the release-PR compatibility boundary

## Verification

- `npm run clean && npm run verify`
- `npm audit --audit-level=high`
- `npm run format && npm run lint && npm run typecheck`
- focused release contracts: 18/18
- disposable `npm run release:version` produced exactly `2.0.0-beta.2`

Production deployment and custom-domain DNS/TLS verification completed before this release preparation.