### PR TITLE
ci: fetch release evidence before staging

### DIFF
--- a/.github/workflows/stage-release.yml
+++ b/.github/workflows/stage-release.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { fetch-depth: 0 }
+      - run: git fetch --no-tags origin 41c0714bca3ec09470e25efde0f30b6bc96cc0ac 92f720211a04563bd4216b90e52b9a7a230c048b
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/test/package/ci-contract.test.ts
+++ b/test/package/ci-contract.test.ts
@@ -71,6 +71,9 @@ describe('continuous integration', () => {
             with: { 'fetch-depth': 0 },
           },
           {
+            run: 'git fetch --no-tags origin 41c0714bca3ec09470e25efde0f30b6bc96cc0ac 92f720211a04563bd4216b90e52b9a7a230c048b',
+          },
+          {
             uses: 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020',
             with: {
               'node-version': 24,


### PR DESCRIPTION
## Summary

- fetch the two immutable historical architecture-evidence commits before the staged release verification
- mirror the proven CI test-job boundary in the protected staging workflow
- lock the behavior into the exact workflow contract

## Regression evidence

- RED: `npm exec vitest run test/package/ci-contract.test.ts` failed because staging lacked the required fetch
- GREEN: `npm exec vitest run test/package/ci-contract.test.ts test/package/release-policy.test.ts` — 17/17 passed
- formatting, lint, and `git diff --check` passed

This fixes staging run https://github.com/NIPE-Solutions/flex-layout-migrator/actions/runs/33987078462, which stopped in `npm run verify` before artifact creation or npm staging.